### PR TITLE
Sprint 2 audit-prep: complete external-audit package

### DIFF
--- a/contracts/src/AggregationRouterAdapter.sol
+++ b/contracts/src/AggregationRouterAdapter.sol
@@ -36,6 +36,8 @@ contract AggregationRouterAdapter is IExecutionAdapter {
     error Slippage();
     error BadOrder();
 
+    /// @param router_ the aggregation router this adapter is permanently pinned to (EX-2)
+    /// @param selectors_ the router function selectors routeData may invoke (EX-1)
     constructor(address router_, bytes4[] memory selectors_) {
         require(router_ != address(0) && selectors_.length > 0, BadOrder());
         router = router_;

--- a/contracts/src/DirectPoolAdapter.sol
+++ b/contracts/src/DirectPoolAdapter.sol
@@ -42,6 +42,7 @@ contract DirectPoolAdapter is IExecutionAdapter {
     error TokenNotInPair();
     error Slippage();
 
+    /// @param pair_ the V2-style pair this adapter is permanently pinned to
     constructor(IUniswapV2Pair pair_) {
         pair = pair_;
         token0 = pair_.token0();

--- a/contracts/src/FeeEngine.sol
+++ b/contracts/src/FeeEngine.sol
@@ -47,6 +47,7 @@ contract FeeEngine is IFeeEngine {
     error UnattestedVault();
     error NothingToClaim();
 
+    /// @param registry_ the canonical OperatorRegistry (carry reads, identity, fee stats)
     constructor(IRegistryView registry_) {
         registry = registry_;
     }
@@ -109,6 +110,8 @@ contract FeeEngine is IFeeEngine {
 
     /// @notice Pull an in-kind fee slice that the vault escrowed after a failed transfer to
     /// this engine (VaultCore EE-6 path), and credit it to the vault's operator.
+    /// @param vault the attested vault holding the escrowed fee slice
+    /// @param asset the escrowed token; credit is the measured balance delta
     function pullEscrowed(address vault, address asset) external {
         uint256 opId = registry.operatorOf(vault);
         require(opId != 0, UnattestedVault());
@@ -122,6 +125,7 @@ contract FeeEngine is IFeeEngine {
     }
 
     /// @notice Operator claims accumulated performance fees for a settlement token.
+    /// @param token USDC or a basket asset with a nonzero claimable balance for the caller
     function claimFees(address token) external {
         uint256 amt = claimableFees[msg.sender][token];
         require(amt > 0, NothingToClaim());

--- a/contracts/src/Governance.sol
+++ b/contracts/src/Governance.sol
@@ -43,6 +43,9 @@ contract Governance is IGovernance {
     error AlreadyWiredSubRegistry();
     error ZeroSubRegistry();
 
+    /// @notice One-shot deploy-time wiring of the SubVaultRegistry used for SV-6 quorum-floor
+    /// inheritance. Deployer-only, callable once, permanently locked after.
+    /// @param r the SubVaultRegistry address (nonzero)
     function wireSubVaultRegistry(address r) external {
         require(msg.sender == deployer, OnlyDeployer());
         require(subVaultRegistry == address(0), AlreadyWiredSubRegistry());
@@ -172,6 +175,8 @@ contract Governance is IGovernance {
 
     /// @notice Register a vault's governance config. Once, by the vault's creator. Config is
     /// thereafter immutable except via a full-consensus RuleChange proposal (CM-8).
+    /// @param vault the VaultCore to register
+    /// @param cfg governance parameters (validated; child quorum must respect the parent floor)
     function registerVault(address vault, GovConfig calldata cfg) external {
         require(!vaultRegistered[vault], AlreadyRegistered());
         require(msg.sender == IVaultSnapshots(vault).creator(), NotVaultCreator());
@@ -204,6 +209,13 @@ contract Governance is IGovernance {
 
     // ───────────────────────────── proposals ──────────────────────────────────
 
+    /// @notice Open a proposal. One active proposal per vault (CM-6 serialization); proposer
+    /// must clear the stake threshold and cooldown; snapshots are taken strictly before
+    /// creation so same-second (flash) stake carries zero weight (VO-9).
+    /// @param vault the target vault (must be registered)
+    /// @param ptype Rebalance | RuleChange | ChildAllocation — fixes quorum regime and payload shape
+    /// @param actionHash keccak256 of the exact execution payload voters are approving
+    /// @return pid the new proposal id
     function propose(address vault, ProposalType ptype, bytes32 actionHash) external returns (uint256 pid) {
         require(vaultRegistered[vault], NotRegistered());
         GovConfig memory cfg = configOf[vault];
@@ -247,6 +259,8 @@ contract Governance is IGovernance {
     // ─────────────────────────── commit-reveal ────────────────────────────────
 
     /// @notice Commit `keccak256(abi.encode(pid, voter, support, salt))` during the commit phase.
+    /// @param pid the proposal id
+    /// @param commitment the vote commitment hash (binds pid + voter — no cross-proposal replay)
     function commitVote(uint256 pid, bytes32 commitment) external {
         Proposal storage p = proposals[pid];
         require(p.status == Status.Active && block.timestamp < p.commitDeadline, WrongPhase());
@@ -262,6 +276,9 @@ contract Governance is IGovernance {
     /// toward nothing (VO-6: non-reveal costs the committer their voice, not the vault its
     /// quorum). Research note: mature systems lost votes to *forgotten* reveals (Kleros) —
     /// agents should automate reveal; the standing-default mechanism is the routine fallback.
+    /// @param pid the proposal id
+    /// @param support the committed vote direction (must match the commitment)
+    /// @param salt the committed salt
     function revealVote(uint256 pid, bool support, bytes32 salt) external {
         Proposal storage p = proposals[pid];
         require(
@@ -290,6 +307,8 @@ contract Governance is IGovernance {
 
     /// @notice Crank a non-participating delegator's weight onto their delegate's revealed
     /// direction. Permissionless. Self-participation (commit) takes precedence over delegation.
+    /// @param pid the proposal id
+    /// @param delegator the member whose standing delegation should be applied
     function revealDelegated(uint256 pid, address delegator) external {
         Proposal storage p = proposals[pid];
         require(
@@ -329,12 +348,18 @@ contract Governance is IGovernance {
 
     // ─────────────────────────── standing defaults ────────────────────────────
 
+    /// @notice Declare a standing absentee vote for future ROUTINE REBALANCE proposals on
+    /// `vault`. Expires 72h after being set (VO-3); only applies to proposals created AFTER it
+    /// was set (G4). Counts toward tallies, never toward quorum (VO-2/K-3).
+    /// @param vault the vault the default applies to
+    /// @param support the pre-declared direction
     function setStandingDefault(address vault, bool support) external {
         require(vaultRegistered[vault], NotRegistered());
         standingDefaultOf[vault][msg.sender] = StandingDefault(true, support, uint64(block.timestamp));
         emit StandingDefaultSet(vault, msg.sender, support);
     }
 
+    /// @notice Clear the caller's standing default for `vault`.
     function clearStandingDefault(address vault) external {
         delete standingDefaultOf[vault][msg.sender];
         emit StandingDefaultCleared(vault, msg.sender);
@@ -344,6 +369,8 @@ contract Governance is IGovernance {
     /// the reveal phase. Permissionless crank. Defaults count toward the tally, NEVER toward
     /// quorum (VO-2/K-3), expire 72h after being set (VO-3), and are structurally limited to
     /// the Rebalance proposal type on-chain (VO-4 — the type is not proposer-asserted text).
+    /// @param pid the proposal id (must be a Rebalance in its reveal phase)
+    /// @param member the non-participating member whose default should be applied
     function applyStandingDefault(uint256 pid, address member) external {
         Proposal storage p = proposals[pid];
         require(
@@ -377,6 +404,8 @@ contract Governance is IGovernance {
 
     /// @notice Set or clear (address(0)) a standing delegate for a vault. Not changeable while
     /// a proposal is in flight — prevents mid-proposal delegation games.
+    /// @param vault the vault the delegation applies to
+    /// @param delegate_ the delegate whose revealed direction carries the caller's weight
     function setDelegate(address vault, address delegate_) external {
         require(vaultRegistered[vault], NotRegistered());
         uint256 activePid = activeProposalOf[vault];
@@ -390,6 +419,10 @@ contract Governance is IGovernance {
 
     // ─────────────────────────── finalize / execute ───────────────────────────
 
+    /// @notice Tally a proposal after its reveal deadline. Quorum regime: RuleChange = full
+    /// consensus; <5 members at creation = strict signer majority (CM-7); otherwise revealed
+    /// stake ≥ quorumBps of snapshot (VO-2). Passing starts the timelock + execution window.
+    /// @param pid the proposal id
     function finalize(uint256 pid) external {
         Proposal storage p = proposals[pid];
         require(p.status == Status.Active && block.timestamp >= p.revealDeadline, WrongPhase());
@@ -421,6 +454,9 @@ contract Governance is IGovernance {
     /// @notice Execute a passed proposal after its timelock, within its execution window.
     /// Rebalance payload execution is wired to the execution adapter in Sprint 4; in Sprint 2
     /// execution is the state transition that releases Mode-F queued exits at post-vote NAV.
+    /// @param pid the passed proposal id
+    /// @param payload the exact bytes hashed into actionHash at propose time; decoded per the
+    /// stored proposal type (never inferred from payload shape)
     function execute(uint256 pid, bytes calldata payload) external {
         Proposal storage p = proposals[pid];
         require(p.status == Status.Passed, NotPassed());
@@ -450,6 +486,7 @@ contract Governance is IGovernance {
     }
 
     /// @notice Mark a passed-but-unexecuted proposal expired once its window lapses (EE-10).
+    /// @param pid the passed proposal id past its execution window
     function markExpired(uint256 pid) external {
         Proposal storage p = proposals[pid];
         require(p.status == Status.Passed && block.timestamp > p.expiresAt, WrongPhase());
@@ -488,6 +525,7 @@ contract Governance is IGovernance {
         return false;
     }
 
+    /// @inheritdoc IGovernance
     function isExecutor(address vault, address account) external view returns (bool) {
         return account == address(this) && vaultRegistered[vault];
     }

--- a/contracts/src/OperatorRegistry.sol
+++ b/contracts/src/OperatorRegistry.sol
@@ -69,6 +69,8 @@ contract OperatorRegistry is IOperatorRegistry {
     }
 
     /// @notice One-shot deploy-time wiring. Immutable thereafter — not an ongoing admin power.
+    /// @param factory_ the canonical VaultFactory (sole attestation caller)
+    /// @param feeEngine_ the FeeEngine (sole fee-stat recorder)
     function wire(address factory_, address feeEngine_) external {
         require(msg.sender == deployer, OnlyDeployer());
         require(factory == address(0) && feeEngine == address(0), AlreadyWired());
@@ -81,6 +83,11 @@ contract OperatorRegistry is IOperatorRegistry {
 
     // ───────────────────────────── identity ───────────────────────────────────
 
+    /// @notice Mint a fresh operator id for a not-yet-registered address. Permissionless and
+    /// harmless: it grants no authority and can never rebind an existing operator (CM-4 — a
+    /// fresh identity restarts at zero track record).
+    /// @param operator the address to register
+    /// @return opId the newly assigned operator id (ids start at 1; 0 = unregistered)
     function registerOperator(address operator) public returns (uint256 opId) {
         require(operatorIdOf[operator] == 0, AlreadyOperator());
         opId = ++operatorCount;
@@ -90,6 +97,8 @@ contract OperatorRegistry is IOperatorRegistry {
     }
 
     /// @notice Attest a factory-deployed vault to its operator. Factory-only (CM-5).
+    /// @param vault the freshly deployed vault
+    /// @param operator the creator identity (auto-registered if new)
     function attestVault(address vault, address operator) external {
         require(msg.sender == factory, OnlyFactory());
         uint256 opId = operatorIdOf[operator];
@@ -128,6 +137,8 @@ contract OperatorRegistry is IOperatorRegistry {
     }
 
     /// @notice Fee-engine callback so collected fees appear in the aggregate record.
+    /// @param opId the operator credited
+    /// @param amountUsdc the fee amount actually collected, USDC units
     function recordFeeCollected(uint256 opId, uint256 amountUsdc) external {
         require(msg.sender == feeEngine, OnlyFeeEngine());
         statsOf[opId].lifetimeFeesUsdc += amountUsdc;
@@ -138,6 +149,9 @@ contract OperatorRegistry is IOperatorRegistry {
 
     /// @notice Aggregate, all-vaults-included operator record (SF-4): monotone accumulators,
     /// nothing is ever removed or restated. Rankings/weighting are an indexer concern (S7).
+    /// @param opId the operator queried
+    /// @return operator the operator's address
+    /// @return stats lifetime gain/loss/fees/vault-count accumulators
     function leaderboardEntry(uint256 opId)
         external
         view

--- a/contracts/src/OracleAggregator.sol
+++ b/contracts/src/OracleAggregator.sol
@@ -39,6 +39,13 @@ contract OracleAggregator is IOracleAggregator {
 
     error BadOracleConfig();
 
+    /// @notice Fix the full per-asset source configuration forever. Floors are load-bearing
+    /// (the creator is untrusted): ≥3 sources, strict-majority freshness quorum, staleness
+    /// bounded to (0, 1 day].
+    /// @param assets_ the priceable assets (no duplicates)
+    /// @param sources_ per-asset IPriceSource sets (3–15 each; mechanism diversity per SF-1)
+    /// @param maxStaleness_ per-asset freshness bound in seconds, ≤ MAX_STALENESS_CEILING
+    /// @param quorum_ per-asset minimum fresh sources, strict majority of the set
     constructor(
         address[] memory assets_,
         address[][] memory sources_,
@@ -99,6 +106,12 @@ contract OracleAggregator is IOracleAggregator {
         return fresh[(k - 1) / 2];
     }
 
+    /// @notice The immutable source configuration for `asset` — what a prospective member
+    /// inspects before depositing into a vault priced by this aggregator.
+    /// @param asset the asset queried
+    /// @return sources the source set
+    /// @return maxStaleness per-source freshness bound, seconds
+    /// @return quorum minimum fresh sources before the breaker trips
     function assetConfig(address asset)
         external
         view
@@ -125,6 +138,7 @@ contract ChainlinkSourceAdapter is IPriceSource {
 
     error BadFeed();
 
+    /// @param feed_ the AggregatorV3 feed to wrap (decimals ≤ 18)
     constructor(IAggregatorV3 feed_) {
         feed = feed_;
         uint8 d = feed_.decimals();
@@ -132,6 +146,10 @@ contract ChainlinkSourceAdapter is IPriceSource {
         scale = 10 ** (18 - d);
     }
 
+    /// @notice WAD-normalized feed price. Non-positive answers surface as (0, 0), which the
+    /// aggregator treats as not-fresh rather than a revert.
+    /// @return priceWad USD price of one whole token, WAD (0 if the feed answer is invalid)
+    /// @return updatedAt the feed's last-update timestamp (0 if invalid)
     function latestPrice() external view returns (uint256, uint256) {
         (, int256 answer,, uint256 updatedAt,) = feed.latestRoundData();
         if (answer <= 0) return (0, 0); // aggregator treats as not-fresh

--- a/contracts/src/SubVaultRegistry.sol
+++ b/contracts/src/SubVaultRegistry.sol
@@ -39,6 +39,9 @@ contract SubVaultRegistry {
         deployer = msg.sender;
     }
 
+    /// @notice One-shot deploy-time wiring of the canonical factory — the only address ever
+    /// allowed to register child edges. Locked after the first call.
+    /// @param factory_ the canonical VaultFactory (nonzero)
     function wire(address factory_) external {
         require(msg.sender == deployer, OnlyDeployer());
         require(factory == address(0), AlreadyWired());
@@ -48,6 +51,9 @@ contract SubVaultRegistry {
 
     /// @notice Register a freshly deployed child under `parent`. Factory-only, creation-time
     /// only. `childExitFeeMaxBps` is the child's exit-fee ceiling, used for the stack cap.
+    /// @param parent the parent vault (depth must stay under MAX_DEPTH)
+    /// @param child the freshly deployed child (must be unknown to the registry)
+    /// @param childExitFeeMaxBps the child's immutable exit-fee ceiling, bps (SV-4 stack input)
     function registerChild(address parent, address child, uint256 childExitFeeMaxBps) external {
         require(msg.sender == factory, OnlyFactory());
         require(parentOf[child] == address(0) && depthOf[child] == 0, AlreadyRegistered());
@@ -71,6 +77,8 @@ contract SubVaultRegistry {
 
     /// @notice Cumulative effective performance fee across the ancestor chain, for display
     /// (SV-4): 1 − (1 − f)^levels, in bps. Depth-capped by construction.
+    /// @param vault the vault whose chain is priced
+    /// @return bps the effective stacked performance fee in bps
     function stackedPerfFeeBps(address vault) external view returns (uint256 bps) {
         uint256 levels = depthOf[vault] + 1;
         uint256 keep = 10_000;
@@ -81,6 +89,8 @@ contract SubVaultRegistry {
     }
 
     /// @notice Cumulative exit-fee ceiling across the ancestor chain, in bps (SV-4 display).
+    /// @param vault the vault whose chain is summed (self included)
+    /// @return bps the summed exit-fee ceilings, bps
     function stackedExitFeeCapBps(address vault) external view returns (uint256 bps) {
         address a = vault;
         while (a != address(0)) {

--- a/contracts/src/VaultCore.sol
+++ b/contracts/src/VaultCore.sol
@@ -175,6 +175,22 @@ contract VaultCore {
     error ExitNeedsChildSettlement();
 
     // ─────────────────────────────── constructor ──────────────────────────────
+
+    /// @notice Deploy a vault. Every trust-relevant choice is fixed here and immutable after —
+    /// members inspect the config before depositing; there are no setters.
+    /// @param usdc_ settlement asset (decimals read at runtime, must be ≤ 18)
+    /// @param basketAssets_ index basket (≤ MAX_BASKET_ASSETS; no zero/duplicate/USDC entries)
+    /// @param creator_ vault creator — the 5% withdrawal gate binds to this address
+    /// @param operatorRegistry_ canonical registry for (member, operator) marks (C-3)
+    /// @param governance_ governance module consulted for the Mode-I/Mode-F exit switch
+    /// @param feeEngine_ performance-fee module called at redemption settlement
+    /// @param oracle_ multi-source median price oracle (staleness breaker freezes NAV paths)
+    /// @param capacityCapUsdc_ max NAV in USDC units; 0 opts out of the cap (SF-3)
+    /// @param minDepositUsdc_ minimum deposit, must be nonzero (dust/rounding defense)
+    /// @param exitFeeMaxBps_ tenure-decayed exit fee ceiling, ≤ EXIT_FEE_CAP_BPS (1%)
+    /// @param exitFeeDecayPeriod_ seconds until the exit fee decays to zero (nonzero iff fee set)
+    /// @param allowedAdapters_ execution-adapter allowlist, fixed forever (EX-1)
+    /// @param subVaultRegistry_ parent/child edge registry; zero disables child allocation
     constructor(
         address usdc_,
         address[] memory basketAssets_,
@@ -230,6 +246,7 @@ contract VaultCore {
 
     /// @notice Vault NAV in WAD USD terms. Pending deposits are excluded (EE-1). Reverts while
     /// the oracle breaker is tripped — freezing everything, including exits, by design (K-4).
+    /// @return nav idle USDC + oracle-priced basket + look-through-priced child positions, WAD
     function navWad() public view returns (uint256 nav) {
         nav = idleUsdc * usdcScalar;
         uint256 n = basketAssets.length;
@@ -279,10 +296,13 @@ contract VaultCore {
         }
     }
 
+    /// @notice Number of registered child vaults (≤ MAX_CHILDREN).
     function childVaultCount() external view returns (uint256) {
         return childVaults.length;
     }
 
+    /// @notice NAV per share, WAD. 1e18 before the first deposit.
+    /// @return NAVps in WAD; reverts with the oracle breaker like navWad
     function navPerShareWad() public view returns (uint256) {
         uint256 ts = totalShares;
         return ts == 0 ? WAD : navWad() * WAD / ts;
@@ -293,6 +313,8 @@ contract VaultCore {
     /// @notice Deposit USDC. First-ever deposit by an agent enters the 4-hour observation
     /// window as escrowed pending capital (no shares, no NAV inclusion, no voting rights).
     /// Repeat deposits and window-skipped agents mint immediately at current NAV.
+    /// @param amountUsdc deposit size in USDC units (≥ minDepositUsdc); receipt is measured,
+    /// so fee-on-transfer shortfalls below the minimum revert
     function deposit(uint256 amountUsdc) external nonReentrant {
         require(amountUsdc > 0, ZeroAmount());
         require(amountUsdc >= minDepositUsdc, BelowMinDeposit());
@@ -324,6 +346,7 @@ contract VaultCore {
 
     /// @notice Activate a pending deposit after the observation window. Shares mint at
     /// activation-time NAV (forward pricing on entry, §4.3). Callable by anyone.
+    /// @param member the depositor whose pending deposit matured
     function activate(address member) external nonReentrant {
         PendingDeposit memory p = pendingDeposit[member];
         require(p.amountUsdc > 0, NoPending());
@@ -386,6 +409,7 @@ contract VaultCore {
     /// distort every quorum (governance re-review, Area 1). It is therefore excluded from all
     /// voting-eligible stake and holder counts. The edge is one-shot (set at child creation),
     /// so cache it once resolved.
+    /// @return the registered parent vault, or address(0) for a root vault
     function parentVault() public view returns (address) {
         if (_cachedParentVault != address(0)) return _cachedParentVault;
         if (subVaultRegistry == address(0)) return address(0);
@@ -412,6 +436,7 @@ contract VaultCore {
     /// Mode I — no passed-but-unexecuted rebalance ⇒ settles now at current NAV, in kind.
     /// Mode F — rebalance passed and pending ⇒ queued, settles at post-execution NAV.
     /// Queued shares stay outstanding but are locked: no voting eligibility, irrevocable.
+    /// @param shares share amount to redeem (≤ balance; one queued exit per member at a time)
     function requestExit(uint256 shares) external nonReentrant {
         require(shares > 0, ZeroAmount());
         require(queuedExitShares[msg.sender] == 0, ExitAlreadyQueued());
@@ -445,6 +470,7 @@ contract VaultCore {
     /// @notice Settle a queued Mode-F exit once no execution is pending (the rebalance executed,
     /// or its proposal expired — either way settlement is at *current* NAV, which post-execution
     /// is the post-rebalance NAV; EE-10 guarantees no indefinite lock). Callable by anyone.
+    /// @param member the member whose queued Mode-F exit should settle
     function settleQueuedExit(address member) external nonReentrant {
         uint256 shares = queuedExitShares[member];
         require(shares > 0, NoQueuedExit());
@@ -623,6 +649,8 @@ contract VaultCore {
     /// @notice Allocate idle USDC into a registered child vault. Governance-only (a
     /// ChildAllocation proposal — standing defaults never apply, VO-4). Edges come from the
     /// SubVaultRegistry, so deposits flow ONLY along creation-time parent→child links (SV-3).
+    /// @param child registered child vault (registry edge parentOf(child) == this)
+    /// @param amountUsdc idle USDC to allocate into the child
     function allocateToChild(address child, uint256 amountUsdc) external nonReentrant {
         require(msg.sender == address(governance), OnlyGovernance());
         require(
@@ -652,6 +680,8 @@ contract VaultCore {
     /// (child baskets ⊆ parent basket, factory-enforced) are credited to internal accounting
     /// from measured deltas. Reverts if the child queues the exit (Mode F) — retry after the
     /// child settles (bounded by the child's timelock + execution window).
+    /// @param child child vault to redeem from (must be a locally registered child)
+    /// @param shares child-vault shares to redeem
     function redeemFromChild(address child, uint256 shares) external nonReentrant {
         require(msg.sender == address(governance), OnlyGovernance());
         require(isChildVault[child], NotRegisteredChild());
@@ -699,6 +729,8 @@ contract VaultCore {
 
     /// @notice Crank: pull a slice the child escrowed for this vault (child EE-6 path) and
     /// credit it. Permissionless.
+    /// @param child child vault holding the escrowed slice
+    /// @param asset USDC or a basket asset to claim from the child's escrow
     function pullChildEscrow(address child, address asset) external nonReentrant {
         require(isChildVault[child], NotRegisteredChild());
         require(assetUnit[asset] != 0 || asset == usdc, BadSwapToken());
@@ -715,6 +747,8 @@ contract VaultCore {
     /// tokens constrained to USDC + basket, every output measured by the vault's OWN balance
     /// delta (EX-3 — the adapter's word is never the accounting source). Internal accounting
     /// is debited before and credited after each swap, so NAV stays truthful mid-rebalance.
+    /// @param adapter allowlisted execution adapter to route every leg through
+    /// @param orders swap legs; tokenIn/tokenOut restricted to USDC + basket assets
     function executeRebalance(address adapter, IExecutionAdapter.SwapOrder[] calldata orders)
         external
         nonReentrant
@@ -774,6 +808,7 @@ contract VaultCore {
     }
 
     /// @notice Claim an in-kind slice that was escrowed after a failed asset transfer (EE-6).
+    /// @param asset the escrowed token to claim; reverts if nothing is claimable
     function claimEscrowed(address asset) external nonReentrant {
         uint256 amt = claimable[msg.sender][asset];
         require(amt > 0, NothingToClaim());
@@ -795,11 +830,15 @@ contract VaultCore {
 
     /// @notice Stake eligible for voting and quorum denominators (Sprint 2): live shares minus
     /// Mode-F-locked shares. Pending deposits hold no shares at all (EE-1/EE-2).
+    /// @param member the member queried (a registered parent vault always reads 0)
+    /// @return eligible share weight for `member`
     function votingEligibleShares(address member) external view returns (uint256) {
         if (member == parentVault()) return 0; // parent vault is a non-voting member
         return sharesOf[member] - queuedExitShares[member];
     }
 
+    /// @notice Total voting-eligible stake: supply minus Mode-F-locked shares minus the parent
+    /// vault's non-voting position.
     function totalVotingEligibleShares() external view returns (uint256) {
         address pv = parentVault();
         uint256 pElig = pv == address(0) ? 0 : sharesOf[pv] - queuedExitShares[pv];
@@ -807,24 +846,33 @@ contract VaultCore {
     }
 
     /// @notice Voting-eligible stake of `member` as of timestamp `ts` (proposal snapshots).
+    /// @param member the member queried
+    /// @param ts historical timestamp (Governance reads createdAt − 1, VO-9)
+    /// @return the last checkpointed eligible weight at or before `ts` (0 if none)
     function pastVotingEligibleShares(address member, uint64 ts) external view returns (uint256) {
         return _eligibleHist[member].getAt(ts);
     }
 
+    /// @notice Total voting-eligible stake as of timestamp `ts` (quorum denominators).
+    /// @param ts historical timestamp (Governance reads createdAt − 1, VO-9)
     function pastTotalVotingEligibleShares(uint64 ts) external view returns (uint256) {
         return _totalEligibleHist.getAt(ts);
     }
 
     /// @notice Holder count as of `ts` — drives the <5-member absolute-signer-count regime
     /// (CM-7: regime is fixed per proposal at creation, membership changes never flip it).
+    /// @param ts historical timestamp (Governance reads createdAt − 1)
     function pastHolderCount(uint64 ts) external view returns (uint256) {
         return _holderCountHist.getAt(ts);
     }
 
+    /// @notice Current tenure-decayed exit fee for `member`, in bps (before any sole-holder
+    /// waiver applied at settlement).
     function exitFeeBpsOf(address member) external view returns (uint256) {
         return _exitFeeBps(member);
     }
 
+    /// @notice Number of basket assets (excludes USDC).
     function basketLength() external view returns (uint256) {
         return basketAssets.length;
     }
@@ -836,15 +884,21 @@ contract VaultCore {
 
     // 4626-SHAPED, INDICATIVE ONLY (C-1): no compliance claim; previews ignore exit fees,
     // observation windows, forward pricing and in-kind mechanics.
+
+    /// @notice Indicative-only NAV in USDC units (C-1: NOT an ERC-4626 compliance claim).
     function totalAssets() external view returns (uint256) {
         return navWad() / usdcScalar;
     }
 
+    /// @notice Indicative-only share preview for a USDC amount; ignores window, fees and
+    /// forward pricing (C-1).
     function convertToShares(uint256 assets) external view returns (uint256) {
         uint256 ts = totalShares;
         return ts == 0 ? assets * usdcScalar : assets * usdcScalar * ts / navWad();
     }
 
+    /// @notice Indicative-only USDC value of `shares`; the real redemption is in-kind and
+    /// fee-bearing (C-1).
     function convertToAssets(uint256 shares) external view returns (uint256) {
         uint256 ts = totalShares;
         return ts == 0 ? shares / usdcScalar : shares * navWad() / ts / usdcScalar;

--- a/contracts/src/VaultFactory.sol
+++ b/contracts/src/VaultFactory.sol
@@ -39,6 +39,10 @@ contract VaultFactory {
 
     event VaultCreated(address indexed vault, address indexed creator, address usdc, uint256 capacityCapUsdc);
 
+    /// @param registry_ canonical OperatorRegistry (attestation target)
+    /// @param governance_ governance module every deployed vault binds to
+    /// @param feeEngine_ fee module every deployed vault binds to
+    /// @param subVaultRegistry_ parent/child edge registry passed into every vault
     constructor(
         IOperatorRegistry registry_,
         IGovernance governance_,
@@ -65,6 +69,10 @@ contract VaultFactory {
         address[] allowedAdapters;
     }
 
+    /// @notice Deploy and attest a root vault. Permissionless; `msg.sender` becomes the
+    /// vault's creator (5% gate identity) and its attested operator.
+    /// @param p the creator's immutable vault configuration
+    /// @return vault the deployed VaultCore address
     function createVault(VaultParams calldata p) external returns (address vault) {
         vault = _deploy(p);
         IRegistryAttest(address(registry)).attestVault(vault, msg.sender);
@@ -76,6 +84,9 @@ contract VaultFactory {
     /// cycles are structurally impossible. The child's basket must be a subset of the
     /// parent's (same USDC), so in-kind child redemptions always map into parent accounting
     /// and look-through pricing (SV-7) is always possible.
+    /// @param p the child's immutable vault configuration (same USDC, basket ⊆ parent's)
+    /// @param parent the parent vault to register the creation-time edge under
+    /// @return vault the deployed child VaultCore address
     function createChildVault(VaultParams calldata p, address parent) external returns (address vault) {
         require(IVaultBasket(parent).usdc() == p.usdc, UsdcMismatch());
         for (uint256 i; i < p.basketAssets.length; ++i) {
@@ -108,6 +119,7 @@ contract VaultFactory {
         );
     }
 
+    /// @notice Number of vaults ever deployed by this factory.
     function vaultCount() external view returns (uint256) {
         return allVaults.length;
     }

--- a/docs/AUDIT-HANDOFF.md
+++ b/docs/AUDIT-HANDOFF.md
@@ -4,6 +4,13 @@ Sprint 9. Everything an external auditor needs to scope the engagement. The prot
 immutable (no proxies, no admin upgrade path), so the audit surface is the deployed bytecode —
 there is no "we'll patch it later."
 
+> **Reviewers start at [audit/README.md](audit/README.md)** — the full audit package: reading
+> order, system map, trust boundaries, wiring order, per-contract walkthroughs
+> ([audit/walkthroughs/](audit/walkthroughs/)), the threat-model→test cross-reference
+> ([audit/TEST-CROSS-REFERENCE.md](audit/TEST-CROSS-REFERENCE.md)), and the findings-response
+> process ([audit/FINDINGS-TEMPLATE.md](audit/FINDINGS-TEMPLATE.md)). This file is the
+> engagement-scoping summary.
+
 ## Scope
 
 | Contract | LoC-ish | Role | Risk |
@@ -49,7 +56,7 @@ The threat model's "Sprint 6 adversarial pass" table maps every finding to its d
 
 ## Invariants proven (Foundry)
 
-100 tests, incl. these invariant suites (256 runs × 16k calls each):
+117 tests, incl. these invariant suites (256 runs × 16k calls each):
 - `Σ member shares == totalShares` across every path (VaultCore + system-level with children)
 - **NAVps non-decreasing for remaining members across any redemption** (§4.6) — proven with and
   without sub-vaults present
@@ -97,7 +104,7 @@ To prevent doc/code confusion during review, these are described in ARCHITECTURE
 ## Build & test
 
 ```bash
-cd contracts && forge build && forge test -vvv    # 100 tests
+cd contracts && forge build && forge test -vvv    # 117 tests
 forge snapshot --check                              # gas regression gate
 slither . --filter-paths "lib|test|script"          # static analysis (triaged: reviews/SLITHER-TRIAGE.md)
 ```

--- a/docs/audit/FINDINGS-TEMPLATE.md
+++ b/docs/audit/FINDINGS-TEMPLATE.md
@@ -1,0 +1,89 @@
+# Findings Response Log — Template & Process
+
+This file is the structured response log for external-audit findings. One entry per finding,
+appended in the auditor's numbering order. The log — not chat, not commit messages — is the
+audit trail: every finding gets a written disposition here, and nothing reported is ever fixed
+silently.
+
+## Severity scale (align with the threat model)
+
+| Sev | Meaning |
+| --- | --- |
+| **Critical / High** | Loss of funds or permanent capital lockup |
+| **Medium** | Value extraction or governance distortion |
+| **Low** | Griefing / nuisance |
+| **Informational** | Code quality, docs, gas |
+
+## Status vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| `Acknowledged` | Received, under analysis |
+| `Confirmed` | Reproduced / mechanism verified by us |
+| `Disputed` | We believe the mechanism does not hold — response explains why, with code refs |
+| `Fixed` | Fix merged; `fix-commit` + regression test listed |
+| `Accepted` | Deliberate tradeoff — response explains why, and the threat model gains/updates a row |
+| `Out of scope` | Off-chain layer / already-documented residual (K-1..K-4, E4/E5/E7, G3/G5, PX-1, GA-2) — response points at the existing disposition |
+
+Note for reviewers: the accepted residuals listed in
+[README.md §7](README.md#7-known-residuals--please-pressure-test-but-dont-re-report-as-new)
+are standing challenges — a finding that shows a **new consequence** beyond the documented one
+is in scope and welcome (that is exactly how S1 H-1 and S6 E1 were found); a re-statement of
+the documented consequence will be dispositioned `Out of scope` with a pointer.
+
+## Entry template
+
+```markdown
+---
+
+### [<AUDITOR-ID>] <one-line title>
+
+- **Severity (auditor):** High | Medium | Low | Informational
+- **Severity (ours, if different):** … — reasoning in Response
+- **Status:** Acknowledged | Confirmed | Disputed | Fixed | Accepted | Out of scope
+- **Component:** <contract>.sol : <function / line range>
+- **Threat-model row(s):** <e.g. EE-6, SV-7, or "new — row added">
+- **Finding summary:** <2–4 sentences, in our words — proves we understood it>
+
+**Response:**
+<Disposition rationale. For Disputed: the code path that breaks the mechanism, with
+file:line. For Accepted: why the tradeoff is deliberate and what bounds the damage. For
+Fixed: what changed and why this shape of fix (constructor validation / code path / docs) —
+remember no admin-rescue fixes exist in this protocol (immutable posture).>
+
+- **Fix commit:** <hash> | n/a
+- **Regression test:** <test/File.t.sol::test_name> | n/a
+- **Docs updated:** <ARCHITECTURE §, THREAT-MODEL row, walkthrough> | n/a
+- **Verified by auditor:** pending | yes (<date>)
+```
+
+## Worked example (from the internal Sprint 6 round)
+
+---
+
+### [S6-E2] `maxStaleness` upper-unbounded → underflow permanently freezes the oracle
+
+- **Severity (auditor):** High
+- **Status:** Fixed
+- **Component:** OracleAggregator.sol : constructor + priceWad
+- **Threat-model row(s):** SF-2 (new consequence — deterministic, source-independent,
+  irreversible panic, distinct from the accepted K-4 staleness freeze)
+- **Finding summary:** The constructor validated only `maxStaleness > 0`; a value above
+  `block.timestamp` made `block.timestamp - maxStaleness` panic-underflow in every `priceWad`
+  call once the basket held assets — a permanent-lockup honeypot needing no malicious module.
+
+**Response:**
+Confirmed. Fixed both sides: constructor now requires
+`0 < maxStaleness ≤ MAX_STALENESS_CEILING (1 day)` — a multi-year staleness bound is never
+legitimate for a spot index — and `minUpdated` computes saturating as defense-in-depth. The
+ceiling also bounds the E7 latency-arb drift window.
+
+- **Fix commit:** (see Sprint 6 hardening series)
+- **Regression test:** test/Sprint6Fixes.t.sol::test_finding2_maxStalenessCeiling,
+  ::test_finding2_saturatingNoUnderflowPanic
+- **Docs updated:** THREAT-MODEL "Sprint 6 adversarial pass" table (E2)
+- **Verified by auditor:** yes
+
+---
+
+<!-- External-audit entries begin below this line. -->

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -1,0 +1,257 @@
+# External Audit Package — Reviewer Entry Point
+
+You are auditing an **immutable** protocol: no proxies, no upgrade path, no admin able to
+re-point anything after deployment. What ships is final; the audit surface is the deployed
+bytecode. This document gets a reviewer with zero context productive within an hour.
+
+## 0. One-paragraph system summary
+
+Permissionless vaults in which AI agents pool USDC into spot crypto index baskets and govern
+rebalances by stake-weighted commit-reveal vote. Members enter through a 4-hour observation
+window, exit in-kind (pro-rata slices of every basket asset) under a two-mode settlement rule
+that closes the exit-before-rebalance free option, and pay a 10% performance fee on realized
+profit netted against a cross-vault per-(member, operator) loss carryforward. Pricing is a
+multi-source median oracle with a staleness circuit breaker that — deliberately — freezes
+everything, including exits, when tripped. Vaults can allocate into child vaults (depth ≤ 3)
+with recursive look-through NAV. The off-chain layer (x402-metered API, indexer, web) never
+custodies funds and is out of scope.
+
+## 1. Reading order (estimated ~1 hour to productive)
+
+| # | Read | Why | Time |
+| --- | --- | --- | --- |
+| 1 | This file, top to bottom | System map, trust boundaries, wiring | 15 min |
+| 2 | [../ARCHITECTURE.md](../ARCHITECTURE.md) | Design intent: NAV/share math (§4), two-mode exits (§4.4), fees (§4.6, §7), governance (§8), sub-vaults (§10), C-1..C-5 commitments, K-1..K-4 accepted contradictions | 20 min |
+| 3 | [../THREAT-MODEL.md](../THREAT-MODEL.md) | 44 mechanic→vector→mitigation rows + Sprint 6 finding dispositions. **"Accepted" rows are deliberate tradeoffs, not oversights** | 15 min |
+| 4 | [walkthroughs/VaultCore.md](walkthroughs/VaultCore.md) | The critical contract, then the others as you reach them | 10 min |
+| 5 | Prior reviews in [../reviews/](../reviews/) | What three internal adversarial passes already found and how each finding was dispositioned | as needed |
+
+Per-contract walkthroughs (state, entry points, invariants, trickiest paths, accepted risks):
+
+- [walkthroughs/VaultCore.md](walkthroughs/VaultCore.md) — **critical**, holds all funds
+- [walkthroughs/Governance.md](walkthroughs/Governance.md) — **critical**, authorizes fund movement
+- [walkthroughs/OracleAggregator.md](walkthroughs/OracleAggregator.md) — **critical**, prices everything
+- [walkthroughs/FeeEngine.md](walkthroughs/FeeEngine.md)
+- [walkthroughs/OperatorRegistry.md](walkthroughs/OperatorRegistry.md)
+- [walkthroughs/AggregationRouterAdapter.md](walkthroughs/AggregationRouterAdapter.md)
+- [walkthroughs/DirectPoolAdapter.md](walkthroughs/DirectPoolAdapter.md)
+- [walkthroughs/SubVaultRegistry.md](walkthroughs/SubVaultRegistry.md)
+- [walkthroughs/VaultFactory.md](walkthroughs/VaultFactory.md)
+
+Cross-references:
+
+- [TEST-CROSS-REFERENCE.md](TEST-CROSS-REFERENCE.md) — every threat-model mechanic → the test(s) covering it
+- [FINDINGS-TEMPLATE.md](FINDINGS-TEMPLATE.md) — how we will respond to your findings
+- [../reviews/SLITHER-TRIAGE.md](../reviews/SLITHER-TRIAGE.md) — every static-analysis detector dispositioned
+
+## 2. System map
+
+```
+                       ┌────────────────────────────────────────────────┐
+                       │                 VaultFactory                   │  permissionless deploy;
+                       │  createVault / createChildVault → attest       │  the ONLY attestation path
+                       └───────┬───────────────────┬────────────────────┘
+                     attests   │                   │ registers child edge
+                               ▼                   ▼
+                    ┌──────────────────┐   ┌──────────────────┐
+                    │ OperatorRegistry │   │ SubVaultRegistry │
+                    │ identity, carry, │   │ parent/child     │
+                    │ leaderboard      │   │ edges, depth ≤ 3 │
+                    └────────▲─────────┘   └───────▲──────────┘
+          carry reads /      │                     │ parentOf (quorum floor,
+          realization writes │                     │ voting exclusion, edges)
+                             │                     │
+┌───────────────┐  executes  ┌▼─────────────────┐  │        ┌──────────────────┐
+│  Governance   │───────────►│    VaultCore     │──┘ prices │ OracleAggregator │
+│ commit-reveal │ rebalance/ │  shares / NAV /  │◄──────────│ ≥3-source median │
+│ quorum/deleg. │ child-alloc│  deposits/exits  │ + breaker │ + staleness trip │
+│ timelock      │◄───────────│  sub-vault flows │           └──────────────────┘
+└───────────────┘ Mode-F     └─┬──────────┬─────┘
+    hasPendingExecution        │          │ onRealize / onFeeCollected*
+                     swaps via │          ▼
+                    ┌──────────▼─────┐  ┌───────────┐
+                    │IExecutionAdapter│ │ FeeEngine │  10% perf fee, HWM netting,
+                    │ 2 impls: agg-   │ │           │  per-token operator claims
+                    │ router + V2 pool│ └───────────┘
+                    └────────────────┘
+```
+
+### Contract roles and risk weights
+
+| Contract | LoC | Role | Risk |
+| --- | --- | --- | --- |
+| `VaultCore.sol` | ~850 | Shares/NAV, deposits + observation window, two-mode exits, in-kind redemption + escrow, rebalance execution, sub-vault allocate/redeem/look-through, creator gate, exit fee, capacity cap, voting-stake checkpoints | **Critical** — holds all funds |
+| `Governance.sol` | ~490 | Proposals (3 types), commit-reveal, 3 quorum regimes, standing defaults, delegation + concentration cap, timelock, execute | **Critical** — authorizes every fund movement |
+| `OracleAggregator.sol` | ~140 | ≥3-source lower-median price with per-source staleness + quorum breaker | **Critical** — prices everything |
+| `FeeEngine.sol` | ~130 | 10% perf fee netted against registry carry; operator fee claims per token | High |
+| `OperatorRegistry.sol` | ~150 | Operator identity, (member, operator) loss carryforward, monotone leaderboard stats | High |
+| `AggregationRouterAdapter.sol` | ~76 | Off-chain-routed DEX-aggregation execution (pinned router + selector allowlist) | High — external calls |
+| `DirectPoolAdapter.sol` | ~94 | On-chain V2-pool execution (second adapter proving venue abstraction) | High — external calls |
+| `SubVaultRegistry.sol` | ~95 | Parent/child edges, depth cap 3, exit-fee stack cap, fee-stack display views | Medium |
+| `VaultFactory.sol` | ~114 | Permissionless deploy + attestation; child-basket-subset enforcement | Medium |
+| `lib/BoundedCall.sol` | ~46 | Gas- and returndata-bounded module calls (H-1 fix) | Medium |
+| `lib/Checkpoints.sol` | ~46 | Timestamp-keyed stake history (VO-9 snapshots) | Medium |
+| `lib/SafeTransferLib.sol` | ~58 | Safe transfers + assembly non-reverting `tryTransfer` (H-2 fix) | Medium |
+
+Out of scope: `packages/indexer`, `apps/api` (x402 metering), `apps/web`. These never custody
+funds; the API server holds no keys; the contracts have zero x402 coupling (ARCHITECTURE §9).
+
+## 3. Trust boundaries
+
+The protocol has **four distinct trust tiers**. Getting these straight matters because several
+defenses only make sense against the right adversary:
+
+1. **Protocol singletons (trusted-by-all, immutable):** `OperatorRegistry`, `FeeEngine`,
+   `Governance`, `SubVaultRegistry`, `VaultFactory`. One canonical set, deployed and one-shot
+   wired together (§5 below). No admin functions exist after wiring. Vaults deployed by the
+   canonical factory reference these; the factory is what makes carry marks and leaderboard
+   rows trustworthy (CM-5) — nothing stops someone deploying a *look-alike* stack, but it
+   won't be attested in the canonical registry.
+2. **Per-vault creator choices (trusted by that vault's members only):** the
+   `OracleAggregator` instance, the adapter allowlist, the basket, fee/capacity/window
+   parameters. All immutable at vault creation and visible on-chain before anyone deposits —
+   "read the config before you deposit" is the security model, so constructor validation
+   (oracle source floor, staleness ceiling, exit-fee cap, basket cap) is load-bearing: it
+   bounds what a malicious creator can configure a honeypot with.
+3. **Modules as adversaries on the exit path:** even the *canonical* governance/feeEngine/
+   registry are treated as potentially faulty where member liveness is at stake. Every module
+   call on the exit path is gas-bounded (300k), returndata-bounded (1 word), and non-blocking
+   (H-1 fix): a failing module forfeits its own bookkeeping, never a member's exit. Value is
+   separately bounded by the 10%-of-gain fee clamp.
+4. **Members, tokens, and children as adversaries:** every member is assumed potentially
+   malicious (snapshots, commit binding, reentrancy locks); basket tokens may misbehave
+   (assembly `tryTransfer` degrades to escrow, EE-6); child vaults are priced through the
+   parent's own oracle and internal accounting, never trusted self-reports (SV-7).
+
+Key boundary facts a reviewer should hold onto:
+
+- **Shares are non-transferable.** There is no `transfer`/`transferFrom` on VaultCore. Several
+  defenses (tenure clock, snapshot completeness, concentration-cap non-splittability) lean on
+  this.
+- **NAV never reads `balanceOf`.** All accounting is internal (`idleUsdc`, `assetBalance`);
+  donations cannot move NAV (EE-1). The only `balanceOf` reads are measured *deltas* around
+  external interactions (deposit receipt, swap output, child redemption proceeds).
+- **`block.timestamp` is the only clock** (C-2). No block-number arithmetic anywhere.
+- **Governance is the only caller** of `executeRebalance`, `allocateToChild`,
+  `redeemFromChild`. Everything else is permissionless or member-initiated.
+- **A parent vault is a non-voting member of its child.** It holds child shares but is excluded
+  from the child's voting-eligible stake and holder counts (`parentVault()` exclusion, GA-1
+  fix) — otherwise child full-consensus RuleChange would be structurally unreachable.
+
+## 4. Immutability posture (read before proposing "add an admin fix")
+
+- **No proxies, no upgradeable contracts, no pause guardians.** Protocol iteration = deploy a
+  new version through a new factory; migration is voluntary per vault.
+- The **only** mutable on-chain surface is per-vault `GovConfig`, changeable exclusively by a
+  full-consensus RuleChange + timelock (CM-8/K-2 — one permanently offline member freezes a
+  vault's config forever, and that is the intent).
+- The `wire()` calls on OperatorRegistry / SubVaultRegistry / Governance are **one-shot
+  deploy-time wiring**, not admin powers: callable only by the deployer, only once, revert
+  `AlreadyWired` thereafter (proven by `test_deployWiresAndLocks`).
+- Consequence for findings: "add an owner who can rescue X" is not an accepted remediation
+  shape. Fixes must be constructor validation, code-path changes, or documented acceptance.
+
+## 5. Deploy & wiring order (the only valid sequence)
+
+From `script/Deploy.s.sol` (proven by `test/Deploy.t.sol`):
+
+```
+1. OperatorRegistry()                      — no deps
+2. SubVaultRegistry()                      — no deps
+3. FeeEngine(registry)                     — immutable registry ref
+4. Governance()                            — no ctor deps
+5. VaultFactory(registry, governance, feeEngine, subVaultRegistry)
+6. registry.wire(factory, feeEngine)       — one-shot, locks attestation + fee recording
+7. subVaultRegistry.wire(factory)          — one-shot, locks child registration
+8. governance.wireSubVaultRegistry(subReg) — one-shot, locks SV-6 floor inheritance
+```
+
+Oracles and adapters are **not** singletons — each creator supplies their own at
+`createVault` time (per-vault venue/source choice, C-2/SF-1).
+
+Per-vault bring-up is **two-step**: `factory.createVault(params)` deploys + attests, then the
+creator calls `governance.registerVault(vault, cfg)` in a second transaction. Until
+registration, no proposals can exist and exits settle Mode I. This gap is documented UX, not
+a trust gap (nothing privileged happens in between).
+
+## 6. What has already been reviewed
+
+Three internal adversarial passes, all findings fixed or explicitly dispositioned:
+
+| Review | Scope | Outcome |
+| --- | --- | --- |
+| [SPRINT1-SECURITY-REVIEW](../reviews/SPRINT1-SECURITY-REVIEW.md) | VaultCore | 4 findings (H-1 module-liveness, H-2 returndata-bomb, M-1 gate-strand, M-2 in-kind fee dodge) — **all fixed**, regression `test/ModuleHardening.t.sol` |
+| [SPRINT6-EXECUTION-REVIEW](../reviews/SPRINT6-EXECUTION-REVIEW.md) | Oracle / execution / sub-vaults | 8 findings (2H/5M/1L) — fixed or documented, regression `test/Sprint6Fixes.t.sol` |
+| [SPRINT6-GOVERNANCE-REVIEW](../reviews/SPRINT6-GOVERNANCE-REVIEW.md) | Governance / economics | 5 findings (1H/2M/2 documented) — fixed/documented |
+| [SPRINT6-GOVERNANCE-ACCEPTED-ROWS](../reviews/SPRINT6-GOVERNANCE-ACCEPTED-ROWS.md) | The deliberately-Accepted governance rows | K-3/VO-2/VO-3 + snapshots hold; GA-1 (parent froze child RuleChange) **fixed**; VO-7 doc-corrected |
+
+The threat model's "Sprint 6 adversarial pass" table maps every finding ID (E1–E8, G1–G5,
+GA-1/GA-2) to its disposition. Each walkthrough's "Accepted risks" section lists what applies
+to that contract.
+
+## 7. Known residuals — please pressure-test, but don't re-report as new
+
+| ID | What | Why accepted |
+| --- | --- | --- |
+| K-4/SF-2 | Stale-oracle breaker freezes exits; induced staleness traps capital | Any exit hatch during staleness IS the stale-price exit the breaker prevents. Mitigations: ≥3 sources, strict-majority quorum, 1-day staleness ceiling. Pending (un-activated) deposits stay cancellable during a freeze |
+| K-2 | One permanently-offline member freezes rule changes forever | Near-immutability is the intent |
+| E7/EE-5 | Latency-arb on repeat deposits against stale NAV; profitable-drift threshold is gas within the oracle drift band | Bounded by 1-day staleness ceiling + non-zero exit fee; full closure needs oracle-enforced mint-time freshness (design option, not shipped) |
+| G3/CM-5 | Single-vault carry farming to shelter perf fees | 1% exit-fee cap forces ~100:1 transient capital fronting; leaderboard reputation drag. Economic deterrent, not a code fix |
+| PX-1 | USDC blacklist on a vault address freezes the USDC leg | Inherent to USDC settlement; in-kind escrow keeps non-USDC assets exitable |
+| E4 (S6) | Parent exit needing child unwind reverts `ExitNeedsChildSettlement` while the only covering child is mid-rebalance | Clean rollback + bounded retry (child timelock). Window narrowed vs. original deep-stack revert, not eliminated |
+| E5 (S6) | A child that persistently escrows an in-kind slice to the parent (e.g. blacklisted parent) makes the parent exit revert rather than escrow-and-continue | Silent underpayment fixed; EE-6 asymmetry for child-held slices is a known residual — a deferred-claim mechanism would close it |
+| GA-2/VO-7 | Mid-reveal tally is publicly readable | Commit binds vote direction, so no direction-changing last-mover advantage; encrypted reveals are a v1 non-goal |
+
+## 8. Specified but NOT in the audited surface
+
+- **Swing pricing (ARCHITECTURE §4.7).** v1 is in-kind-only redemption, which imposes no
+  dilution on remaining members, so there is nothing to swing; EE-11 is N/A in v1. The spec
+  exists for a future optional cash-redemption path. No swing code exists.
+- **ERC-4626 compliance.** Deliberately not claimed (C-1). `totalAssets`/`convertToShares`/
+  `convertToAssets` are indicative-only views for tooling.
+
+## 9. Suggested audit focus (highest leverage first)
+
+1. `VaultCore._settleExit` — two-mode exit accounting: the forward-pricing seam (VO-8 × K-1),
+   the SV-5 shortfall unwind with children present, rounding direction, and the §4.6
+   NAVps-non-decreasing invariant.
+2. `Governance.execute` payload decoding across the three proposal types (type-confusion), and
+   commit-reveal quorum math at the <5-member regime boundary (CM-7).
+3. `VaultCore._fullNavWad` recursive look-through — depth bounding, and whether any descendant
+   state can misprice an ancestor's NAV (S6 E1 fix).
+4. `OracleAggregator` median robustness (lower-median, strict-majority quorum, saturating
+   staleness) and `BoundedCall`/`tryTransfer` returndata handling.
+5. `AggregationRouterAdapter` vs. the 2026 arbitrary-calldata exploit class (SwapNet/Aperture
+   et al.) — the reason the pinned router + selector allowlist + measured-delta minOut exist.
+
+## 10. Build, test, verify
+
+```bash
+cd contracts
+forge build
+forge test                                   # 117 tests, incl. 6 invariant/fuzz suites
+forge snapshot --check                       # gas regression gate
+slither . --filter-paths "lib|test|script"   # triaged: docs/reviews/SLITHER-TRIAGE.md
+```
+
+Invariant suites run 256 runs × 16k calls each. Key proven invariants:
+
+- Σ member shares == totalShares across every path (single-vault and with children)
+- NAVps non-decreasing for remaining members across any redemption (§4.6), with and without
+  sub-vaults
+- Vault solvency: real USDC ≥ internal idle + escrowed pending, under adversarial donation
+- Queued (Mode-F) share consistency; voting-eligible = supply − locked
+- Pending escrow excluded from NAV; child fully backs parent
+- Fee/carry ghost-model equivalence; leaderboard stats monotone; fee ≤ 10% of net gain
+
+See [TEST-CROSS-REFERENCE.md](TEST-CROSS-REFERENCE.md) for the full mechanic → test map.
+
+## 11. Findings process
+
+Submit findings in any format; we will respond using
+[FINDINGS-TEMPLATE.md](FINDINGS-TEMPLATE.md) — one entry per finding with severity,
+disposition, response rationale, and fix commit. Ground rules we commit to:
+
+- Every finding gets a written disposition; "Accepted" always comes with a why.
+- Fixes land as isolated commits referenced from the findings log, with regression tests.
+- We will not silently fix anything you report — the log is the audit trail.

--- a/docs/audit/TEST-CROSS-REFERENCE.md
+++ b/docs/audit/TEST-CROSS-REFERENCE.md
@@ -1,0 +1,119 @@
+# Threat-Model → Test Cross-Reference
+
+Every mechanic in [THREAT-MODEL.md](../THREAT-MODEL.md) mapped to the test(s) covering it.
+Suite: 117 tests across 15 files (`contracts/test/`), including 6 invariant/fuzz suites
+(256 runs × 16k calls). Rows with no dedicated test say so explicitly — traceability includes
+the honest gaps.
+
+Test names abbreviated to `File::test`; all files live in `contracts/test/`.
+
+## Entry / exit (EE) & share accounting
+
+| Row / mechanic | Tests |
+| --- | --- |
+| EE-1 donation defense, pending excluded from NAV | `VaultCore::test_donationDoesNotMoveNav`, `::test_firstDepositEntersWindow_noSharesNoNav`, `VaultCoreInvariant::invariant_pendingEscrowConsistent`, `::invariant_solvency` (adversarial donation) |
+| §5 observation window state machine | `VaultCore::test_activateBeforeWindowReverts`, `::test_activateAfterWindowMintsAtActivationNav`, `::test_cancelPendingRefunds`, `::test_skipWindow_immediateActivation_andIrreversible`, `::test_repeatDepositSkipsWindow` |
+| SF-3 capacity cap (optional) + min deposit | `VaultCore::test_capacityCapEnforced`, `::test_uncappedVaultAcceptsUnboundedDeposits`, `::test_minDepositEnforced` |
+| CM-1/CM-2 creator 5% withdrawal gate | `VaultCore::test_creatorCannotExitBelow5PctWhileMembersRemain`, `::test_creatorCanExitPartiallyDownTo5Pct`, `::test_creatorCanFullyExitWhenNoMembersRemain`, `VaultCoreInvariant::invariant_creatorFloor` |
+| EE-7 / §4.6 exit fee: decay, accrual to remainers, sole-holder waiver | `VaultCore::test_exitFeeDecaysWithTenure`, `::test_exitFeeAccruesToRemainingMembers_neverOperator` (also EE-9), `::test_exitFeeWaivedForSoleHolder` (EE-8) |
+| C-4 two-mode settlement (Mode I / Mode F) | `VaultCore::test_modeI_instantWhenNoPendingExecution`, `::test_modeF_queuesDuringPendingExecution_settlesAtPostNav`, `::test_modeF_doubleQueueReverts`, `VaultCoreInvariant::invariant_queuedConsistent` |
+| VO-8 × K-1 forward-pricing seam; EE-10 queue release | `Governance::test_exitDuringRevealPhaseIsForwardPriced`, `::test_expiredProposalReleasesQueuedExits`, `Execution::test_e2e_governedRebalance_modeFExitSettlesAtPostNav` |
+| EE-6 in-kind + escrow isolation | `VaultCore::test_inKindRedemption_proRataAcrossAssets`, `::test_blockedAssetEscrows_redemptionStillCompletes` |
+| §4.6 NAVps non-decreasing + conservation + solvency | `VaultCoreInvariant::invariant_sharesConserved`, `::invariant_solvency`; system-level with children: `SystemInvariant::invariant_parentShareConservation`, `::invariant_parentSolvency`, `::invariant_childBacksParent` |
+| C-1 indicative 4626 views | `VaultCore::test_indicativeViews` |
+| EE-5/E7 latency arb | **Accepted residual** — no test; bounded by oracle ceiling + exit fee (see README §7) |
+
+## Module hardening (MO / S1 review fixes)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| MO-1/H-1 reverting modules never block exits; governance failure → Mode I | `ModuleHardening::test_h1_revertingFeeEngineAndRegistry_exitStillSettles`, `::test_h1_revertingGovernance_fallsBackToModeI`, `::test_h1_moduleFailureEmitsEvent` |
+| MO-2/H-2 malformed-returndata / bomb token degrades to escrow | `ModuleHardening::test_h2_malformedReturnTokenEscrows_exitCompletes` |
+| MO-3/M-1 creator gate at queue time, not re-checked at settle | gate-at-queue asserted in `VaultCore::test_modeF_*` paths; settle-time non-recheck verified in S1 review — no dedicated regression test |
+| MO-4/M-2 fee withheld uniformly across cash + in-kind legs | `ModuleHardening::test_m2_fullyInvestedVault_feeStillCollected` |
+
+## Fees, carry, registry (CM / SF-4/5)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| CM-3 crystallization only at redemption; 10% of realized gain | `FeesAndRegistry::test_tenPercentOfRealizedGain`, `VaultCore::test_realizedGainReportedToFeeEngineAndRegistry`, `::test_realizedLossReported_noFee` |
+| Hostile-module fee clamp (≤10% of gain) | `VaultCore::test_perfFeeClampedTo10PctOfGain`, `FeeCarryInvariant::invariant_feeNeverExceedsNetGainTenth` |
+| §7 cross-vault HWM carry portability | `FeesAndRegistry::test_lossInVaultA_offsetsFeeInVaultB_sameOperator`, `::test_carryFullyConsumedThenFeesResume`, `FeeCarryInvariant::invariant_carryMatchesGhost` |
+| CM-4 fresh identity sheds carry, restarts record | `FeesAndRegistry::test_carryIsPerOperator_freshIdentityGetsNoOffset` |
+| CM-5 attestation gate (factory-only, canonical) | `FeesAndRegistry::test_factoryAttestsAndAutoRegistersOperator`, `::test_unattestedVaultCannotRecordOrBeFeeAssessed`, `::test_onlyFactoryAttests` |
+| SF-4/SF-5 monotone leaderboard, history retained | `FeesAndRegistry::test_statsAreMonotone_closedVaultHistoryRetained`, `FeeCarryInvariant::invariant_lifetimeMonotone`, `FeesAndRegistry::test_operatorClaimsFees` |
+| G3/CM-5 carry farming | **Accepted residual** — economic deterrent, no test |
+| G5 fee/carry non-atomicity | covered indirectly by `invariant_carryMatchesGhost`; divergence unreachable at current gas params (S6 review) |
+
+## Governance / voting (VO / CM-6/7/8)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| Lifecycle propose→commit→reveal→finalize→timelock→execute | `Governance::test_fullLifecycle_passAndExecute` |
+| VO-2/K-3 quorum floor; defaults tally-only | `Governance::test_quorumFloorDefeats`, `::test_defaultCountsInTallyNeverQuorum` |
+| VO-3 default 72h TTL | `Governance::test_defaultExpiresAfter72h` |
+| VO-4 defaults structurally Rebalance-only | `Governance::test_defaultOnlyForRebalanceType` |
+| G4 default must predate proposal (`setAt < createdAt`) | verified in accepted-rows review (Area 2) — no dedicated regression test |
+| VO-5/G1 delegation + concentration cap on received weight only | `Governance::test_delegationCranksOntoDelegateDirection`, `::test_concentrationCapBlocksExcessDelegation`, `::test_ownWeightIsNeverConcentrationCapped`, `::test_selfVoteBeatsDelegation` |
+| VO-6 unrevealed commits forfeit | `Governance::test_unrevealedCommitIsForfeit` |
+| VO-9 flash-stake zero weight (snapshot at createdAt−1) | `Governance::test_postCreationDepositHasZeroWeight`, `GovernanceInvariant::invariant_revealedNeverExceedsSnapshot` |
+| CM-6 proposal threshold + serialization + cooldown | `Governance::test_proposalThresholdEnforced`, `::test_oneActiveProposalPerVault`, `GovernanceInvariant::invariant_atMostOneLiveProposal` |
+| CM-7 <5-member signer regime, fixed at creation | `Governance::test_signerRegimeUnder5Members` |
+| CM-8/K-2 RuleChange full consensus | `Governance::test_ruleChangeRequiresFullConsensus`, `::test_ruleChangeFullConsensusPassesAndApplies` |
+| VO-8 timelock hard cap | `Governance::test_timelockHardCapEnforced` |
+| Tally/round bookkeeping | `GovernanceInvariant::invariant_roundAccountingConsistent` |
+| GA-2/VO-7 mid-reveal tally visibility | **Accepted residual** — commit-binding is the defense, no test |
+
+## Oracle (SF-1/2, E2/E6)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| SF-1 median of ≥3, robustness to outliers | `Execution::test_medianOfThree`, `::test_manipulatedOutlierAbsorbedByMedian`, `OracleFuzz::testFuzz_lowerMedianOfFive`, `::testFuzz_medianWithinRange`, `::testFuzz_minorityOutliersCannotMoveMedian` |
+| E6 fix: ≥3 sources + strict-majority quorum enforced | `Sprint6Fixes::test_finding6_minSourcesAndMajorityQuorum` |
+| One dead source ≠ breaker; below quorum = breaker | `Execution::test_oneDeadSourceStillQuorum`, `::test_belowQuorumTripsBreaker`, `OracleFuzz::testFuzz_belowQuorumTripsBreaker` |
+| E2 fix: staleness ceiling + saturating subtraction | `Sprint6Fixes::test_finding2_maxStalenessCeiling`, `::test_finding2_saturatingNoUnderflowPanic` |
+| K-4/SF-2 breaker freezes deposits AND exits | `VaultCore::test_staleOracleFreezesDepositsAndExits_whenBasketHeld` |
+| SF-2 softening: pending capital never trapped | `VaultCore::test_pendingDepositCancellableDuringOracleFreeze` |
+| Chainlink adapter WAD normalization | `Execution::test_chainlinkAdapterNormalizes8Decimals` |
+
+## Execution / adapters (EX-1..3, E3)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| EX-1 selector allowlist; adapter allowlist; governance-only | `Execution::test_adapterRejectsUnknownSelector`, `::test_rebalanceRejectsUnlistedAdapter`, `::test_rebalanceOnlyThroughGovernance`, `SubVaults::test_childFlowsAreGovernanceOnly` |
+| EX-3 measured-delta minOut, never router's word | `Execution::test_adapterEnforcesMinOutOnMeasuredDelta`, `::test_adapterRequiresMinOut`, `::test_rebalanceRejectsRogueOutputToken`, `DirectPoolAdapter::test_directAdapterEnforcesMinOutOnMeasuredDelta` |
+| Deadline enforcement | `Execution::test_adapterEnforcesDeadline` |
+| C-2 venue abstraction (2 structurally different adapters) | `DirectPoolAdapter::test_governedRebalanceThroughDirectPoolAdapter`, `::test_directAdapterRejectsTokenNotInPair` |
+| E3 fix: leftover sweep from per-swap delta | fix verified in S6 review; escrow non-absorption covered indirectly by `SystemInvariant::invariant_parentSolvency` / `VaultCoreInvariant::invariant_solvency` — no dedicated regression test |
+| End-to-end governed rebalance + Mode-F settle | `Execution::test_e2e_governedRebalance_modeFExitSettlesAtPostNav` |
+
+## Sub-vaults (SV-1..7, E1/E4/E5/E8, GA-1)
+
+| Row / mechanic | Tests |
+| --- | --- |
+| SV-2 depth cap 3 | `SubVaults::test_depthCapAtThreeLevels` |
+| SV-3 edges creation-only, deposits only along edges | `SubVaults::test_allocationOnlyAlongRegisteredEdges`, `SystemInvariant::invariant_childHasOnlyParent` |
+| Child basket ⊆ parent basket | `SubVaults::test_basketMustBeSubsetOfParent` |
+| SV-4 fee-stack cap + display views | `SubVaults::test_exitFeeStackCapEnforced`, `::test_stackedFeeViews` |
+| SV-6 quorum floor inheritance (registration + RuleChange, G2) | `SubVaults::test_childQuorumFloorInheritsFromParent` |
+| SV-7/E1 look-through pricing incl. grandchildren | `SubVaults::test_allocatePreservesParentNav`, `::test_lookThroughTracksChildAssets`, `Sprint6Fixes::test_finding1_grandchildValueInRootNav` |
+| SV-5 idle-first exit, shortfall unwind | `SubVaults::test_exitDrawsIdleFirst_childUntouched`, `::test_exitShortfallUnwindsChild`, `::test_governanceRedeemsFromChild` |
+| E4 fix: mid-rebalance child skipped when idle covers | `Sprint6Fixes::test_finding4_pendingChildDoesNotBlockWhenIdleCovers` |
+| E5 fix: shortfall decremented by measured value | asserted inside `SubVaults::test_exitShortfallUnwindsChild` value accounting; the escrowing-child residual itself is **accepted** (README §7) |
+| E8 fix: basket cap + bounded navWad gas | `Sprint6Fixes::test_finding8_basketCapEnforced`, `NavGas::test_navWadGasBoundedAtDepthThree` |
+| GA-1 fix: parent excluded from child voting stake | `SubVaults::test_childRuleChangePassesAfterParentAllocates` |
+
+## Deployment / wiring
+
+| Row / mechanic | Tests |
+| --- | --- |
+| One-shot wiring, locked back-references, valid order | `Deploy::test_deployWiresAndLocks` |
+
+## Known coverage gaps (candidates for the audit, not oversights)
+
+1. **MO-3 settle-time non-recheck** and **G4 lower-bound** have review-verified fixes but no
+   dedicated regression tests.
+2. **E3 sweep** is covered only indirectly through solvency invariants.
+3. Accepted residuals (EE-5/E7 latency arb, G3 carry farming, K-4 induced staleness cost,
+   VO-7 tally visibility) are deliberately untested — they are economic/design bounds, not
+   code properties.

--- a/docs/audit/walkthroughs/AggregationRouterAdapter.md
+++ b/docs/audit/walkthroughs/AggregationRouterAdapter.md
@@ -1,0 +1,58 @@
+# Walkthrough — AggregationRouterAdapter.sol
+
+**Risk: High (external calls with off-chain-supplied calldata).** ~76 LoC.
+`contracts/src/AggregationRouterAdapter.sol`.
+
+## Purpose
+
+The first concrete `IExecutionAdapter`: swap execution through a DEX-aggregation router
+(0x/1inch-style) using off-chain-computed route calldata. This is the contract class behind
+the 2026 arbitrary-calldata exploits (SwapNet/Aperture ~$13–17M; earlier Dexible, Unizen,
+LI.FI), all sharing one root cause — trusting off-chain-supplied call targets/calldata. Every
+hardening below exists because of that history (EX-1..EX-3, RESEARCH-SPRINT1).
+
+## The hardening, point by point
+
+| Defense | Mechanism |
+| --- | --- |
+| No attacker-chosen target | `router` is **pinned immutable** at construction — `routeData` cannot choose where the call goes (EX-2) |
+| No arbitrary function | `routeData`'s 4-byte selector must be on the **construction-time allowlist** (EX-1); ≥4 bytes required |
+| No trusted slippage | `minAmountOut > 0` is mandatory; enforced HERE on the **measured tokenOut balance delta**, never on router return values or calldata-embedded params (EX-3) |
+| No stale execution | `deadline` enforced here, `block.timestamp`-compared (C-2) |
+| No approval residue | Approve exactly `amountIn` pre-swap, **revoke to 0 after** — no cross-transaction approval remains for a router upgrade to abuse (EX-2) |
+| No stranded partials | Unspent `tokenIn` is swept back to the caller after the swap |
+
+Call sequence: pull `amountIn` from caller → approve router → snapshot `tokenOut` balance →
+`router.call(routeData)` (must succeed) → measure delta → `require(delta ≥ minAmountOut)` →
+revoke approval → send output + leftover input back to caller.
+
+## Trust position
+
+The adapter is chosen by the vault creator via the construction-time **adapter allowlist** in
+VaultCore (EX-1: members signed up for these venues; changing venues means a new vault). Even
+so, VaultCore does not trust the adapter's arithmetic: `executeRebalance` re-measures the
+output on the **vault's own** balance of the fixed, basket-constrained `tokenOut` and enforces
+the order's `minAmountOut` again. A malicious adapter can at worst fail swaps or waste the
+input leg it was approved for in that transaction — it cannot misreport its way into vault
+accounting.
+
+## Review focus
+
+1. **Selector-allowlist bypass surface:** an allowlisted router selector whose argument
+   structure lets `routeData` embed a nested arbitrary call (router-dependent — the allowlist
+   is only as good as the chosen selectors; this is a deployment-review item, flag anything
+   that makes a dangerous selector look safe).
+2. **Token callbacks:** `amountOut` is measured as a same-address balance delta; a
+   fee-on-transfer or reentrant `tokenOut` interacts with the delta measurement (vault-side
+   re-measurement + `nonReentrant` on the vault bound the blast radius).
+3. **The `router.call` is intentionally unbounded** (unlike module calls): a malicious router
+   can consume gas or revert — that fails the rebalance transaction, which is governance-
+   initiated and retryable; it never touches member exit liveness.
+
+## Accepted risks here (do not re-report)
+
+- **EX-2 residual:** sandwich/MEV on rebalance execution is bounded by `minAmountOut`, not
+  eliminated; private-mempool submission is an off-chain operator concern (documented).
+- A creator who allowlists a bad router+selector set at creation builds a vault whose
+  rebalances can fail or leak slippage — visible on-chain pre-deposit; PX-3-class "read the
+  config" risk, not a protocol control.

--- a/docs/audit/walkthroughs/DirectPoolAdapter.md
+++ b/docs/audit/walkthroughs/DirectPoolAdapter.md
@@ -1,0 +1,47 @@
+# Walkthrough — DirectPoolAdapter.sol
+
+**Risk: High (external calls), structurally simpler than the router adapter.** ~94 LoC.
+`contracts/src/DirectPoolAdapter.sol`.
+
+## Purpose
+
+A **second** `IExecutionAdapter` implementation that swaps directly against one
+Uniswap-V2-style pair, with the amount-out computed on-chain from reserves. It exists to
+*prove* the venue abstraction (C-2): `VaultCore.executeRebalance` drives it identically to
+the aggregation adapter although the venue shape is completely different — no off-chain
+calldata, no selector allowlist (`test_governedRebalanceThroughDirectPoolAdapter`). If a
+reviewer wants to check that VaultCore has no hidden venue assumptions, diffing the two
+adapters against the interface contract is the fast way.
+
+## Mechanism
+
+- One immutable `pair` per adapter instance (the analog of the pinned router); `token0`/
+  `token1` cached at construction. `FEE_BPS = 30` (canonical V2 fee).
+- `executeSwap`: validate deadline / minOut>0 / amountIn>0 / tokenIn≠tokenOut / both tokens
+  in the pair → pull input → read reserves → compute constant-product quote → transfer input
+  to the pair → `pair.swap(...)` → measure output delta → `require(delta ≥ minAmountOut)` →
+  send output to caller.
+
+The same safety contract as the router adapter holds: **minOut and deadline enforced here on
+measured deltas** (EX-3), never trusting the quote or any external return value, and the
+`routeData` field is simply ignored.
+
+## Review focus
+
+1. **Reserve read vs. swap atomicity:** the quote is computed from `getReserves` in the same
+   transaction; a sandwich moves reserves before this transaction executes, which surfaces as
+   the measured delta failing `minAmountOut` — the caller's floor is the real protection, the
+   quote is just sizing. Verify no path pays out on the quote rather than the delta.
+2. **Token quirks:** fee-on-transfer input tokens under-deliver to the pair (V2 `swap` then
+   reverts on K); rebasing/callback tokens interact with the delta measurement. Bounded by the
+   vault-side re-measurement and `nonReentrant`.
+3. **No approval surface at all** on this path (direct transfer to the pair) — one less thing
+   to audit; confirm the leftover-input story (none should exist here because the full
+   `amountIn` goes to the pair).
+
+## Accepted risks here (do not re-report)
+
+- Ordinary V2 MEV exposure bounded by `minAmountOut` (EX-2 residual, as with the router
+  adapter).
+- A creator allowlisting an adapter pinned to a pathological pair is a visible-at-creation
+  config choice (PX-3-class), not a protocol control.

--- a/docs/audit/walkthroughs/FeeEngine.md
+++ b/docs/audit/walkthroughs/FeeEngine.md
@@ -1,0 +1,69 @@
+# Walkthrough — FeeEngine.sol
+
+**Risk: High.** ~130 LoC. `contracts/src/FeeEngine.sol`.
+
+## Purpose
+
+The 10% performance fee on realized profit, netted against the cross-vault
+per-(member, operator) loss carryforward held by the OperatorRegistry (the portable HWM, §7).
+Crystallization happens **only at member redemption** (CM-3) — never on rebalance, so an
+operator cannot churn to crystallize early. Collected fees accumulate per (operator, token)
+for pull-based claims.
+
+## Trust position
+
+The engine is a protocol singleton, but VaultCore treats it as **potentially hostile on the
+exit path** (H-1 philosophy): every call from `_settleExit` is gas-bounded, returndata-bounded
+and non-blocking, and the returned fee is clamped by the vault to ≤ 10% of realized gain. The
+engine can therefore never block an exit or extract more than the protocol fee. Conversely the
+engine trusts only **attested vaults** — every mutating entry point resolves
+`registry.operatorOf(msg.sender)` and reverts `UnattestedVault` for opId 0, so arbitrary
+contracts cannot mint fee credits or read/consume carry through it.
+
+## State
+
+- `registry` (immutable) — carry reads + operator identity + fee-stat recording.
+- `claimableFees[operator][token]` — collected fees awaiting operator claim (USDC *and*
+  in-kind asset legs; M-2 uniform withholding means fees arrive in every payout token).
+
+## External entry points
+
+| Function | Caller | What it does |
+| --- | --- | --- |
+| `onRealize(member, gain, loss)` | attested vault (bounded call) | Gain path: `netGain = gain − carry` (floored at 0), returns `10% × netGain`. Loss path: no-op — losses reach the carry via the vault's own `recordRealization` call |
+| `onFeeCollected(member, amountUsdc)` | attested vault, **after** the USDC fee transfer | Credits `claimableFees[operator][usdc]` with the amount **actually sent** (the vault's clamp may have reduced it) and reports it to registry stats |
+| `onFeeCollectedAsset(member, asset, amount)` | attested vault, after an in-kind fee transfer | Credits the asset-leg fee at token amounts (USD-terms stats stay cash-leg-only; the indexer prices asset legs, S7) |
+| `pullEscrowed(vault, asset)` | anyone (crank) | Claims a fee slice the vault EE-6-escrowed for the engine (failed transfer path) and credits it, measured by balance delta |
+| `claimFees(token)` | operator | Pull-payment of accumulated fees |
+
+## Key sequencing invariant (the subtle one)
+
+Within one `_settleExit`, the call order is fixed: `onRealize` reads the carry **pre-update**,
+then the vault calls `registry.recordRealization`, which consumes (gain) or builds (loss) the
+carry. The "fee assessed ⟺ carry consumed" pairing is therefore **two decoupled best-effort
+calls**, not an atomic operation — dispositioned as G5 (documented): both calls sit inside the
+same 300k-gas bounded-call budget, the only revert path (`opId == 0`) is impossible for an
+attested vault, and any realistic divergence favors the member, never solvency.
+`FeeCarryInvariant.t.sol` fuzzes the pairing against a ghost model
+(`invariant_carryMatchesGhost`, `invariant_feeNeverExceedsNetGainTenth`).
+
+## Review focus
+
+1. **Credit-from-collected discipline:** operator credits must come only from
+   `onFeeCollected*` amounts (what physically arrived), never from the `onRealize` return
+   (which the vault may clamp). An undercollected fee is forgiven in the member's favor —
+   verify no path books uncollected fees as debt.
+2. **`pullEscrowed` delta measurement:** fee-on-transfer or misbehaving assets credit only
+   the measured delta; check no double-credit with a later direct `onFeeCollectedAsset`.
+3. **Cross-vault flows:** two attested vaults under the same operator interleaving
+   settlements — carry reads are per-call, so ordering across vaults in one block is worth a
+   thought (registry state is global).
+
+## Accepted risks here (do not re-report)
+
+- **G5:** fee-assess vs. carry-consume non-atomicity (bounded, member-favoring; documented).
+- **G3/CM-5:** exit-fee-manufactured losses build real carry — single-vault carry farming is
+  economically gated (1% exit-fee cap ⇒ ~100:1 capital fronting + leaderboard drag), not
+  code-prevented.
+- Asset-leg fees are recorded in token units, not USD, in registry stats — a deliberate
+  indexer-side pricing decision, not a lost-fee bug.

--- a/docs/audit/walkthroughs/Governance.md
+++ b/docs/audit/walkthroughs/Governance.md
@@ -1,0 +1,139 @@
+# Walkthrough — Governance.sol
+
+**Risk: Critical (authorizes every fund movement).** ~490 LoC. `contracts/src/Governance.sol`.
+
+## Purpose
+
+The Sprint 2 module: proposal lifecycle with commit-reveal voting, three quorum regimes,
+standing defaults, delegation with a concentration cap, post-vote timelock, and typed
+execution against the vault. One protocol singleton serves all vaults; per-vault behavior
+comes from `configOf[vault]` (a `GovConfig`), registered once by the creator and thereafter
+mutable only via full-consensus RuleChange.
+
+It is also the source of the one signal VaultCore's exit path depends on:
+`hasPendingExecution(vault)` — the Mode-I/Mode-F switch (VO-8/K-1 coupling).
+
+## Lifecycle
+
+```
+propose ──► commit phase ──► reveal phase ──► finalize ──► [timelock] ──► execute
+                                                 │                          │
+                                                 └─► Defeated               └─► (window lapses) markExpired
+```
+
+- **One active proposal per vault** (`activeProposalOf`) — serialization is the CM-6 spam
+  defense and keeps the Mode-F coupling unambiguous.
+- `hasPendingExecution` is true from **reveal start** (outcome starts leaking on-chain) until
+  Executed / Defeated / expiry — so exits requested after reveals begin are forward-priced,
+  and queued exits always release eventually (EE-10).
+
+## Proposal types (structurally distinct on-chain, VO-4)
+
+| Type | Quorum | Standing defaults? | Execution payload |
+| --- | --- | --- | --- |
+| `Rebalance` | normal (regime below) | **Yes — only type** | `(adapter, SwapOrder[])` → `vault.executeRebalance` |
+| `RuleChange` | **full consensus**: `revealedWeight == snapshotTotal && forWeight >= snapshotTotal` | No | `GovConfig` → validate + parent-floor check + store |
+| `ChildAllocation` | normal | No | `(child, allocateUsdc, redeemShares)` → `allocateToChild` / `redeemFromChild` |
+
+The payload is bound at propose time by `actionHash = keccak256(payload)`; `execute` requires
+the exact bytes and decodes keyed on the stored `ptype` — voters approve the
+`(ptype, actionHash)` pair, so payload type-confusion was examined and judged sound (S6
+governance review, Coverage).
+
+## Quorum regimes (finalize)
+
+1. **RuleChange:** every unit of snapshot-eligible stake revealed FOR (CM-8/K-2).
+2. **Signer regime** (`memberCount < 5` at creation): `revealedVoterCount * 2 > memberCount`
+   — absolute head-count majority (CM-7). The regime is **fixed per proposal at creation**
+   from `pastHolderCount(createdAt − 1)`; membership changes never flip an in-flight proposal.
+3. **Stake quorum** (≥5 members): `revealedWeight * BPS >= quorumBps * snapshotTotal`, with
+   `quorumBps >= 2500` (25% protocol floor). **Only revealed (live) weight counts** — standing
+   defaults never touch the quorum numerator (VO-2/K-3).
+
+Pass additionally requires `forWeight > againstWeight` in every regime.
+
+## Voting paths (mutually exclusive per member per proposal)
+
+| Path | Who | Counts in quorum? | Notes |
+| --- | --- | --- | --- |
+| `commitVote` → `revealVote` | member with weight at snapshot | Yes | Commitment binds `(pid, voter, support, salt)` — no cross-proposal replay, no direction change at reveal. **Own weight is never concentration-capped** (G1 fix) |
+| `revealDelegated(pid, delegator)` | anyone (crank) | Yes | Requires the delegate to have revealed; routes the delegator's weight onto the delegate's direction; `_accrueDelegate` enforces the concentration cap on **received** weight; self-commit takes precedence |
+| `applyStandingDefault(pid, member)` | anyone (crank) | **Never** | Rebalance-only (on-chain type check); default must **predate the proposal** (`setAt < createdAt`, G4 fix) and be within its 72h TTL; tally direction only |
+
+Mutual exclusion: `revealVote` needs a commit; the two cranks require `commitOf == 0` and
+share the `defaultApplied` consumed-flag. So `revealedWeight ≤ snapshotTotal` with each member
+counted at most once (verified in the S6 review and by `invariant_revealedNeverExceedsSnapshot`).
+
+## Snapshot discipline (VO-9)
+
+All weight reads — proposer eligibility, commit gate, reveal weight, delegated weight, default
+weight — use `pastVotingEligibleShares(…, createdAt − 1)`: strictly before creation, so stake
+minted in the proposal's own second (flash deposits included) carries zero weight. First-ever
+deposits mint no shares at all (observation window), doubly defeating atomic flash-stake.
+`snapshotTotal` and `memberCount` are captured once at propose and never rewritten.
+
+## Config (`GovConfig`) validation
+
+`commitDuration ≥ 1h`, `revealDuration ≥ 1h`, `executionWindow ≥ 1h`,
+`timelockDuration ≤ 30 days` (hard cap), `2500 ≤ quorumBps ≤ 10000`,
+`proposalThresholdBps ≤ 10000`, `0 < concentrationCapBps ≤ 10000`. Plus SV-6 parent-floor
+inheritance — `quorumBps >= parent's quorumBps` — enforced at **both** `registerVault` and the
+RuleChange update path (G2 fix; the check is shared, `_requireParentQuorumFloor`).
+
+The `commitDuration ≥ 1h` floor is load-bearing beyond UX: it guarantees exiters at least one
+hour of Mode-I notice between `Proposed` and the Mode-F lock engaging at reveal start
+("propose → instantly trap exiters" is impossible).
+
+## External entry points
+
+`wireSubVaultRegistry` (one-shot, deployer-only), `registerVault` (creator, once),
+`propose`, `commitVote`, `revealVote`, `revealDelegated`, `setStandingDefault` /
+`clearStandingDefault`, `applyStandingDefault`, `setDelegate` (blocked mid-proposal),
+`finalize`, `execute`, `markExpired`, and the views `hasPendingExecution` / `isExecutor`.
+
+Note the **trust direction**: Governance calls into VaultCore (`executeRebalance`,
+`allocateToChild`, `redeemFromChild`) as the authorized caller; VaultCore calls back only
+through the bounded, non-blocking `hasPendingExecution` read. A bricked Governance therefore
+degrades vaults to Mode-I-only exits — never a lockup (H-1 design).
+
+## Invariants
+
+- One live (Active/Passed-unexpired) proposal per vault (`invariant_atMostOneLiveProposal`).
+- `revealedWeight ≤ snapshotTotal`; `forWeight + againstWeight` consistent with reveals +
+  cranked defaults/delegations (`invariant_roundAccountingConsistent`).
+- `snapshotTotal` immutable per proposal.
+- Standing defaults contribute to tally only — a vault of pure defaults is defeated in every
+  regime (accepted-rows review, Area 2).
+
+## Trickiest paths (review focus)
+
+1. **`execute` payload decoding across the three types.** Keyed on stored `ptype` + exact
+   `actionHash` bytes. Adversarial question: can any payload decode validly under two types,
+   or can a vault-side callee (`allocateToChild` etc.) be reached with arguments voters did
+   not approve? (Vault re-validates child edges independently.)
+2. **Quorum regime boundary at exactly 5 members (CM-7).** Regime snapshots at creation;
+   `holderCount` includes fully-queued members (weight 0 but still holders), which errs
+   toward harder-to-pass. Check the boundary arithmetic both sides.
+3. **Concentration cap after the G1 fix.** Own weight uncapped; only cranked delegation
+   accrues via `_accrueDelegate` (re-checked per accrual, order-independent). Residual freeze
+   case = delegator who neither self-votes nor can be cranked ≡ offline member (accepted K-2).
+4. **The Mode-F coupling.** `hasPendingExecution` truth table vs. VaultCore's queue/settle
+   paths: Active+reveal-phase → true; Passed within window → true; everything else false.
+   EE-10: a passed-but-never-executed proposal expires → queued exits settle at then-current
+   NAV. Check `markExpired`/`_refreshStatus` cannot be used to flip state mid-settlement.
+5. **RuleChange full consensus + the parent exclusion.** Reachable for allocated children
+   only because VaultCore excludes the parent position from `snapshotTotal` (GA-1); regression
+   `test_childRuleChangePassesAfterParentAllocates`.
+
+## Accepted risks that live here (do not re-report)
+
+- **K-2/CM-8:** one permanently-offline member freezes RuleChange forever — intended.
+- **K-3/VO-2/VO-3:** standing defaults can dominate *direction* once ≥25% live stake clears
+  quorum; 72h expiry can leave a vault voiceless — intended liveness floor.
+- **GA-2/VO-7:** the running tally is publicly readable mid-reveal (public `proposals` getter
+  + cleartext `Revealed` events). Commit-binding on `support` prevents direction change; the
+  originally-specified "tally view gating" was deliberately not built.
+- **VO-6:** a large holder abstaining can deny stake quorum with their own absent weight —
+  the inherent participation requirement, not a griefing primitive.
+- Proposer holding the payload preimage can let a passed proposal expire unexecuted
+  (releasing Mode-F exits at then-current NAV) — execution-layer optionality bounded by EE-10.

--- a/docs/audit/walkthroughs/OperatorRegistry.md
+++ b/docs/audit/walkthroughs/OperatorRegistry.md
@@ -1,0 +1,75 @@
+# Walkthrough — OperatorRegistry.sol
+
+**Risk: High.** ~150 LoC. `contracts/src/OperatorRegistry.sol`.
+
+## Purpose
+
+The C-3 load-bearing reference: operator identity, the cross-vault (member, operator) USDC
+loss carryforward (the portable HWM), and the monotone aggregate leaderboard. Three
+requirements meet here:
+
+1. **HWM portability (§7):** a member who realized a loss under operator X in vault A pays no
+   performance fee under X in vault B until made whole.
+2. **Leaderboard integrity (SF-4/SF-5):** lifetime gain/loss/fee accumulators per operator,
+   monotone — nothing ever decrements or restates, so closed-vault history is permanent and
+   cherry-picking is impossible.
+3. **Anti-Sybil (CM-4):** identity is the registry id. A fresh identity sheds its loss carry
+   but restarts at zero track record — visible and reputation-costly by construction (the
+   enforcement is reputational, an accepted residual).
+
+## Trust position
+
+Carry and stats mutate **only through attested vaults**, and attestation flows **only from
+the canonical factory** (CM-5). `wire(factory, feeEngine)` is one-shot deploy-time
+configuration by the deployer, permanently locked after (`AlreadyWired`) — not an admin power.
+Like the FeeEngine, this contract is treated as potentially faulty on the exit path: VaultCore
+calls `recordRealization` bounded and non-blocking (a failing registry loses the mark,
+event-logged, never the member's exit).
+
+## State
+
+- Identity: `operatorIdOf` / `operatorAddressOf` (ids from 1; 0 = unregistered),
+  `operatorCount`.
+- Attestation: `_vaultOperator[vault] → opId` (0 = unattested).
+- Marks: `carryOf[member][opId]` — USDC loss carryforward.
+- Stats: `statsOf[opId]` = lifetime gain / loss / fees collected / vault count, all
+  write-once-additive.
+
+## External entry points
+
+| Function | Caller | Notes |
+| --- | --- | --- |
+| `wire(factory, feeEngine)` | deployer, once | Zero-address-guarded (Slither pass) |
+| `registerOperator(operator)` | anyone | Mints a fresh id for a not-yet-registered address only (`AlreadyOperator`). Grants no authority — harmless permissionless (verified in S6 review) |
+| `attestVault(vault, operator)` | **factory only** | Auto-registers the operator if needed; increments `vaultCount` |
+| `recordRealization(member, gain, loss)` | **attested vaults only** | Loss builds carry (+= loss); gain consumes it (saturating to 0). Called AFTER the FeeEngine read the pre-update carry (order fixed in `_settleExit`) |
+| `recordFeeCollected(opId, amount)` | **feeEngine only** | Stats-only |
+| `operatorOf`, `leaderboardEntry`, `carryOf`, … | views | Ranking/weighting is an indexer concern (S7) |
+
+## Invariants (fuzz-tested)
+
+- `carryOf` matches an independent ghost model across arbitrary gain/loss sequences
+  (`invariant_carryMatchesGhost`).
+- All `OperatorStats` fields are monotone non-decreasing (`invariant_lifetimeMonotone`);
+  regression `test_statsAreMonotone_closedVaultHistoryRetained`.
+- Carry is strictly per-(member, opId): a fresh identity gets no offset
+  (`test_carryIsPerOperator_freshIdentityGetsNoOffset`).
+
+## Review focus
+
+1. **Attestation authorization chain:** factory → `attestVault` → `_vaultOperator`. Can a
+   non-factory path ever set `_vaultOperator`? Can an operator front-run `registerOperator`
+   to grab someone's address? (Ids bind to `msg.sender`-independent addresses; rebinding is
+   impossible — but confirm the auto-register-inside-attest path.)
+2. **Carry ordering within a settlement:** `recordRealization` runs after `onRealize` reads
+   carry; both are best-effort bounded calls (G5 — see FeeEngine walkthrough).
+3. **Same-block cross-vault interleavings** of two attested vaults mutating one
+   (member, opId) carry.
+
+## Accepted risks here (do not re-report)
+
+- **CM-4 residual:** identity reset escapes carry; reputation (zero track record) is the
+  enforcement, not funds.
+- **G3/CM-5:** carry farming economics (see FeeEngine walkthrough).
+- **SF-4 residual:** reputation systems are gameable at the margin; the leaderboard shows
+  TVL- and member-weighted views off-chain to bound dust-vault inflation.

--- a/docs/audit/walkthroughs/OracleAggregator.md
+++ b/docs/audit/walkthroughs/OracleAggregator.md
@@ -1,0 +1,81 @@
+# Walkthrough — OracleAggregator.sol
+
+**Risk: Critical (prices everything).** ~140 LoC. `contracts/src/OracleAggregator.sol`.
+
+## Purpose
+
+Multi-source median price oracle with a staleness circuit breaker (SF-1/SF-2). Per-vault, not
+a singleton: each vault creator deploys (or reuses) an aggregator and binds it immutably at
+`createVault`. Members inspect the source set before depositing — that inspection is the trust
+model, which is why the constructor floors are load-bearing.
+
+Also in this file: `ChainlinkSourceAdapter`, a thin `IPriceSource` wrapper normalizing an
+AggregatorV3 feed to WAD (one mechanism class among several; SF-1 requires mechanism-diverse
+sources for real independence).
+
+## Config (immutable after construction)
+
+Per asset: `sources[]`, `maxStaleness`, `quorum`. Constructor enforces (all S6 Finding 2/6
+fixes):
+
+- `3 ≤ sources.length ≤ 15` (`MIN_SOURCES = 3`, matches ARCHITECTURE §11)
+- `quorum > m/2` and `≤ m` — **strict majority** freshness quorum, so no single source can
+  freeze or move an asset
+- `0 < maxStaleness ≤ 1 days` (`MAX_STALENESS_CEILING`) — kills the unbounded-staleness
+  underflow honeypot AND bounds the EE-5 latency-arb drift window
+- no duplicate asset entries
+
+No setters exist. A creator wanting different sources deploys a different aggregator.
+
+## `priceWad(asset)` — the whole algorithm
+
+1. Unlisted asset → revert `StaleOracle` (breaker, not zero — an unpriceable asset must fail
+   safe, never value at 0).
+2. `minUpdated = saturating(block.timestamp − maxStaleness)` — cannot underflow-panic even in
+   pathological clock states (S6 Finding 2 defense-in-depth alongside the ceiling).
+3. Poll every source under `try/catch`: a reverting source is simply *not fresh* — one broken
+   feed must not trip the breaker while quorum holds elsewhere. Accept `p > 0 && updatedAt ≥
+   minUpdated`.
+4. `k < quorum` → revert `StaleOracle` (the breaker).
+5. Insertion-sort the fresh set (m ≤ 15) and return the **lower median** `fresh[(k−1)/2]` —
+   no even-k averaging, hence no single-outlier half-deviation swing and no checked-add
+   overflow freeze (S6 Finding 6).
+
+## Breaker semantics (K-4 — the deliberate design decision)
+
+When quorum fails, `priceWad` reverts, which reverts **every NAV-reading path in consuming
+vaults: deposits, exits, rebalance-adjacent views**. There is intentionally no escape hatch —
+any exit during staleness is exactly the stale-price exit the breaker exists to prevent.
+Mitigation is source count + independence + the 1-day ceiling, not a hatch. The one deliberate
+softening lives in VaultCore: `cancelPending` reads no oracle, so observation-window capital
+is never trapped.
+
+## Invariants / properties (fuzz-tested)
+
+- Result is always an element of the fresh set (no synthetic averages) and lies within
+  [min, max] of fresh values (`testFuzz_lowerMedianOfFive`, `testFuzz_medianWithinRange`).
+- A minority of adversarial sources (< quorum, at any extreme values) cannot move the median
+  outside the honest range (`testFuzz_minorityOutliersCannotMoveMedian`).
+- Below-quorum freshness always reverts `StaleOracle` (`testFuzz_belowQuorumTripsBreaker`).
+
+## Review focus
+
+1. **Freshness edge cases:** sources reporting `updatedAt` in the future; `p > 0` filtering vs.
+   the ChainlinkSourceAdapter's `answer <= 0 → (0, 0)` convention (adapter output is treated
+   as not-fresh, by design).
+2. **Median parity at even k:** the lower median biases *down* when k is even — check no
+   consuming path becomes exploitable from a systematically half-step-low price (direction
+   favors under-valuing the basket: mints fewer shares, pays exiters less — conservative for
+   remainers, and symmetric for entry/exit).
+3. **Source-set quality is out of code's reach:** correlated upstreams (same aggregator API
+   behind two adapters) defeat the independence assumption — a listing-criterion problem
+   (SF-1), not detectable on-chain. Confirm nothing in the code *claims* otherwise.
+4. `ChainlinkSourceAdapter`: decimals ≤ 18 enforced; no `answeredInRound`/round-completeness
+   checks — staleness is delegated to the aggregator's `updatedAt` bound. Worth a look.
+
+## Accepted risks here (do not re-report)
+
+- **K-4/SF-2:** induced staleness traps active capital; honest staleness in a crash locks
+  members into a falling basket. Accepted with eyes open; no hatch will be added.
+- **SF-1 residual:** compromise of a strict majority of sources moves the median — the bound
+  is the config floor, source independence is a listing criterion.

--- a/docs/audit/walkthroughs/SubVaultRegistry.md
+++ b/docs/audit/walkthroughs/SubVaultRegistry.md
@@ -1,0 +1,56 @@
+# Walkthrough — SubVaultRegistry.sol
+
+**Risk: Medium.** ~95 LoC. `contracts/src/SubVaultRegistry.sol`.
+
+## Purpose
+
+The structural truth about parent/child vault relationships (SV-1..SV-7): who is whose child,
+how deep the tree goes, and whether the cumulative fee stack stays under the protocol
+ceiling. Consumed by three parties: VaultCore (`parentOf` for edge-checked allocation and the
+parent-voting exclusion), Governance (`parentOf` for SV-6 quorum-floor inheritance), and the
+factory (the only writer).
+
+## The one structural guarantee everything else leans on
+
+**Edges are creation-time only.** A vault becomes a child exactly once, at factory deployment
+(`createChildVault` → `registerChild`), and `registerChild` requires the child to be
+previously unknown (`parentOf == 0 && depthOf == 0`). A pre-existing vault can never be
+re-registered as someone's child. Consequences:
+
+- **Cycles are impossible by construction** (SV-3): a cycle would require an existing vault
+  to acquire a parent, which no code path allows. There is no cycle-detection walk because
+  none is needed.
+- Vault-to-vault deposits flow only along registered parent→child edges — VaultCore's
+  `allocateToChild` checks `parentOf(child) == address(this)`.
+- `depthOf[child] = depthOf[parent] + 1`, required `< MAX_DEPTH = 3` — so depths 0/1/2, three
+  levels including root (SV-2: depth derives from the recorded chain, not operator identity).
+
+## State & entry points
+
+| Item | Notes |
+| --- | --- |
+| `wire(factory)` | One-shot deployer wiring; zero-guarded; locked after (`AlreadyWired`) |
+| `registerChild(parent, child, childExitFeeMaxBps)` | **Factory-only.** Depth check + SV-4 stack check: Σ exit-fee ceilings over the whole ancestor chain (child included) ≤ `STACKED_EXIT_FEE_CAP_BPS = 250` (2.5%) |
+| `parentOf` / `depthOf` | The edge data |
+| `stackedPerfFeeBps(vault)` | Display view (SV-4): `1 − (1−10%)^levels` in bps — bounded by the depth cap |
+| `stackedExitFeeCapBps(vault)` | Display view: Σ ancestor exit-fee ceilings |
+
+## Review focus
+
+1. **Depth/stack arithmetic at the boundaries:** parent at depth 2 must be rejected
+   (`parentDepth + 1 < 3`); the ancestor-chain walk in the stack check terminates because
+   depth ≤ 2 (`test_depthCapAtThreeLevels`, `test_exitFeeStackCapEnforced`).
+2. **The stack cap uses exit-fee *ceilings*** (`exitFeeMaxBps`), which are immutable per
+   vault — so the cap cannot be evaded by post-registration fee changes (there are none).
+   The SV-4 threat-model row's "child changes fees after allocation" concern is structurally
+   moot in v1 for exit fees; perf fee is protocol-fixed at 10% per level.
+3. **`registerChild` calls `IVaultFees(parent).exitFeeMaxBps()`** on an arbitrary `parent`
+   address supplied by the factory — the factory only passes real vaults, and only the
+   factory may call. Confirm no other caller can reach it post-wiring.
+
+## Accepted risks here (do not re-report)
+
+- **SV-1:** mandate enforcement between parent and child is governance, not code — the parent
+  is a (non-voting) member of the child; code cannot read mandates.
+- The registry records structure only; economic consequences of the structure (E4/E5 exit
+  residuals, look-through pricing) live in VaultCore and are documented there.

--- a/docs/audit/walkthroughs/VaultCore.md
+++ b/docs/audit/walkthroughs/VaultCore.md
@@ -1,0 +1,166 @@
+# Walkthrough — VaultCore.sol
+
+**Risk: Critical (holds all funds).** ~850 LoC. `contracts/src/VaultCore.sol`.
+
+## Purpose
+
+The vault itself: share accounting, NAV, deposits with a 4-hour observation window, two-mode
+redemption settlement, in-kind payout with per-asset escrow isolation, tenure-decaying exit
+fee, creator 5% withdrawal gate, capacity cap, governance-driven rebalance execution,
+sub-vault allocation/redemption with recursive look-through pricing, and the voting-stake
+checkpoints Governance reads. Everything else in the system exists to authorize, price, or
+account for what this contract does.
+
+Not ERC-4626 (C-1): in-kind redemption and forward pricing break preview round-trips. The
+4626-shaped views (`totalAssets`, `convertToShares`, `convertToAssets`) are indicative only.
+
+## Construction and immutables
+
+Everything trust-relevant is fixed at the constructor and visible before anyone deposits:
+`usdc` (+ `usdcScalar` from a runtime decimals read, ≤18 enforced), `creator`, the four module
+references (`operatorRegistry`, `governance`, `feeEngine`, `oracle`), `capacityCapUsdc`
+(0 = uncapped, SF-3 is opt-in), `minDepositUsdc` (>0), `exitFeeMaxBps` (≤100 = 1% protocol
+cap), `exitFeeDecayPeriod`, the adapter allowlist (EX-1), the basket (≤ `MAX_BASKET_ASSETS`
+= 10, no zero/duplicate/USDC entries, per-asset decimals ≤18), and `subVaultRegistry`
+(0 disables child flows). There are no setters for any of these.
+
+## State (grouped)
+
+| Group | Variables | Notes |
+| --- | --- | --- |
+| Accounting | `idleUsdc`, `assetBalance[asset]`, `basketAssets`, `assetUnit[asset]` | **Internal accounting only — NAV never reads `balanceOf`** (EE-1 donation defense). `assetUnit != 0 ⇔ in basket` |
+| Shares | `totalShares`, `sharesOf`, `costBasisUsdc`, `lastDepositTime`, `nonCreatorMemberCount`, `holderCount` | WAD-scaled shares; cost basis feeds realized-P&L; `lastDepositTime` is the tenure clock (resets on every deposit) |
+| Observation window | `pendingDeposit[member]`, `totalPendingUsdc`, `windowCleared`, `skipOptIn` | Pending capital is escrowed: excluded from NAV **and** `idleUsdc`, zero shares, zero voting rights |
+| Mode-F queue | `queuedExitShares[member]`, `totalQueuedShares` | Queued shares stay outstanding (earn/lose with the vault) but are locked: non-votable, irrevocable |
+| Snapshots | `_eligibleHist`, `_totalEligibleHist`, `_holderCountHist` (Checkpoints) | Written by `_snapshot` after **every** share/queue mutation; Governance reads them at `createdAt − 1` (VO-9) |
+| Sub-vaults | `childVaults` (≤ `MAX_CHILDREN` = 8), `isChildVault`, `_cachedParentVault` | Children added only on first governance allocation along a registry edge |
+| Escrow | `claimable[member][asset]` | EE-6: failed in-kind transfers park here; `claimEscrowed` pays out later |
+| Reentrancy | `_lock` | Single mutex shared by every state-mutating external function |
+
+## External entry points
+
+**Member / permissionless:**
+
+| Function | Guard | What it does |
+| --- | --- | --- |
+| `deposit(amount)` | nonReentrant | First-ever deposit → pending escrow (4h window); repeat/window-cleared → immediate mint at current NAV. Receipt measured by balance delta, capacity checked against NAV + pending + amount |
+| `activate(member)` | nonReentrant, anyone | Mints a matured pending deposit at **activation-time** NAV (forward pricing on entry) |
+| `cancelPending()` | nonReentrant | Refunds an un-activated pending deposit. **Reads no oracle** — always works during a breaker freeze |
+| `skipWindow()` | nonReentrant | Irrevocable per-agent opt-out of the window; activates any pending immediately |
+| `requestExit(shares)` | nonReentrant | Mode I (no pending execution): settles instantly. Mode F: checks creator gate, queues, de-eligibles the shares |
+| `settleQueuedExit(member)` | nonReentrant, anyone | Settles a queued exit once no execution is pending, at then-current NAV |
+| `claimEscrowed(asset)` | nonReentrant | Pays out an EE-6-escrowed slice |
+| `pullChildEscrow(child, asset)` | nonReentrant, anyone | Crank: claims a slice a child escrowed for this vault and credits internal accounting |
+
+**Governance-only** (`msg.sender == address(governance)`):
+
+| Function | What it does |
+| --- | --- |
+| `executeRebalance(adapter, orders)` | Allowlisted adapter; per-leg: debit input accounting → approve → swap → measure output delta ≥ minOut → revoke approval → credit output → refund unspent input from **this swap's own delta** (S6 E3 fix) |
+| `allocateToChild(child, amount)` | Only along registered registry edges (SV-3); first allocation registers the child locally and calls `child.skipWindow()` |
+| `redeemFromChild(child, shares)` | Redeems child shares, credits measured deltas to internal accounting; reverts `ChildSettlementPending` if the child queues (Mode F) |
+
+**Views** worth knowing: `navWad`, `navPerShareWad`, `parentVault`,
+`votingEligibleShares` / `totalVotingEligibleShares` (+ `past*` checkpoint reads,
+`pastHolderCount`), `exitFeeBpsOf`, `isCapped`, and the indicative 4626-shaped trio.
+
+## Invariants (all fuzz/invariant-tested — see TEST-CROSS-REFERENCE)
+
+1. **Share conservation:** Σ `sharesOf` == `totalShares` (single-vault and system-level).
+2. **§4.6 NAVps non-decreasing for remaining members across any redemption.** Every payout
+   component rounds *down* with `keepBps ≤ BPS`, so the exiter never takes more than exact
+   pro-rata; the fee fraction stays in the vault. Proven with and without children.
+3. **Solvency:** physical USDC ≥ `idleUsdc` + `totalPendingUsdc`, under adversarial donation.
+4. **Queue consistency:** Σ `queuedExitShares` == `totalQueuedShares`; eligible = supply −
+   queued (− parent position).
+5. **Pending escrow excluded from NAV**; a pending deposit and live shares never coexist
+   (`shares > 0 ⇒ windowCleared`).
+6. **Creator floor:** while non-creator members remain, creator redemptions cannot take the
+   creator below 5% of post-burn supply.
+7. **Rounding is always against the actor:** mint rounds shares down, payouts round down, the
+   fee fraction rounds down in the member's favor only where under-collection is the safe
+   direction (dust accrues to the vault).
+
+## The trickiest paths (where to spend review time)
+
+### 1. `_settleExit` — two-mode exit / forward pricing (C-4, VO-8 × K-1)
+
+Shares burn at settlement, never at request. Mode selection is `_pendingExecution()`: a
+**bounded, non-reverting** staticcall to `governance.hasPendingExecution` — on any failure the
+fallback is Mode I (a broken governance forfeits forward pricing, never member liveness; H-1).
+`hasPendingExecution` turns true at *reveal start* (outcome starts leaking on-chain), false on
+Defeated/Executed/expiry, so queued exits always settle eventually (EE-10).
+
+`_settleExit` structure (CEI: two passes):
+
+- **Pass 1 — internal accounting only.** Exit fee bps (tenure decay; waived for sole holder);
+  cash target = exiter's share of (idle + total child value) × keepBps; `usdcPay` capped at
+  idle; shortfall computed. Shares burned, member counts updated, `_snapshot`, cost basis
+  removed pro-rata (rounds down, residual stays with member), per-asset slices deducted from
+  `assetBalance` **before** any external call.
+- **SV-5 shortfall loop.** Children unwound by value only for the cash shortfall: skip a child
+  mid-rebalance (`_childPendingExecution`, S6 E4 — calling in would queue Mode-F and revert
+  deep); redeem measured (`credit=false`); decrement shortfall by what **actually arrived**,
+  never the intended take (S6 E5 — child escrow must not silently underpay the exiter). If the
+  shortfall survives the loop beyond dust: revert `ExitNeedsChildSettlement` (clean rollback,
+  bounded retry — the E4/E5 accepted residuals live here).
+- **Realized P&L.** `gain/loss = payoutValue − basisRemoved`; `feeEngine.onRealize` and
+  `registry.recordRealization` are bounded + non-blocking (failures event-logged); the fee is
+  **clamped to 10% of gain** regardless of what the module returns (hostile-module value bound).
+- **Pass 2 — transfers.** The fee is withheld *uniformly* across cash and in-kind legs via
+  `feeFracWad` (M-2 fix). Every in-kind transfer is assembly `tryTransfer` (gas-capped,
+  returndata-bounded, H-2): failure → `claimable` escrow, never a revert. Fee slices that fail
+  to reach the FeeEngine escrow to the FeeEngine's own claimable entry.
+
+Review pressure points: rounding direction at each `* burnShares / ts * keepBps / BPS` step
+(the `divide-before-multiply` Slither hits are deliberate — see SLITHER-TRIAGE); whether any
+path lets `payoutValueWad` exceed exact pro-rata; the interplay when a queued exit settles
+after supply changed (gate deliberately NOT re-checked, M-1/MO-3).
+
+### 2. Recursive look-through pricing — `navWad` / `_childValueWad` / `_fullNavWad` (SV-7, S6 E1)
+
+A child position is valued as `fullNav(child) × myShares / child.totalShares`, where
+`_fullNavWad` recurses into the child's own children, **depth-bounded by
+`MAX_LOOKTHROUGH_DEPTH = 3`** (the registry caps real nesting at 3; the bound here is the
+backstop). Every level is priced from *internal* accounting through **this vault's own
+oracle** — never child-reported NAVps, never the child's oracle. Child baskets are
+factory-enforced subsets of the parent's, so every descendant asset resolves in the parent's
+`assetUnit`/oracle; an unpriceable asset fails safe via `StaleOracle`. Gas is bounded:
+basket ≤ 10, children ≤ 8, depth ≤ 3, empirically ~237k worst-case (`NavGas.t.sol`).
+
+Review pressure points: can a descendant *misprice* (not just DoS) an ancestor — e.g. via
+`totalShares` manipulation in a child (fair-mint preserves the ratio; dust attacks were
+examined and judged sound in the S6 review) — and whether depth-bound truncation at level 3
+can ever hide real value (registry prevents deeper nesting from existing).
+
+### 3. Creator gate × Mode-F queue (CM-1/CM-2, M-1/MO-3)
+
+The 5% gate is evaluated on creator *action*: at instant settlement, and at **queue time** for
+Mode-F requests. It is deliberately not re-checked when a queued exit settles — re-checking
+would let third-party deposits permanently strand a once-valid queued exit (the original M-1).
+New joiners had on-chain notice of the queue. Passive dilution below 5% only freezes future
+creator withdrawals (CM-2), it is never a solvency condition.
+
+### 4. Snapshots — `_snapshot` and the parent-vault exclusion (VO-9, GA-1)
+
+After every mutation of `sharesOf`/`queuedExitShares`/`holderCount`, `_snapshot` pushes:
+member eligible (0 for the parent vault), total eligible (minus queued minus parent), and
+holder count (minus parent). The parent vault is a contract with no vote path; counting it
+would make child full-consensus RuleChange unreachable and distort quorums (GA-1 fix). The
+parent edge is one-shot, so it is lazily cached (`_cachedParentVault`). Shares are
+non-transferable, so no mutation path can bypass `_snapshot` (exhaustively verified in the
+accepted-rows review, Area 4).
+
+## Accepted risks that live in this contract (do not re-report)
+
+- **K-4/SF-2:** oracle breaker freezes deposits *and* exits. Softening: `cancelPending` reads
+  no oracle, so window capital is never trapped.
+- **E4/E5 residuals:** `ExitNeedsChildSettlement` when the only covering child is
+  mid-rebalance (bounded retry) or persistently escrows to the parent (permanent for that
+  configuration — known EE-6 asymmetry for child-held slices).
+- **E7/EE-5:** repeat-deposit latency arb against stale-but-fresh-enough NAV; threshold is gas
+  within the oracle drift band.
+- **EE-8/EE-9:** last-two-members fee endgame; operator-as-member receives fee pro-rata via
+  shares (routing prohibition is on routing, not identity).
+- **PX-1:** USDC blacklist of the vault freezes the USDC leg.
+- **CM-2:** passive creator dilution freezes creator withdrawals until restored.

--- a/docs/audit/walkthroughs/VaultFactory.md
+++ b/docs/audit/walkthroughs/VaultFactory.md
@@ -1,0 +1,54 @@
+# Walkthrough — VaultFactory.sol
+
+**Risk: Medium.** ~114 LoC. `contracts/src/VaultFactory.sol`.
+
+## Purpose
+
+Permissionless canonical deployment + attestation. The factory is what makes the registry
+trustworthy (CM-5/SF-4/PX-3): only vaults deployed here get attested, so carry marks and
+leaderboard rows can only be produced by real, visible, protocol-shaped vaults. Creation is
+fully permissionless — attestation is automatic and identity-keyed (to `msg.sender` as
+operator), never curated.
+
+## What it fixes at deployment
+
+Every vault it deploys gets the **same immutable protocol singletons** (registry, governance,
+feeEngine, subVaultRegistry — all immutable on the factory itself) plus the **creator's
+choices** from `VaultParams`: usdc, basket, oracle, capacity cap, min deposit, exit-fee
+ceiling + decay, adapter allowlist. `msg.sender` becomes the vault's `creator` (the 5% gate
+binds to this identity) and its attested operator.
+
+## Entry points
+
+| Function | Notes |
+| --- | --- |
+| `createVault(params)` | `_deploy` → `registry.attestVault(vault, msg.sender)` → record in `allVaults` |
+| `createChildVault(params, parent)` | Additionally: **child USDC must equal parent USDC** and **child basket ⊆ parent basket** (`assetUnit != 0` check per asset) — the property that makes in-kind child redemptions always map into parent accounting and look-through pricing always resolvable (SV-7). Then `subVaultRegistry.registerChild(parent, vault, exitFeeMaxBps)` (depth + fee-stack checks live there) + attestation |
+| `vaultCount` / `allVaults` | Enumeration for the indexer |
+
+## Two-step bring-up (documented UX, not a trust gap)
+
+After `createVault`, the creator registers the vault's `GovConfig` with Governance in a
+second transaction (`governance.registerVault`). Until then no proposals can exist and exits
+settle Mode I. Nothing privileged can happen in the gap: the vault is fully functional for
+deposits/exits, and `registerVault` is creator-gated on the vault's own `creator()`.
+
+## Review focus
+
+1. **Attestation-identity binding:** the operator attested is `msg.sender` at creation.
+   A contract creating vaults on behalf of others attests *itself* — fine for the trust model
+   (identity = whoever controls creation), but confirm downstream assumptions (leaderboard,
+   carry) hold for contract operators.
+2. **Child-subset check reads `parent.assetUnit`** — `assetUnit != 0 ⇔ in basket` on
+   VaultCore, and the parent address comes from the caller; a bogus `parent` fails at
+   `registerChild` (factory-only writer, parent must exist for depth/fee reads) — walk that
+   failure ordering.
+3. **No de-attestation exists.** A vault attested is attested forever (SF-5 retention). The
+   factory has no owner, no pause, no list curation.
+
+## Accepted risks here (do not re-report)
+
+- **PX-3:** permissionless creation means scam vaults exist; the registry makes them
+  distinguishable (identity-first surfacing), not impossible.
+- Vaults deployed *outside* the factory can imitate the shape but are never attested — their
+  marks and stats simply don't exist in the canonical registry.


### PR DESCRIPTION
## What this delivers

A complete external-audit package so a firm can start cold — an auditor with zero context reads `docs/audit/README.md` and is productive within an hour.

1. **`docs/audit/README.md`** — reviewer entry point: reading order, one-paragraph system summary, system map, per-contract roles/risk weights, the four trust tiers, immutability posture (no admin-rescue fixes exist), the only valid deploy/wiring order, prior-review summary, known residuals, suggested audit focus, and the findings process.
2. **`docs/audit/walkthroughs/`** — 9 per-contract walkthroughs (VaultCore, Governance, OracleAggregator, FeeEngine, OperatorRegistry, both adapters, SubVaultRegistry, VaultFactory): purpose, state, external entry points, invariants, trickiest paths (two-mode exit / forward pricing, commit-reveal quorum regimes, cross-vault carry HWM, recursive look-through), and the accepted risks that live in each contract.
3. **`docs/audit/FINDINGS-TEMPLATE.md`** — structured findings-response log: severity/status vocabulary, per-entry template (id, severity, status, response, fix-commit, regression test), and a worked example from the internal Sprint 6 round.
4. **NatSpec completeness pass** on all external/public functions in `contracts/src` — missing `@notice`/`@param`/`@return` added. **Comments only: the diff is purely additive comment lines (zero executable-line changes).**
5. **`docs/audit/TEST-CROSS-REFERENCE.md`** — threat-model → test map: every mechanic row to the test(s) covering it, with the honest coverage gaps called out explicitly.

Also refreshed `docs/AUDIT-HANDOFF.md` (stale "100 tests" → 117) and linked the package as the reviewer entry point.

## Verification

- `forge fmt` clean, `forge build` clean
- Full suite green: the 117 pre-existing tests all pass (a concurrently-added `DeployTestnet.t.sol` from another work stream brings the local total to 119, also green; that file is deliberately **not** part of this PR)
- No contract logic changed; no accepted risks (K-1..K-4) restated as bugs; no new findings encountered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2