### PR TITLE
Sprint 3: live runtime — indexer, facilitator, API server, web live mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+node_modules
+contracts
+docs
+data
+**/*.md
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy to `.env` and fill in. Never commit a real .env. Neither process holds a private key.
 
 # ── Chain / indexer ──
-RPC_URL=https://sepolia.base.org          # Base (or Base Sepolia) HTTP RPC endpoint
+RPC_URL=https://base-sepolia-rpc.publicnode.com   # Base (or Base Sepolia) HTTP RPC (sepolia.base.org 503s; publicnode is reliable)
 CHAIN_ID=84532                            # 8453 = Base mainnet, 84532 = Base Sepolia
 CHAIN_NAME=base-sepolia
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# ── Runtime configuration for the indexer + API stack ──
+# Copy to `.env` and fill in. Never commit a real .env. Neither process holds a private key.
+
+# ── Chain / indexer ──
+RPC_URL=https://sepolia.base.org          # Base (or Base Sepolia) HTTP RPC endpoint
+CHAIN_ID=84532                            # 8453 = Base mainnet, 84532 = Base Sepolia
+CHAIN_NAME=base-sepolia
+
+# Deployed singleton addresses (from your DeployTestnet / DeployMainnet run).
+FACTORY_ADDRESS=0x0000000000000000000000000000000000000000
+OPERATOR_REGISTRY_ADDRESS=0x0000000000000000000000000000000000000000
+SUBVAULT_REGISTRY_ADDRESS=0x0000000000000000000000000000000000000000
+GOVERNANCE_ADDRESS=0x0000000000000000000000000000000000000000
+
+START_BLOCK=0                            # block the contracts were deployed at (skip empty history)
+CONFIRMATIONS=5                          # lag behind head for reorg safety
+BATCH_BLOCKS=2000                        # max blocks per getLogs batch
+POLL_INTERVAL_MS=12000                   # ~one Base block
+
+# ── API pricing (x402) ──
+PRICE_ASSET=0x036CbD53842c5426634e7929541eC2318f3dCF7e   # USDC on the chain above
+PRICE_PAYTO=0x0000000000000000000000000000000000000000   # who receives metered-read payments
+PRICE_AMOUNT=10000                       # base units, 6dp — 10000 = $0.01
+PRICE_NETWORK=base-sepolia
+
+# ── API facilitator ──
+FACILITATOR=stub                         # stub = accept-all (DEV ONLY); http = delegate to a real facilitator
+# FACILITATOR_URL=https://facilitator.example/settle   # required when FACILITATOR=http
+
+# ── API server ──
+PORT=8402
+RELOAD_MS=5000                           # how often the API re-reads the snapshot
+CORS=1                                   # 1 to allow the browser live mode (apps/web ?api=)
+STATE_PATH=./data/indexer-state.json     # shared snapshot (compose overrides to /data/...)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Single image for both runtime processes (indexer + API). Pick which to run via the compose
+# service command or a `docker run` override. Both are non-custodial: no keys, no fund movement.
+#
+#   docker build -t vault-runtime .
+#   docker run --env-file .env vault-runtime npm run start:indexer
+#   docker run --env-file .env -p 8402:8402 vault-runtime npm run start:api
+FROM node:24-slim
+
+WORKDIR /app
+
+# Install runtime deps first for layer caching. No lockfile in this repo, so `npm install`
+# (not `npm ci`). --omit=dev pulls only viem (the sole runtime dependency).
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+# App source (contracts/ and other heavy dirs excluded via .dockerignore).
+COPY packages ./packages
+COPY apps ./apps
+
+# Snapshot lives on a mounted volume so indexer (writer) and API (reader) share it.
+ENV STATE_PATH=/data/indexer-state.json
+VOLUME /data
+
+# Default to the API; override the command to run the indexer.
+EXPOSE 8402
+CMD ["npm", "run", "start:api"]

--- a/apps/api/src/facilitator.mjs
+++ b/apps/api/src/facilitator.mjs
@@ -1,0 +1,234 @@
+// @ts-check
+/**
+ * x402 facilitators for the metered API — the component behind x402.mjs's injected
+ * `verifyAndSettle(challenge, envelope)` seam.
+ *
+ * Three implementations, one interface:
+ *   - createStubFacilitator     accept/deny with no chain — tests and local dev.
+ *   - createHttpFacilitator     delegate verify+settle to a REMOTE facilitator over HTTP. This is
+ *                               the API server's production default: the server stays non-custodial
+ *                               (holds no key, moves no funds) and a separate facilitator settles.
+ *   - createSettlingFacilitator run-your-own settler: recover the EIP-712 payer, then settle via
+ *                               USDC.transferWithAuthorization with an OPERATOR-SUPPLIED account.
+ *                               It needs viem + a funded key the operator injects at runtime; this
+ *                               module never embeds, reads, or logs a key.
+ *
+ * Design contract (per x402.mjs): verifyAndSettle's first arg is `{ price }`, NOT the full
+ * challenge — it carries no chainId. So chainId and the USDC name/version/address come from
+ * CONSTRUCTION config, never from the call argument. The non-crypto pieces (shape + typed-data
+ * reconstruction) are pure and unit-tested; viem is a lazy optional dependency loaded only by the
+ * crypto path, so this file imports cleanly with no node_modules.
+ */
+
+const SIG_RE = /^0x[0-9a-fA-F]{130}$/; // 65 bytes: r(32) s(32) v(1)
+const ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Rebuild the EIP-712 typed data for a `transferWithAuthorization` authorization. MUST match the
+ * SDK's builder (packages/agent-sdk/src/eip3009.mjs buildTypedData) field-for-field, or a valid
+ * client signature will fail to recover. The domain's verifyingContract is the USDC address —
+ * taken from config, falling back to the envelope's declared asset only for the pure helper.
+ *
+ * @param {object} envelope  decoded PAYMENT-SIGNATURE envelope ({ authorization, ... })
+ * @param {{chainId:number, usdcName?:string, usdcVersion?:string, usdcAddress?:string}} cfg
+ */
+export function reconstructTypedData(envelope, cfg) {
+  const auth = envelope.authorization ?? {};
+  const verifyingContract = cfg.usdcAddress ?? auth.asset;
+  return {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' },
+      ],
+      TransferWithAuthorization: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'validAfter', type: 'uint256' },
+        { name: 'validBefore', type: 'uint256' },
+        { name: 'nonce', type: 'bytes32' },
+      ],
+    },
+    primaryType: 'TransferWithAuthorization',
+    domain: {
+      name: cfg.usdcName ?? 'USD Coin',
+      version: cfg.usdcVersion ?? '2',
+      chainId: cfg.chainId,
+      verifyingContract,
+    },
+    message: {
+      from: auth.from,
+      to: auth.to,
+      value: auth.value,
+      validAfter: auth.validAfter,
+      validBefore: auth.validBefore,
+      nonce: auth.nonce,
+    },
+  };
+}
+
+/**
+ * Non-crypto structural validation of an envelope before we spend a settlement. Confirms the
+ * authorization is well-formed and the signature is a 65-byte hex string. Cryptographic recovery
+ * and the on-chain nonce check happen in the settling/remote path.
+ * @returns {{ok:true}|{ok:false, reason:string}}
+ */
+export function verifyEnvelopeShape(envelope, nowMs) {
+  if (!envelope || typeof envelope !== 'object') return { ok: false, reason: 'no-envelope' };
+  if (envelope.x402Version !== 2) return { ok: false, reason: 'bad-version' };
+  const a = envelope.authorization;
+  if (!a || typeof a !== 'object') return { ok: false, reason: 'no-authorization' };
+  for (const f of ['from', 'to']) {
+    if (!ADDR_RE.test(a[f] ?? '')) return { ok: false, reason: `bad-${f}` };
+  }
+  if (typeof envelope.signature !== 'string' || !SIG_RE.test(envelope.signature))
+    return { ok: false, reason: 'bad-signature-format' };
+  let value;
+  try { value = BigInt(a.value ?? ''); } catch { return { ok: false, reason: 'bad-value' }; }
+  if (value <= 0n) return { ok: false, reason: 'nonpositive-value' };
+  if (!/^0x[0-9a-fA-F]{64}$/.test(a.nonce ?? '')) return { ok: false, reason: 'bad-nonce' };
+  const validBefore = Number(a.validBefore ?? 0) * 1000;
+  if (validBefore && validBefore < nowMs) return { ok: false, reason: 'authorization-expired' };
+  return { ok: true };
+}
+
+/**
+ * Recover the EIP-712 signer of an authorization and confirm it equals `authorization.from`.
+ * Uses viem (lazy). Returns { ok, payer } — payer lowercased.
+ * @param {object} envelope
+ * @param {{chainId:number, usdcName?:string, usdcVersion?:string, usdcAddress?:string}} cfg
+ */
+export async function recoverPayer(envelope, cfg) {
+  const { recoverTypedDataAddress } = await import('viem').catch(() => {
+    throw new Error('facilitator: viem is not installed — run `npm install viem`');
+  });
+  const td = reconstructTypedData(envelope, cfg);
+  const recovered = await recoverTypedDataAddress({
+    domain: td.domain,
+    types: { TransferWithAuthorization: td.types.TransferWithAuthorization },
+    primaryType: 'TransferWithAuthorization',
+    message: td.message,
+    signature: envelope.signature,
+  });
+  const from = (envelope.authorization?.from ?? '').toLowerCase();
+  const payer = recovered.toLowerCase();
+  return payer === from ? { ok: true, payer } : { ok: false, reason: 'signer-mismatch', payer };
+}
+
+/** Accept/deny facilitator for tests and local dev — no chain, no crypto. */
+export function createStubFacilitator({ accept = true, receiptPrefix = 'stub' } = {}) {
+  let n = 0;
+  return {
+    async verifyAndSettle(_challenge, envelope) {
+      if (!accept) return { ok: false, reason: 'stub-deny' };
+      const nonce = envelope?.authorization?.nonce ?? '';
+      return { ok: true, receiptId: `${receiptPrefix}_${++n}_${nonce.slice(0, 10)}` };
+    },
+  };
+}
+
+/**
+ * Production default: delegate verify+settle to a REMOTE facilitator over HTTP. The API server
+ * holds no key; this posts the challenge+envelope and returns the remote verdict. Non-custodial.
+ * @param {{url:string, fetchImpl?:typeof fetch, timeoutMs?:number}} cfg
+ */
+export function createHttpFacilitator({ url, fetchImpl = fetch, timeoutMs = 10_000 }) {
+  return {
+    async verifyAndSettle(challenge, envelope) {
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), timeoutMs);
+      try {
+        const res = await fetchImpl(url, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ x402Version: 2, challenge, envelope }),
+          signal: ctrl.signal,
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) return { ok: false, reason: body.reason ?? `facilitator-http-${res.status}` };
+        return { ok: !!body.ok, receiptId: body.receiptId, reason: body.reason };
+      } catch (err) {
+        return { ok: false, reason: `facilitator-unreachable: ${err?.message ?? err}` };
+      } finally {
+        clearTimeout(t);
+      }
+    },
+  };
+}
+
+// Minimal USDC ABI: the (v,r,s) transferWithAuthorization overload (FiatTokenV2, universally
+// supported) plus authorizationState for a pre-flight replay check.
+const USDC_ABI = [
+  {
+    type: 'function', name: 'transferWithAuthorization', stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'from', type: 'address' }, { name: 'to', type: 'address' }, { name: 'value', type: 'uint256' },
+      { name: 'validAfter', type: 'uint256' }, { name: 'validBefore', type: 'uint256' }, { name: 'nonce', type: 'bytes32' },
+      { name: 'v', type: 'uint8' }, { name: 'r', type: 'bytes32' }, { name: 's', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function', name: 'authorizationState', stateMutability: 'view',
+    inputs: [{ name: 'authorizer', type: 'address' }, { name: 'nonce', type: 'bytes32' }],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+];
+
+/**
+ * Run-your-own settling facilitator: recover the payer, then settle the EIP-3009 authorization by
+ * calling USDC.transferWithAuthorization. The `account` (a viem account with signing capability)
+ * is supplied by the OPERATOR at runtime — this code never creates or persists a key. Not wired
+ * into the API server by default; see docs/RUNTIME.md for running it as a separate process.
+ *
+ * @param {Object} cfg
+ * @param {any} cfg.publicClient    viem PublicClient (reads / simulate)
+ * @param {any} cfg.walletClient    viem WalletClient (sends the settlement tx)
+ * @param {string} cfg.usdcAddress
+ * @param {number} cfg.chainId
+ * @param {string} [cfg.usdcName]   USDC EIP-712 domain name (default 'USD Coin')
+ * @param {string} [cfg.usdcVersion]
+ * @param {() => number} [cfg.now]
+ */
+export function createSettlingFacilitator({ publicClient, walletClient, usdcAddress, chainId, usdcName, usdcVersion, now = () => Date.now() }) {
+  if (!ADDR_RE.test(usdcAddress ?? '')) throw new Error('settling facilitator: usdcAddress required');
+  const domainCfg = { chainId, usdcName, usdcVersion, usdcAddress };
+
+  return {
+    async verifyAndSettle(_challenge, envelope) {
+      const shape = verifyEnvelopeShape(envelope, now());
+      if (!shape.ok) return { ok: false, reason: shape.reason };
+
+      const rec = await recoverPayer(envelope, domainCfg).catch((e) => ({ ok: false, reason: String(e?.message ?? e) }));
+      if (!rec.ok) return { ok: false, reason: rec.reason };
+
+      const a = envelope.authorization;
+      const sig = envelope.signature;
+      const r = `0x${sig.slice(2, 66)}`;
+      const s = `0x${sig.slice(66, 130)}`;
+      let v = parseInt(sig.slice(130, 132), 16);
+      if (v < 27) v += 27; // normalize recovery id
+
+      try {
+        // Pre-flight: reject an already-used authorization nonce before spending gas.
+        const used = await publicClient.readContract({
+          address: usdcAddress, abi: USDC_ABI, functionName: 'authorizationState', args: [a.from, a.nonce],
+        });
+        if (used) return { ok: false, reason: 'authorization-used' };
+
+        const { request } = await publicClient.simulateContract({
+          address: usdcAddress, abi: USDC_ABI, functionName: 'transferWithAuthorization',
+          args: [a.from, a.to, BigInt(a.value), BigInt(a.validAfter), BigInt(a.validBefore), a.nonce, v, r, s],
+          account: walletClient.account,
+        });
+        const hash = await walletClient.writeContract(request);
+        return { ok: true, receiptId: hash };
+      } catch (err) {
+        return { ok: false, reason: `settle-failed: ${err?.shortMessage ?? err?.message ?? err}` };
+      }
+    },
+  };
+}

--- a/apps/api/src/serve.mjs
+++ b/apps/api/src/serve.mjs
@@ -1,0 +1,112 @@
+// @ts-check
+/**
+ * Runnable API server entrypoint. Serves the x402-metered read API over the indexer's snapshot.
+ * Env-driven and NON-CUSTODIAL: it holds no key and settles nothing itself — payment verification
+ * and settlement are delegated to a facilitator (a remote HTTP facilitator in production; an
+ * accept-all stub for local dev). It shares state with the indexer through the snapshot file: it
+ * loads the snapshot on boot and reloads it periodically, so indexer and API run as separate
+ * processes.
+ *
+ * Required env:
+ *   PRICE_ASSET     USDC contract address (what payments are denominated in)
+ *   PRICE_PAYTO     recipient address for metered-read payments
+ * Optional env:
+ *   STATE_PATH (./data/indexer-state.json)  PORT (8402)  RELOAD_MS (5000)
+ *   PRICE_AMOUNT (10000 = $0.01)  PRICE_NETWORK (base)
+ *   FACILITATOR (stub | http)   FACILITATOR_URL (required when FACILITATOR=http)
+ *   CORS (1 to enable — needed for the browser live mode)
+ *
+ * Run: `PRICE_ASSET=… PRICE_PAYTO=… node apps/api/src/serve.mjs`
+ */
+
+import { fileURLToPath } from 'node:url';
+import { createApi } from './server.mjs';
+import { createHttpFacilitator, createStubFacilitator } from './facilitator.mjs';
+import { loadSnapshot } from '../../../packages/indexer/src/store.mjs';
+
+/**
+ * Parse + validate the API config from a raw env object. Pure and testable.
+ * @param {Record<string,string|undefined>} env
+ */
+export function resolveApiConfig(env) {
+  const isAddr = (a) => /^0x[0-9a-fA-F]{40}$/.test(a ?? '');
+  const missing = ['PRICE_ASSET', 'PRICE_PAYTO'].filter((k) => !env[k]);
+  if (missing.length) throw new Error(`api: missing required env: ${missing.join(', ')}`);
+  if (!isAddr(env.PRICE_ASSET)) throw new Error(`api: PRICE_ASSET is not an address: ${env.PRICE_ASSET}`);
+  if (!isAddr(env.PRICE_PAYTO)) throw new Error(`api: PRICE_PAYTO is not an address: ${env.PRICE_PAYTO}`);
+
+  const facilitator = (env.FACILITATOR || 'stub').toLowerCase();
+  if (facilitator !== 'stub' && facilitator !== 'http')
+    throw new Error(`api: FACILITATOR must be 'stub' or 'http', got '${facilitator}'`);
+  if (facilitator === 'http' && !env.FACILITATOR_URL)
+    throw new Error('api: FACILITATOR=http requires FACILITATOR_URL');
+
+  const num = (k, d) => (env[k] != null && env[k] !== '' ? Number(env[k]) : d);
+  return {
+    statePath: env.STATE_PATH || './data/indexer-state.json',
+    port: num('PORT', 8402),
+    reloadMs: num('RELOAD_MS', 5000),
+    cors: env.CORS === '1' || env.CORS === 'true',
+    price: {
+      asset: env.PRICE_ASSET,
+      amount: env.PRICE_AMOUNT || '10000',
+      payTo: env.PRICE_PAYTO,
+      network: env.PRICE_NETWORK || 'base',
+    },
+    facilitatorKind: facilitator,
+    facilitatorUrl: env.FACILITATOR_URL,
+  };
+}
+
+/** Build the facilitator a config asks for. */
+export function facilitatorFromConfig(cfg, { fetchImpl } = {}) {
+  return cfg.facilitatorKind === 'http'
+    ? createHttpFacilitator({ url: cfg.facilitatorUrl, fetchImpl })
+    : createStubFacilitator();
+}
+
+/**
+ * Build the API server from config. Loads the initial snapshot and exposes a `reload()` that
+ * refreshes state IN PLACE (so createApi's closure stays valid) — fault-tolerant: a malformed or
+ * version-mismatched snapshot is logged and the previous good state is kept serving.
+ * @param {ReturnType<typeof resolveApiConfig>} cfg
+ * @param {{facilitator?:object, log?:(m:string)=>void}} [opts]
+ */
+export async function buildApiServer(cfg, { facilitator, log = console.log } = {}) {
+  const state = await loadSnapshot(cfg.statePath);
+  const fac = facilitator ?? facilitatorFromConfig(cfg);
+  const api = createApi({ state, facilitator: fac, price: cfg.price, cors: cfg.cors });
+
+  async function reload() {
+    try {
+      const fresh = await loadSnapshot(cfg.statePath);
+      // Replace the Map/scalar fields on the SAME object the API closes over.
+      Object.assign(state, fresh);
+      return true;
+    } catch (err) {
+      log(`api: snapshot reload failed, keeping stale state at block ${state.lastBlock}: ${err?.message ?? err}`);
+      return false;
+    }
+  }
+
+  return { api, state, reload };
+}
+
+// ── entrypoint ──
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const cfg = resolveApiConfig(process.env);
+  buildApiServer(cfg).then(({ api, state, reload }) => {
+    if (cfg.facilitatorKind === 'stub') {
+      console.warn('⚠ api: FACILITATOR=stub — payments are ACCEPTED WITHOUT on-chain settlement (dev only). Set FACILITATOR=http + FACILITATOR_URL for production.');
+    }
+    const timer = setInterval(reload, cfg.reloadMs);
+    if (typeof timer.unref === 'function') timer.unref();
+    api.server.listen(cfg.port, () => {
+      console.log(`api: listening on :${cfg.port} — snapshot ${cfg.statePath} (block ${state.lastBlock}), reload ${cfg.reloadMs}ms, facilitator ${cfg.facilitatorKind}${cfg.cors ? ', cors on' : ''}`);
+    });
+  }).catch((err) => {
+    console.error(err?.message ?? err);
+    process.exit(1);
+  });
+}

--- a/apps/api/src/server.mjs
+++ b/apps/api/src/server.mjs
@@ -24,8 +24,9 @@ function jsonStringify(obj) {
  * @param {import('./x402.mjs').Facilitator} deps.facilitator
  * @param {import('./x402.mjs').PriceSpec} deps.price
  * @param {() => number} [deps.now]
+ * @param {boolean} [deps.cors]  emit permissive CORS headers + answer preflight (browser live mode)
  */
-export function createApi({ state, facilitator, price, now = () => Date.now() }) {
+export function createApi({ state, facilitator, price, now = () => Date.now(), cors = false }) {
   const seenNonces = new Set();
 
   /** @returns {Promise<{status:number, headers:Record<string,string>, body:string}>} */
@@ -71,12 +72,13 @@ export function createApi({ state, facilitator, price, now = () => Date.now() })
 
     const mp = path.match(/^\/vaults\/(0x[0-9a-fA-F]{40})\/members\/(0x[0-9a-fA-F]{40})$/);
     if (mp) {
-      return { status: 200, headers: paidHeaders, body: jsonStringify(memberPosition(state, mp[1], mp[2])) };
+      // Projection keys are canonical lowercase (see chain.normalizeLog); match the lookup.
+      return { status: 200, headers: paidHeaders, body: jsonStringify(memberPosition(state, mp[1].toLowerCase(), mp[2].toLowerCase())) };
     }
 
     const m = path.match(/^\/vaults\/(0x[0-9a-fA-F]{40})$/);
     if (m) {
-      const v = vaultView(state, m[1]);
+      const v = vaultView(state, m[1].toLowerCase());
       if (!v) return { status: 404, headers: paidHeaders, body: jsonStringify({ error: 'unknown vault' }) };
       return { status: 200, headers: paidHeaders, body: jsonStringify(v) };
     }
@@ -84,14 +86,35 @@ export function createApi({ state, facilitator, price, now = () => Date.now() })
     return { status: 404, headers: paidHeaders, body: jsonStringify({ error: 'not found' }) };
   }
 
+  // CORS is required for the browser live mode (apps/web ?api=…): a cross-origin fetch cannot see
+  // the payment-required/response headers without Expose-Headers, and the paid retry's custom
+  // payment-signature header triggers a preflight OPTIONS that must be answered before the method
+  // check. Off by default so existing same-process tests are unaffected.
+  const corsHeaders = cors
+    ? {
+        'access-control-allow-origin': '*',
+        'access-control-expose-headers': `${HEADERS.REQUIRED}, ${HEADERS.RESPONSE}`,
+      }
+    : {};
+
   const server = createServer((req, res) => {
+    if (cors && req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        ...corsHeaders,
+        'access-control-allow-methods': 'GET, OPTIONS',
+        'access-control-allow-headers': `${HEADERS.SIGNATURE}, content-type`,
+        'access-control-max-age': '600',
+      });
+      res.end();
+      return;
+    }
     handle(req.method ?? 'GET', req.url ?? '/', req.headers)
       .then(({ status, headers, body }) => {
-        res.writeHead(status, { 'content-type': 'application/json', ...headers });
+        res.writeHead(status, { 'content-type': 'application/json', ...corsHeaders, ...headers });
         res.end(body);
       })
       .catch((err) => {
-        res.writeHead(500, { 'content-type': 'application/json' });
+        res.writeHead(500, { 'content-type': 'application/json', ...corsHeaders });
         res.end(jsonStringify({ error: 'internal', detail: String(err?.message ?? err) }));
       });
   });

--- a/apps/api/test/facilitator.test.mjs
+++ b/apps/api/test/facilitator.test.mjs
@@ -1,0 +1,128 @@
+// @ts-check
+/**
+ * Facilitator tests. The non-crypto surface (shape validation, typed-data reconstruction,
+ * HTTP delegation, stub) is unit-tested with no dependencies. A crypto round-trip against the
+ * real SDK signer is included but SKIPS when viem is absent, so CI stays zero-dependency while a
+ * dev with viem gets true end-to-end signature coverage.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  reconstructTypedData, verifyEnvelopeShape, createStubFacilitator, createHttpFacilitator, recoverPayer,
+} from '../src/facilitator.mjs';
+import { buildTypedData } from '../../../packages/agent-sdk/src/eip3009.mjs';
+
+const USDC = '0x' + 'c'.repeat(40);
+const FROM = '0x' + '1'.repeat(40);
+const TO = '0x' + '2'.repeat(40);
+const NONCE = '0x' + 'a'.repeat(64);
+const SIG = '0x' + 'b'.repeat(130);
+
+const authorization = () => ({ from: FROM, to: TO, value: '10000', validAfter: '100', validBefore: '999999999999', nonce: NONCE, asset: USDC });
+const envelope = (over = {}) => {
+  const { authorization: authOver, ...rest } = over;
+  return { x402Version: 2, scheme: 'exact', network: 'base', signature: SIG, ...rest, authorization: { ...authorization(), ...(authOver ?? {}) } };
+};
+
+// ── typed-data reconstruction MUST equal the SDK's builder (or valid sigs won't recover) ──
+
+test('reconstructTypedData matches the SDK buildTypedData field-for-field', () => {
+  const domain = { name: 'USD Coin', version: '2', chainId: 8453, verifyingContract: USDC };
+  const sdk = buildTypedData({ authorization: authorization(), domain });
+  const server = reconstructTypedData(envelope(), { chainId: 8453, usdcAddress: USDC });
+  assert.deepEqual(server.domain, sdk.domain);
+  assert.deepEqual(server.message, sdk.message);
+  assert.deepEqual(server.types.TransferWithAuthorization, sdk.types.TransferWithAuthorization);
+  assert.equal(server.primaryType, sdk.primaryType);
+});
+
+test('reconstructTypedData uses config USDC over the envelope-declared asset (no trust in the envelope)', () => {
+  const evilAsset = '0x' + 'd'.repeat(40);
+  const td = reconstructTypedData(envelope({ authorization: { asset: evilAsset } }), { chainId: 8453, usdcAddress: USDC });
+  assert.equal(td.domain.verifyingContract, USDC, 'must bind to the operator-configured USDC, not the client asset');
+});
+
+// ── shape validation ──
+
+test('verifyEnvelopeShape accepts a well-formed envelope', () => {
+  assert.deepEqual(verifyEnvelopeShape(envelope(), 1000), { ok: true });
+});
+
+test('verifyEnvelopeShape rejects malformations with a precise reason', () => {
+  assert.equal(verifyEnvelopeShape(null, 1000).reason, 'no-envelope');
+  assert.equal(verifyEnvelopeShape({ x402Version: 1 }, 1000).reason, 'bad-version');
+  assert.equal(verifyEnvelopeShape(envelope({ signature: '0x1234' }), 1000).reason, 'bad-signature-format');
+  assert.equal(verifyEnvelopeShape(envelope({ authorization: { from: 'nope' } }), 1000).reason, 'bad-from');
+  assert.equal(verifyEnvelopeShape(envelope({ authorization: { value: '0' } }), 1000).reason, 'nonpositive-value');
+  assert.equal(verifyEnvelopeShape(envelope({ authorization: { nonce: '0x00' } }), 1000).reason, 'bad-nonce');
+  // validBefore is in seconds; 100s * 1000 = 100000ms < now 200000ms → expired
+  assert.equal(verifyEnvelopeShape(envelope({ authorization: { validBefore: '100' } }), 200_000).reason, 'authorization-expired');
+});
+
+// ── stub ──
+
+test('createStubFacilitator accepts and denies as configured', async () => {
+  const ok = await createStubFacilitator().verifyAndSettle({ price: {} }, envelope());
+  assert.equal(ok.ok, true);
+  assert.match(ok.receiptId, /^stub_1_/);
+  const deny = await createStubFacilitator({ accept: false }).verifyAndSettle({ price: {} }, envelope());
+  assert.deepEqual(deny, { ok: false, reason: 'stub-deny' });
+});
+
+// ── HTTP facilitator delegates and maps the remote verdict ──
+
+test('createHttpFacilitator posts challenge+envelope and returns the remote receipt', async () => {
+  let captured;
+  const fetchImpl = async (url, opts) => {
+    captured = { url, body: JSON.parse(opts.body) };
+    return { ok: true, json: async () => ({ ok: true, receiptId: 'remote_42' }) };
+  };
+  const fac = createHttpFacilitator({ url: 'https://facilitator.example/settle', fetchImpl });
+  const r = await fac.verifyAndSettle({ price: { amount: '10000' } }, envelope());
+  assert.deepEqual(r, { ok: true, receiptId: 'remote_42', reason: undefined });
+  assert.equal(captured.url, 'https://facilitator.example/settle');
+  assert.equal(captured.body.envelope.authorization.from, FROM);
+  assert.equal(captured.body.challenge.price.amount, '10000');
+});
+
+test('createHttpFacilitator surfaces a non-2xx remote failure', async () => {
+  const fetchImpl = async () => ({ ok: false, status: 402, json: async () => ({ ok: false, reason: 'insufficient-balance' }) });
+  const r = await createHttpFacilitator({ url: 'x', fetchImpl }).verifyAndSettle({}, envelope());
+  assert.deepEqual(r, { ok: false, reason: 'insufficient-balance' });
+});
+
+test('createHttpFacilitator treats an unreachable facilitator as a settlement failure (never throws)', async () => {
+  const fetchImpl = async () => { throw new Error('ECONNREFUSED'); };
+  const r = await createHttpFacilitator({ url: 'x', fetchImpl }).verifyAndSettle({}, envelope());
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /unreachable/);
+});
+
+// ── crypto round-trip: skips without viem, so CI stays dependency-free ──
+
+let viem = null;
+try { viem = await import('viem'); } catch { /* optional */ }
+let accounts = null;
+try { accounts = await import('viem/accounts'); } catch { /* optional */ }
+
+test('recoverPayer confirms a genuine SDK-signed authorization (viem)', { skip: !viem || !accounts ? 'viem not installed' : false }, async () => {
+  const pk = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'; // well-known test key (not a real account)
+  const account = accounts.privateKeyToAccount(pk);
+  const chainId = 8453;
+  const auth = { from: account.address, to: TO, value: '10000', validAfter: '100', validBefore: '999999999999', nonce: NONCE, asset: USDC };
+  const td = buildTypedData({ authorization: auth, domain: { name: 'USD Coin', version: '2', chainId, verifyingContract: USDC } });
+  const signature = await account.signTypedData({
+    domain: td.domain,
+    types: { TransferWithAuthorization: td.types.TransferWithAuthorization },
+    primaryType: 'TransferWithAuthorization',
+    message: td.message,
+  });
+  const good = await recoverPayer({ authorization: auth, signature }, { chainId, usdcAddress: USDC });
+  assert.equal(good.ok, true);
+  assert.equal(good.payer, account.address.toLowerCase());
+
+  // Tampering with the amount must break recovery (signer-mismatch).
+  const bad = await recoverPayer({ authorization: { ...auth, value: '99999' }, signature }, { chainId, usdcAddress: USDC });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.reason, 'signer-mismatch');
+});

--- a/apps/api/test/serve.test.mjs
+++ b/apps/api/test/serve.test.mjs
@@ -1,0 +1,114 @@
+// @ts-check
+/**
+ * Tests the API server entrypoint: config resolution, facilitator selection, fault-tolerant
+ * in-place snapshot reload, and the CORS/preflight path over the REAL http server (the piece the
+ * browser live mode depends on).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, writeFile } from 'node:fs/promises';
+import { resolveApiConfig, facilitatorFromConfig, buildApiServer } from '../src/serve.mjs';
+import { createApi } from '../src/server.mjs';
+import { createStubFacilitator } from '../src/facilitator.mjs';
+import { applyAll } from '../../../packages/indexer/src/projections.mjs';
+import { saveSnapshot } from '../../../packages/indexer/src/store.mjs';
+
+const USDC = '0x' + 'c'.repeat(40);
+const PAYTO = '0x' + '9'.repeat(40);
+const BASE_ENV = { PRICE_ASSET: USDC, PRICE_PAYTO: PAYTO };
+
+test('resolveApiConfig defaults + price assembly', () => {
+  const cfg = resolveApiConfig(BASE_ENV);
+  assert.equal(cfg.port, 8402);
+  assert.equal(cfg.reloadMs, 5000);
+  assert.equal(cfg.facilitatorKind, 'stub');
+  assert.deepEqual(cfg.price, { asset: USDC, amount: '10000', payTo: PAYTO, network: 'base' });
+});
+
+test('resolveApiConfig requires PRICE_ASSET + PRICE_PAYTO and validates them', () => {
+  assert.throws(() => resolveApiConfig({}), /PRICE_ASSET.*PRICE_PAYTO/);
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, PRICE_ASSET: '0xzz' }), /PRICE_ASSET is not an address/);
+});
+
+test('resolveApiConfig: FACILITATOR=http demands a URL', () => {
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, FACILITATOR: 'http' }), /requires FACILITATOR_URL/);
+  const ok = resolveApiConfig({ ...BASE_ENV, FACILITATOR: 'http', FACILITATOR_URL: 'https://f.example' });
+  assert.equal(ok.facilitatorKind, 'http');
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, FACILITATOR: 'nope' }), /must be 'stub' or 'http'/);
+});
+
+test('facilitatorFromConfig builds stub vs http', () => {
+  assert.equal(typeof facilitatorFromConfig(resolveApiConfig(BASE_ENV)).verifyAndSettle, 'function');
+  const http = facilitatorFromConfig(resolveApiConfig({ ...BASE_ENV, FACILITATOR: 'http', FACILITATOR_URL: 'https://f.example' }));
+  assert.equal(typeof http.verifyAndSettle, 'function');
+});
+
+test('buildApiServer reload picks up a new snapshot IN PLACE, and keeps stale state on a bad one', async () => {
+  const path = join(tmpdir(), `serve-${process.pid}-${Date.now()}.json`);
+  try {
+    const V = '0x' + '1'.repeat(40);
+    await saveSnapshot(path, applyAll([{ name: 'VaultCreated', vault: V, blockNumber: 5, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } }]));
+
+    const cfg = resolveApiConfig({ ...BASE_ENV, STATE_PATH: path });
+    const { state, reload } = await buildApiServer(cfg, { log: () => {} });
+    assert.equal(state.lastBlock, 5);
+    assert.equal(state.vaults.size, 1);
+
+    // Newer snapshot → reload reflects it on the same state object.
+    await saveSnapshot(path, applyAll([
+      { name: 'VaultCreated', vault: V, blockNumber: 9, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } },
+    ]));
+    assert.equal(await reload(), true);
+    assert.equal(state.lastBlock, 9);
+
+    // Corrupt snapshot → reload returns false and keeps the last good state.
+    await writeFile(path, '{ not json', 'utf8');
+    assert.equal(await reload(), false);
+    assert.equal(state.lastBlock, 9, 'stale-but-valid state kept serving');
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test('CORS: preflight OPTIONS is answered and payment headers are exposed', async () => {
+  const state = applyAll([]);
+  const { server } = createApi({ state, facilitator: createStubFacilitator(), price: { asset: USDC, amount: '10000', payTo: PAYTO, network: 'base' }, cors: true });
+  server.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    // Preflight for the paid retry's custom header.
+    const pre = await fetch(`http://127.0.0.1:${port}/vaults`, { method: 'OPTIONS', headers: { 'access-control-request-headers': 'payment-signature' } });
+    assert.equal(pre.status, 204);
+    assert.equal(pre.headers.get('access-control-allow-origin'), '*');
+    assert.match(pre.headers.get('access-control-allow-headers') ?? '', /payment-signature/i);
+
+    // A real 402 exposes the challenge header cross-origin.
+    const res = await fetch(`http://127.0.0.1:${port}/vaults`);
+    assert.equal(res.status, 402);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+    assert.match(res.headers.get('access-control-expose-headers') ?? '', /payment-required/i);
+    assert.ok(res.headers.get('payment-required'), 'challenge header present');
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+});
+
+test('no CORS headers by default (existing behavior preserved)', async () => {
+  const state = applyAll([]);
+  const { server } = createApi({ state, facilitator: createStubFacilitator(), price: { asset: USDC, amount: '10000', payTo: PAYTO, network: 'base' } });
+  server.listen(0);
+  await once(server, 'listening');
+  const port = server.address().port;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(res.headers.get('access-control-allow-origin'), null);
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+});

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -439,12 +439,52 @@
     else if(parts[0]==='portfolio')html=renderPortfolio();
     else html=renderDiscover();
     $('#view').innerHTML=html;
+    if(liveNote)$('#view').insertAdjacentHTML('afterbegin',liveNote);
     const nav=[['Discover','#/discover'],['Portfolio','#/portfolio']];
     $('#nav').innerHTML=nav.map(([t,u])=>`<span class="navlink ${h.startsWith(u)?'on':''}" onclick="go('${u}')">${t}</span>`).join('');
     window.scrollTo(0,0);
   }
   window.addEventListener('hashchange',router);
-  router();
+
+  // ── optional live mode: ?api=<url> pulls real indexed data from a running API, with graceful
+  //    fallback to the embedded demo. No ?api → nothing is imported, so the standalone/artifact
+  //    build stays fully self-contained. Reads are metered over x402; against a dev (stub-
+  //    facilitator) API a dummy signature is accepted and the browser never holds a real key. ──
+  let liveNote='';
+  const apiUrl=new URLSearchParams(location.search).get('api');
+  async function bootLive(){
+    if(!apiUrl){router();return;}
+    try{
+      const [{createClient},{mapVaults,mapLeaderboard}]=await Promise.all([
+        import('./src/api-client.mjs'),
+        import('./src/live-adapter.mjs'),
+      ]);
+      const base=apiUrl.replace(/\/$/,'');
+      const devSigner=async(ch)=>({x402Version:2,scheme:'exact',network:ch.network,
+        signature:'0x'+'00'.repeat(65),
+        authorization:{from:'0x'+'0'.repeat(40),to:ch.payTo,value:ch.amount,
+          validAfter:'0',validBefore:String(Math.floor(Date.now()/1000)+300),nonce:ch.nonce,asset:ch.asset}});
+      const client=createClient({baseUrl:base,signer:devSigner});
+      const health=await(await fetch(base+'/health')).json();
+      const [vres,lres]=await Promise.all([client.get('/vaults'),client.get('/operators/leaderboard')]);
+      const board=lres.data.leaderboard||[];
+      vaults.length=0;vaults.push(...mapVaults(vres.data.vaults,board,health.lastBlock));
+      operators.length=0;operators.push(...mapLeaderboard(board));
+      positions.length=0;
+      $('.tag').textContent='LIVE · block '+health.lastBlock;
+      $('.chip').style.display='none';
+      liveNote=`<div class="banner info"><div><span class="bt">Live API — ${base}</span>
+        Vaults, operators and members are read straight from the on-chain indexer over x402
+        (block ${health.lastBlock}). NAV/share, basket weights and proposal phases need the
+        chain-read enrichment layer the API does not expose yet, so those show as placeholders.</div></div>`;
+    }catch(err){
+      console.warn('live API unavailable — using embedded demo data:',err);
+      liveNote=`<div class="banner" style="background:var(--crit-soft)"><div><span class="bt">Live API unreachable.</span>
+        Showing embedded demo data. (${String(err&&err.message||err)})</div></div>`;
+    }
+    router();
+  }
+  bootLive();
 
   // ── theme ──
   $('#themeBtn').addEventListener('click',()=>{

--- a/apps/web/src/live-adapter.mjs
+++ b/apps/web/src/live-adapter.mjs
@@ -1,0 +1,71 @@
+// @ts-check
+/**
+ * Map the API's event-derived projection shapes into the display shapes the Vault Atlas UI renders.
+ *
+ * Honesty boundary: the metered API serves ONLY event-derived data (addresses, share counts,
+ * operator P&L, sub-vault links, capacity). NAV/share, live basket weights, and proposal-phase
+ * deadlines are chain-read enrichment the daemon does not yet expose over HTTP — so live mode fills
+ * those with neutral placeholders and the UI shows a "live · structure only" banner rather than
+ * inventing numbers. Pure functions, unit-tested; the browser hook lives in index.html.
+ */
+
+/** USDC base units (6dp) string → whole-dollar Number for display. */
+export function usdFromBase(s) {
+  try { return Number(BigInt(s ?? '0')) / 1e6; } catch { return 0; }
+}
+
+export function shortAddr(a) {
+  return typeof a === 'string' && a.length >= 10 ? `${a.slice(0, 6)}…${a.slice(-4)}` : (a || '?');
+}
+
+/** /operators/leaderboard rows → UI operator rows (base units → dollars, address → short label). */
+export function mapLeaderboard(rows) {
+  return (rows ?? []).map((o, idx) => ({
+    rank: idx + 1,
+    operator: shortAddr(o.operator),
+    operatorId: o.operatorId,
+    net: usdFromBase(o.netRealizedUsdc),
+    gain: usdFromBase(o.lifetimeGainUsdc),
+    loss: usdFromBase(o.lifetimeLossUsdc),
+    fees: usdFromBase(o.lifetimeFeesUsdc),
+    vaultCount: o.vaultCount ?? 0,
+  }));
+}
+
+/**
+ * /vaults list (+ the leaderboard, to resolve operatorId → operator address) → UI vault cards.
+ * @param {Array<object>} list       from /vaults
+ * @param {Array<object>} board      from /operators/leaderboard (may be empty)
+ * @param {number|string} lastBlock  from /health, for the "as of" line
+ */
+export function mapVaults(list, board, lastBlock) {
+  const opById = new Map((board ?? []).map((o) => [o.operatorId, o]));
+  return (list ?? []).map((v, i) => {
+    const attested = v.attested ?? (v.operatorId !== 0);
+    const op = opById.get(v.operatorId);
+    return {
+      i,
+      vault: v.vault,
+      name: `Vault ${shortAddr(v.vault)}`,
+      operator: attested ? (op ? shortAddr(op.operator) : `operator #${v.operatorId}`) : 'unattested',
+      operatorId: v.operatorId,
+      verified: attested,
+      unattested: !attested,
+      // Chain-read enrichment not exposed over HTTP yet — neutral placeholders (see banner).
+      navPs: 1.0,
+      entryPs: 1.0,
+      navUsd: 0,
+      asOf: `block ${lastBlock ?? '—'}`,
+      members: v.memberCount ?? 0,
+      capUsd: usdFromBase(v.capacityCapUsdc),
+      depth: v.depth ?? 0,
+      parent: v.parent ?? null,
+      exitFee: [0],
+      basket: [],
+      hist: [1],
+      frozen: false,
+      proposal: null,
+      live: true,
+    };
+  });
+}

--- a/apps/web/test/live-adapter.test.mjs
+++ b/apps/web/test/live-adapter.test.mjs
@@ -1,0 +1,67 @@
+// @ts-check
+/**
+ * Tests the live-API → UI shape mappers. These guard the join between the metered API's
+ * event-derived JSON and the fields the Vault Atlas renderers read, so a live-mode render can't
+ * crash on a missing field or misread base-unit amounts as dollars.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { usdFromBase, shortAddr, mapLeaderboard, mapVaults } from '../src/live-adapter.mjs';
+
+test('usdFromBase converts 6dp base units to whole dollars', () => {
+  assert.equal(usdFromBase('6000000000000'), 6_000_000); // $6M cap
+  assert.equal(usdFromBase('10000'), 0.01);
+  assert.equal(usdFromBase('-100000000'), -100); // net can be negative
+  assert.equal(usdFromBase(undefined), 0);
+  assert.equal(usdFromBase('not-a-number'), 0);
+});
+
+test('shortAddr truncates, tolerates junk', () => {
+  assert.equal(shortAddr('0x1234567890abcdef1234567890abcdef12345678'), '0x1234…5678');
+  assert.equal(shortAddr(''), '?');
+});
+
+test('mapLeaderboard: base units → dollars, address → label, rank by order', () => {
+  const rows = [
+    { operatorId: 2, operator: '0x' + 'a'.repeat(40), netRealizedUsdc: '412000000000', lifetimeGainUsdc: '512000000000', lifetimeLossUsdc: '100000000000', lifetimeFeesUsdc: '41200000000', vaultCount: 2 },
+  ];
+  const [o] = mapLeaderboard(rows);
+  assert.equal(o.rank, 1);
+  assert.equal(o.operator, '0xaaaa…aaaa');
+  assert.equal(o.net, 412_000);
+  assert.equal(o.gain, 512_000);
+  assert.equal(o.vaultCount, 2);
+  assert.deepEqual(mapLeaderboard(undefined), []);
+});
+
+test('mapVaults produces every field the renderers read, with safe placeholders', () => {
+  const V = '0x' + '1'.repeat(40);
+  const list = [{ vault: V, operatorId: 3, memberCount: 5, depth: 1, parent: '0x' + '2'.repeat(40), capacityCapUsdc: '1000000000', attested: true }];
+  const board = [{ operatorId: 3, operator: '0x' + 'b'.repeat(40) }];
+  const [v] = mapVaults(list, board, 42);
+
+  // Fields renderVault/vaultCard dereference without guards:
+  assert.equal(typeof v.navPs.toFixed, 'function');
+  assert.equal(v.exitFee.reduce((a, b) => a + b, 0), 0);
+  assert.deepEqual(v.hist, [1]);
+  assert.deepEqual(v.basket, []);
+  assert.equal(v.proposal, null);
+  assert.equal(v.frozen, false);
+  // Mapped data:
+  assert.equal(v.vault, V);
+  assert.equal(v.members, 5);
+  assert.equal(v.depth, 1);
+  assert.equal(v.capUsd, 1000); // $1000 cap from base units
+  assert.equal(v.operator, '0xbbbb…bbbb'); // resolved via leaderboard join
+  assert.equal(v.verified, true);
+  assert.equal(v.asOf, 'block 42');
+  assert.equal(v.live, true);
+});
+
+test('mapVaults flags an unattested vault (operatorId 0) as quarantined', () => {
+  const [v] = mapVaults([{ vault: '0x' + '5'.repeat(40), operatorId: 0, memberCount: 0, capacityCapUsdc: '0' }], [], 7);
+  assert.equal(v.unattested, true);
+  assert.equal(v.verified, false);
+  assert.equal(v.operator, 'unattested');
+  assert.equal(v.capUsd, 0); // uncapped renders as "uncapped" in the UI
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     env_file: .env
     environment:
       STATE_PATH: /data/indexer-state.json
+      PORT: 8402   # pin the CONTAINER port; ${PORT} below is the host-side knob only
     ports:
       - "${PORT:-8402}:8402"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+# Runtime stack: the indexer (writes the snapshot) and the API (reads it), sharing one volume.
+# Configure via a .env file (see .env.example). Neither service holds a key or moves funds.
+#
+#   cp .env.example .env   # fill in RPC_URL + deployed addresses + price
+#   docker compose up --build
+services:
+  indexer:
+    build: .
+    command: npm run start:indexer
+    env_file: .env
+    environment:
+      STATE_PATH: /data/indexer-state.json
+    volumes:
+      - vault-state:/data
+    restart: unless-stopped
+
+  api:
+    build: .
+    command: npm run start:api
+    env_file: .env
+    environment:
+      STATE_PATH: /data/indexer-state.json
+    ports:
+      - "${PORT:-8402}:8402"
+    volumes:
+      - vault-state:/data
+    depends_on:
+      - indexer
+    restart: unless-stopped
+
+volumes:
+  vault-state:

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -1,0 +1,209 @@
+# Runtime guide — running the live stack
+
+This is the operator runbook for the three runtime processes that turn deployed contracts into a
+live product: the **indexer**, the **API**, and the **web** front end. Everything here is
+**non-custodial** — no process in this repo holds a private key or moves funds. Payment settlement
+is delegated to an external **facilitator**.
+
+For the tested internals behind each piece, see [ARCHITECTURE.md](ARCHITECTURE.md); for contract
+deployment, [DEPLOYMENT.md](DEPLOYMENT.md) (the testnet deploy flow — `DeployTestnet.s.sol`, the
+`contracts/config/base-sepolia.json` infrastructure config, and `TESTNET-CHECKLIST.md` — ships with
+the testnet-deploy work).
+
+---
+
+## 1. How the pieces fit
+
+```
+   Base RPC ──logs──▶  indexer  ──snapshot file──▶  API  ──HTTP/x402──▶  web
+ (viem getLogs)     (index-runner.mjs)  (JSON)   (serve.mjs)          (index.html?api=)
+                                                     │
+                                          verifyAndSettle │ (no key here)
+                                                     ▼
+                                            facilitator (external)
+                                          verifies EIP-712 sig + settles
+                                          USDC.transferWithAuthorization
+```
+
+- The **indexer** reads real logs from a Base RPC via viem, folds them into projection state, and
+  writes an atomic **snapshot file** on an interval. It resumes from that snapshot on restart.
+- The **API** loads the snapshot and reloads it on an interval (separate process, shared file). It
+  serves read routes gated by the x402 payment scheme. It holds **no key** — it asks a facilitator
+  to verify+settle each payment.
+- The **facilitator** is where settlement (and the only key) lives. In production this is a
+  **remote HTTP facilitator** you point the API at. You may also run your own settler (§6).
+- The **web** app is self-contained demo by default; with `?api=<url>` it renders live data.
+
+**Wiring order** (each step needs the previous one's output):
+
+1. Deploy the contracts → record the **factory / operator-registry / sub-vault-registry /
+   governance** addresses and the **deploy block**.
+2. Start the **indexer** with the RPC + those addresses. Let it catch up.
+3. Start the **API** pointed at the same snapshot file + a facilitator + the USDC price.
+4. Open the **web** app with `?api=<api-url>` (or ship the API URL into a deployed build).
+
+---
+
+## 2. Prerequisites
+
+- **Node 24+** (`node --version`).
+- **viem** — the sole runtime dependency, lazily imported. Install it once at the repo root:
+  ```bash
+  npm install
+  ```
+  (The test suite needs no dependencies; only the running indexer/API/settler import viem.)
+- A **Base RPC URL** (mainnet `8453` or Base Sepolia `84532`). A public endpoint works for low
+  volume; use a provider endpoint for production throughput.
+- **Deployed contract addresses** + the **deploy block**. On testnet these come from the
+  `DeployTestnet.s.sol` run; the verified Base Sepolia infrastructure addresses (USDC, router,
+  Chainlink feeds) live in `contracts/config/base-sepolia.json` (ships with the testnet-deploy work).
+- The **USDC address** on your chain and a **payTo** address to receive metered-read payments.
+
+---
+
+## 3. Run locally (stub facilitator)
+
+The fastest path to "real vault data flowing to the front end". Uses the accept-all **stub**
+facilitator so you don't need a live facilitator to see the loop work. **Stub accepts payments
+without on-chain settlement — dev only.**
+
+```bash
+npm install                      # pulls viem
+cp .env.example .env             # then edit .env (see the table in §5)
+```
+
+**Terminal 1 — indexer:**
+```bash
+RPC_URL=https://sepolia.base.org \
+CHAIN_ID=84532 CHAIN_NAME=base-sepolia \
+FACTORY_ADDRESS=0x… OPERATOR_REGISTRY_ADDRESS=0x… \
+SUBVAULT_REGISTRY_ADDRESS=0x… GOVERNANCE_ADDRESS=0x… \
+START_BLOCK=<deploy-block> STATE_PATH=./data/indexer-state.json \
+npm run start:indexer
+```
+It logs `indexed [from..to] — N events, now at <block>` as it catches up, then idles at the head.
+
+**Terminal 2 — API:**
+```bash
+PRICE_ASSET=0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+PRICE_PAYTO=0x<your-recipient> PRICE_NETWORK=base-sepolia \
+STATE_PATH=./data/indexer-state.json PORT=8402 CORS=1 FACILITATOR=stub \
+npm run start:api
+```
+
+**Verify:**
+```bash
+curl -s localhost:8402/health                 # {"ok":true,"lastBlock":…}
+curl -s localhost:8402/.well-known/x402        # pricing + route map (free)
+curl -si localhost:8402/vaults | head -1       # 402 Payment Required (metered)
+```
+
+**Terminal 3 — web** (any static server rooted at `apps/web`, so `./src/*.mjs` resolves):
+```bash
+cd apps/web && python3 -m http.server 8080
+```
+Open `http://localhost:8080/index.html?api=http://localhost:8402`. You'll see a **Live API** banner
+and the indexed vaults/operators. Drop the `?api=` param and it falls back to the embedded demo.
+
+> Live mode reads are metered over x402. In the browser the SDK signs with a **dev signer** (a dummy
+> signature the stub facilitator accepts) — the browser never holds a real key. Against a real
+> settling facilitator that dummy signature is rejected, which is correct: the browser demo is not
+> meant to move funds. NAV/share, basket weights, and proposal phases are chain-read enrichment the
+> API does not expose yet, so live mode shows those as placeholders (the banner says so).
+
+---
+
+## 4. Run in production (Docker + remote facilitator)
+
+Production swaps the stub for a **remote HTTP facilitator** (which holds the settlement key, not
+you) and runs both processes from one image sharing a snapshot volume.
+
+```bash
+cp .env.example .env     # fill in RPC_URL, addresses, PRICE_*, and:
+                         #   FACILITATOR=http
+                         #   FACILITATOR_URL=https://<your-facilitator>/settle
+docker compose up --build
+```
+
+`docker-compose.yml` runs `indexer` (writes `/data/indexer-state.json`) and `api` (reads it,
+publishes `:8402`) against a shared `vault-state` volume. Both `restart: unless-stopped`.
+
+Production notes:
+- Put the API behind TLS (a reverse proxy). `CORS=1` is required if the browser front end is served
+  from a different origin than the API.
+- Size `CONFIRMATIONS` for your reorg tolerance and `POLL_INTERVAL_MS` (~one Base block ≈ 2s; the
+  default 12s is conservative). `BATCH_BLOCKS` caps each `getLogs` range for RPC limits.
+- The API serves **stale-but-valid** state if a snapshot reload ever fails (corrupt/partial write),
+  and logs it — it never serves a torn read (snapshots are written temp-then-rename).
+- Back up / persist the snapshot volume to avoid a full re-index on a fresh host (or set
+  `START_BLOCK` to the deploy block so a cold start skips empty history).
+
+---
+
+## 5. Environment variables
+
+### Indexer (`npm run start:indexer`)
+
+| Var | Required | Default | Meaning |
+|---|---|---|---|
+| `RPC_URL` | ✅ | — | Base HTTP RPC endpoint |
+| `FACTORY_ADDRESS` | ✅ | — | VaultFactory |
+| `OPERATOR_REGISTRY_ADDRESS` | ✅ | — | OperatorRegistry |
+| `SUBVAULT_REGISTRY_ADDRESS` | ✅ | — | SubVaultRegistry |
+| `GOVERNANCE_ADDRESS` | ✅ | — | Governance |
+| `CHAIN_ID` | | `8453` | `8453` Base, `84532` Base Sepolia |
+| `CHAIN_NAME` | | `base` | label for the viem chain |
+| `START_BLOCK` | | `0` | deploy block — skip empty history on a cold start |
+| `STATE_PATH` | | `./data/indexer-state.json` | snapshot file (share with the API) |
+| `CONFIRMATIONS` | | `5` | blocks to lag behind head (reorg safety) |
+| `BATCH_BLOCKS` | | `2000` | max blocks per `getLogs` batch |
+| `POLL_INTERVAL_MS` | | `12000` | poll cadence once caught up |
+
+### API (`npm run start:api`)
+
+| Var | Required | Default | Meaning |
+|---|---|---|---|
+| `PRICE_ASSET` | ✅ | — | USDC contract address (payment denomination) |
+| `PRICE_PAYTO` | ✅ | — | recipient of metered-read payments |
+| `PRICE_AMOUNT` | | `10000` | price in USDC base units (6dp); `10000` = $0.01 |
+| `PRICE_NETWORK` | | `base` | network label echoed in the x402 challenge |
+| `FACILITATOR` | | `stub` | `stub` (dev, accept-all) or `http` (remote settler) |
+| `FACILITATOR_URL` | if `http` | — | remote facilitator endpoint |
+| `STATE_PATH` | | `./data/indexer-state.json` | snapshot file (share with the indexer) |
+| `PORT` | | `8402` | HTTP listen port |
+| `RELOAD_MS` | | `5000` | snapshot re-read cadence |
+| `CORS` | | off | `1`/`true` to enable CORS + preflight (browser live mode) |
+
+The `PRICE_ASSET`/`PRICE_NETWORK`/`CHAIN_ID` must agree across the API and whatever wallet/agent
+pays: the challenge binds the payment to that exact asset + network.
+
+---
+
+## 6. Running your own settling facilitator (optional)
+
+If you don't use a third-party facilitator, run your own settler. It recovers the EIP-712 payer from
+the signed authorization and settles `USDC.transferWithAuthorization` on-chain. **It needs a funded
+account to pay gas — a key you supply and control.** This repo never embeds, reads from env, or logs
+a key: `createSettlingFacilitator` takes a viem account you inject at runtime.
+
+`apps/api/src/facilitator.mjs` exports `createSettlingFacilitator({ publicClient, walletClient,
+usdcAddress, chainId })`. Wire it in a small process you own (a viem `WalletClient` built from your
+account), expose an HTTP endpoint that calls its `verifyAndSettle`, and point the API's
+`FACILITATOR_URL` at it. Keep that process — and its key — isolated from the API and the indexer,
+which stay keyless.
+
+Settlement path per request: validate envelope shape → recover signer == `authorization.from` →
+check the on-chain authorization nonce is unused → `simulateContract` → `writeContract`. The receipt
+id returned to the client is the settlement tx hash.
+
+---
+
+## 7. Non-custodial guarantees
+
+- The **indexer** is read-only: `getLogs` and `getBlockNumber` only. It never signs or sends.
+- The **API** holds no key. It only asks a facilitator to `verifyAndSettle`; it serves the resource
+  when settlement succeeds. USDC moves via EIP-3009 executed **by the facilitator**, from payer to
+  `payTo`, never through the API.
+- The **web** browser signer is a dummy against a dev facilitator; real signing is the user's wallet.
+- The only key in the whole stack is the settlement key inside the facilitator (yours in §6, or the
+  third party's), which is a **relayer** paying gas — it never takes custody of vault funds.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "scripts": {
     "build:contracts": "cd contracts && forge build",
     "test:contracts": "cd contracts && forge test -vv",
-    "test:backend": "node --test packages/indexer/test/*.test.mjs packages/agent-sdk/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs"
+    "test:backend": "node --test packages/indexer/test/*.test.mjs packages/agent-sdk/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs",
+    "start:indexer": "node packages/indexer/src/index-runner.mjs",
+    "start:api": "node apps/api/src/serve.mjs"
+  },
+  "dependencies": {
+    "viem": "^2.21.0"
   }
 }

--- a/packages/indexer/src/abis.mjs
+++ b/packages/indexer/src/abis.mjs
@@ -1,0 +1,75 @@
+// @ts-check
+/**
+ * Minimal event-ABI fragments for the contracts the indexer projects from.
+ *
+ * These are plain JSON ABI event objects (the standard `{type:'event', name, inputs, anonymous}`
+ * shape) — viem's `getLogs({ events })` consumes them directly to decode logs into
+ * `{ eventName, args }`. Kept embedded (not read from `contracts/out`) so the runtime indexer is
+ * self-contained and needs no built-contracts directory in production.
+ *
+ * To guarantee these never drift from the deployed contracts, test/abis.test.mjs cross-checks
+ * every fragment here against the compiled Foundry ABIs when they are present — a Solidity event
+ * signature change breaks that test instead of silently producing wrong logs at runtime.
+ *
+ * Grouped by the on-chain source that emits them:
+ *   - `factory`, `operatorRegistry`, `subvaultRegistry`, `governance` are SINGLETONS (one address).
+ *   - `vault` events are emitted by every VaultCore instance — a dynamic address set the runner
+ *     discovers from VaultCreated logs (see rpc.mjs).
+ */
+
+/** @typedef {{type:'event', name:string, anonymous:boolean, inputs:Array<{name:string,type:string,indexed:boolean}>}} AbiEvent */
+
+const ev = (name, inputs) => ({ type: 'event', name, anonymous: false, inputs });
+const addr = (name, indexed = false) => ({ name, type: 'address', indexed });
+const u256 = (name, indexed = false) => ({ name, type: 'uint256', indexed });
+
+/** @type {Record<string, AbiEvent[]>} */
+export const CONTRACT_ABIS = Object.freeze({
+  factory: [
+    ev('VaultCreated', [addr('vault', true), addr('creator', true), addr('usdc'), u256('capacityCapUsdc')]),
+  ],
+  operatorRegistry: [
+    ev('OperatorRegistered', [u256('opId', true), addr('operator', true)]),
+    ev('VaultAttested', [addr('vault', true), u256('opId', true)]),
+    ev('RealizationRecorded', [
+      addr('vault', true), u256('opId', true), addr('member', true),
+      u256('gainUsdc'), u256('lossUsdc'), u256('carryAfter'),
+    ]),
+    ev('FeeRecorded', [u256('opId', true), u256('amountUsdc')]),
+  ],
+  subvaultRegistry: [
+    ev('ChildRegistered', [addr('parent', true), addr('child', true), u256('depth')]),
+  ],
+  governance: [
+    ev('Proposed', [
+      u256('pid', true), addr('vault', true),
+      { name: 'ptype', type: 'uint8', indexed: false }, addr('proposer', true),
+      { name: 'actionHash', type: 'bytes32', indexed: false },
+    ]),
+    ev('Revealed', [u256('pid', true), addr('voter', true), { name: 'support', type: 'bool', indexed: false }, u256('weight')]),
+    ev('DefaultApplied', [u256('pid', true), addr('member', true), { name: 'support', type: 'bool', indexed: false }, u256('weight')]),
+    ev('DelegatedRevealed', [u256('pid', true), addr('delegator', true), addr('delegate', true), u256('weight')]),
+    ev('Finalized', [u256('pid', true), { name: 'status', type: 'uint8', indexed: false }]),
+    ev('Executed', [u256('pid', true)]),
+    ev('ProposalExpired', [u256('pid', true)]),
+  ],
+  vault: [
+    ev('DepositActivated', [addr('member', true), u256('amountUsdc'), u256('sharesMinted')]),
+    ev('DepositPending', [addr('member', true), u256('amountUsdc'), { name: 'availableAt', type: 'uint64', indexed: false }]),
+    ev('PendingCancelled', [addr('member', true), u256('amountUsdc')]),
+    ev('ExitSettled', [addr('member', true), u256('sharesBurned'), u256('usdcPaid'), u256('exitFeeBps'), u256('perfFeeUsdc')]),
+  ],
+});
+
+/** Which config label supplies each singleton contract's address. `vault` is dynamic (not here). */
+export const SINGLETON_LABELS = Object.freeze(['factory', 'operatorRegistry', 'subvaultRegistry', 'governance']);
+
+/** Every event fragment, flattened — used by the drift test and by callers that want a union. */
+export function allEventFragments() {
+  return Object.values(CONTRACT_ABIS).flat();
+}
+
+/** Canonical `name(type,type,...)` signature for an event fragment (for drift comparison). */
+export function eventSignature(fragment) {
+  return `${fragment.name}(${fragment.inputs.map((i) => i.type).join(',')})`;
+}

--- a/packages/indexer/src/chain.mjs
+++ b/packages/indexer/src/chain.mjs
@@ -1,62 +1,49 @@
 // @ts-check
 /**
- * Production chain adapter: turns on-chain logs into the normalized events that projections.mjs
- * folds. This is the ONLY chain-coupled file; it is not unit-tested (it needs a live RPC).
- * Kept deliberately thin so the tested core (projections) carries the logic.
+ * Log normalization: turn an ABI-decoded viem log into the normalized event that projections.mjs
+ * folds. This and rpc.mjs are the only chain-coupled files; the tested projection core carries the
+ * logic. `normalizeLog` is pure and unit-tested; the RPC wiring lives in rpc.mjs.
  *
- * Uses viem when installed; falls back to a clear error otherwise. Wire it from a runner that
- * polls `getLogs` from the factory + known vault addresses and feeds `apply()`.
- *
- * Event → normalized-name mapping (matches the Solidity event names the API relies on):
- *   VaultFactory.VaultCreated, OperatorRegistry.OperatorRegistered / VaultAttested /
- *   RealizationRecorded / FeeRecorded, SubVaultRegistry.ChildRegistered,
+ * Event → normalized-name mapping (matches the Solidity event names the projection relies on):
+ *   VaultFactory.VaultCreated; OperatorRegistry.OperatorRegistered / VaultAttested /
+ *   RealizationRecorded / FeeRecorded; SubVaultRegistry.ChildRegistered; Governance.Proposed /
+ *   Revealed / DefaultApplied / DelegatedRevealed / Finalized / Executed / ProposalExpired;
  *   VaultCore.DepositPending / DepositActivated / PendingCancelled / ExitSettled.
  */
 
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/** Lowercase anything that is a 20-byte hex address; leave bytes32/nonces/values untouched. */
+function canon(v) {
+  return typeof v === 'string' && ADDRESS_RE.test(v) ? v.toLowerCase() : v;
+}
+
 /**
  * Decode a viem-style log (already matched to an ABI event) into a normalized event.
- * @param {{eventName:string, address:string, blockNumber:bigint, logIndex:number, args:Record<string,any>}} log
+ *
+ * Address canonicalization is load-bearing: viem returns `log.address` lowercased but decoded
+ * address ARGS EIP-55 checksummed, so a vault seen via `args.vault` (VaultCreated) and via
+ * `log.address` (its own DepositActivated) would key two different Map entries and split the
+ * projection. We lowercase every address-shaped value — the emitting `vault` and each arg — so a
+ * vault has exactly one canonical key everywhere.
+ *
+ * @param {{eventName:string, address:string, blockNumber:bigint|number, logIndex:number, args:Record<string,any>}} log
  * @param {string} [vaultAddress] the emitting vault, when the event is vault-scoped
  */
 export function normalizeLog(log, vaultAddress) {
   const args = {};
-  for (const [k, v] of Object.entries(log.args ?? {})) {
-    args[k] = typeof v === 'bigint' ? v : v;
-  }
+  for (const [k, v] of Object.entries(log.args ?? {})) args[k] = canon(v);
+  const vault = canon(vaultAddress ?? args.vault ?? log.address);
   return {
     name: log.eventName,
-    vault: vaultAddress ?? args.vault ?? log.address,
+    vault,
     blockNumber: Number(log.blockNumber),
-    logIndex: log.logIndex,
+    logIndex: Number(log.logIndex),
     args,
   };
 }
 
-/**
- * Create a poller that reads new logs and applies them to `state`. `client` is a viem
- * PublicClient; `contracts` maps a label to { address, abi }. Caller supplies the apply fn.
- *
- * Returns an async `poll(fromBlock, toBlock)` — schedule it however you like (setInterval, a
- * cron, or the harness). Left as a factory so tests can drive it with a fake client.
- *
- * @param {Object} cfg
- * @param {any} cfg.client
- * @param {Array<{address:string, abi:any[]}>} cfg.sources
- * @param {(evt:import('./projections.mjs').Event) => void} cfg.onEvent
- */
-export function createPoller({ client, sources, onEvent }) {
-  return async function poll(fromBlock, toBlock) {
-    for (const src of sources) {
-      const logs = await client.getLogs({
-        address: src.address,
-        fromBlock: BigInt(fromBlock),
-        toBlock: BigInt(toBlock),
-      });
-      for (const log of logs) {
-        // Assumes the caller passed an ABI-aware client that populates eventName/args.
-        if (!log.eventName) continue;
-        onEvent(normalizeLog(log));
-      }
-    }
-  };
+/** Deterministic fold order: (blockNumber, logIndex). daemon.tick applies in returned order. */
+export function sortEvents(events) {
+  return [...events].sort((x, y) => x.blockNumber - y.blockNumber || x.logIndex - y.logIndex);
 }

--- a/packages/indexer/src/index-runner.mjs
+++ b/packages/indexer/src/index-runner.mjs
@@ -84,8 +84,13 @@ export async function buildIndexer(cfg, { log = console.log, client } = {}) {
 
   // Fresh state (no snapshot) honors START_BLOCK; a resumed state keeps its own cursor.
   const st = daemon.getState();
-  if (st.lastBlock === 0 && st.lastLogIndex === -1 && cfg.startBlock > 0) {
+  const fresh = st.lastBlock === 0 && st.lastLogIndex === -1;
+  if (fresh && cfg.startBlock > 0) {
     st.lastBlock = cfg.startBlock - 1; // resumeCursor → startBlock
+    // Vaults are discovered from VaultCreated within polled ranges; any vault created BEFORE
+    // START_BLOCK will never be discovered (its VaultCore events go unindexed). Set START_BLOCK
+    // to the deploy block, not later. Warn so this is never silent.
+    log(`⚠ indexer: START_BLOCK=${cfg.startBlock} on a fresh snapshot — vaults created before block ${cfg.startBlock} will NOT be discovered. Use the factory deploy block.`);
   }
 
   async function start({ signal } = {}) {

--- a/packages/indexer/src/index-runner.mjs
+++ b/packages/indexer/src/index-runner.mjs
@@ -1,0 +1,122 @@
+// @ts-check
+/**
+ * Runnable indexer entrypoint. Env-driven: point it at a Base RPC and the deployed singleton
+ * addresses, and it resumes from the snapshot, polls new logs via the viem chain source, folds
+ * them, and snapshots — forever. Non-custodial and read-only: it never signs or sends anything.
+ *
+ * Required env:
+ *   RPC_URL                    Base (or Base Sepolia) HTTP RPC endpoint
+ *   FACTORY_ADDRESS            VaultFactory
+ *   OPERATOR_REGISTRY_ADDRESS  OperatorRegistry
+ *   SUBVAULT_REGISTRY_ADDRESS  SubVaultRegistry
+ *   GOVERNANCE_ADDRESS         Governance
+ * Optional env:
+ *   CHAIN_ID (8453)  CHAIN_NAME (base)  START_BLOCK (0)  STATE_PATH (./data/indexer-state.json)
+ *   CONFIRMATIONS (5)  BATCH_BLOCKS (2000)  POLL_INTERVAL_MS (12000)
+ *
+ * Run: `RPC_URL=… FACTORY_ADDRESS=… … node packages/indexer/src/index-runner.mjs`
+ */
+
+import { fileURLToPath } from 'node:url';
+import { createChainSource } from './rpc.mjs';
+import { createIndexerDaemon } from './daemon.mjs';
+import { loadSnapshot, resumeCursor } from './store.mjs';
+
+/**
+ * Parse + validate the indexer config from a raw env object. Pure and testable (no I/O).
+ * Throws with a precise message listing every missing required var.
+ * @param {Record<string,string|undefined>} env
+ */
+export function resolveIndexerConfig(env) {
+  const required = ['RPC_URL', 'FACTORY_ADDRESS', 'OPERATOR_REGISTRY_ADDRESS', 'SUBVAULT_REGISTRY_ADDRESS', 'GOVERNANCE_ADDRESS'];
+  const missing = required.filter((k) => !env[k]);
+  if (missing.length) throw new Error(`indexer: missing required env: ${missing.join(', ')}`);
+
+  const num = (k, d) => (env[k] != null && env[k] !== '' ? Number(env[k]) : d);
+  const isAddr = (a) => /^0x[0-9a-fA-F]{40}$/.test(a);
+  const addresses = {
+    factory: env.FACTORY_ADDRESS,
+    operatorRegistry: env.OPERATOR_REGISTRY_ADDRESS,
+    subvaultRegistry: env.SUBVAULT_REGISTRY_ADDRESS,
+    governance: env.GOVERNANCE_ADDRESS,
+  };
+  for (const [label, a] of Object.entries(addresses)) {
+    if (!isAddr(a)) throw new Error(`indexer: ${label} is not a 20-byte address: ${a}`);
+  }
+  return {
+    rpcUrl: env.RPC_URL,
+    chainId: num('CHAIN_ID', 8453),
+    chainName: env.CHAIN_NAME || 'base',
+    addresses,
+    startBlock: num('START_BLOCK', 0),
+    statePath: env.STATE_PATH || './data/indexer-state.json',
+    confirmations: num('CONFIRMATIONS', 5),
+    batchBlocks: num('BATCH_BLOCKS', 2000),
+    pollIntervalMs: num('POLL_INTERVAL_MS', 12_000),
+  };
+}
+
+/**
+ * Build a wired (but not yet started) indexer from a resolved config. Seeds the chain source's
+ * known-vault set from the resumed snapshot so VaultCore events keep indexing across restarts.
+ * Returns the daemon plus a `start()` that polls forever.
+ */
+export async function buildIndexer(cfg, { log = console.log, client } = {}) {
+  // Load once to discover already-known vaults, so VaultCore events keep indexing across restarts.
+  const resumed = await loadSnapshot(cfg.statePath);
+  const knownVaults = [...resumed.vaults.keys()];
+
+  const source = createChainSource({
+    client, // tests inject a fake viem client; production builds one from rpcUrl
+    rpcUrl: cfg.rpcUrl, chainId: cfg.chainId, chainName: cfg.chainName,
+    addresses: cfg.addresses, knownVaults,
+  });
+
+  const daemon = createIndexerDaemon({
+    statePath: cfg.statePath,
+    fetchEvents: source.fetchEvents,
+    headBlock: source.headBlock,
+    confirmations: cfg.confirmations,
+    batchBlocks: cfg.batchBlocks,
+    log,
+  });
+  await daemon.init(); // loads the same snapshot into the daemon's own state
+
+  // Fresh state (no snapshot) honors START_BLOCK; a resumed state keeps its own cursor.
+  const st = daemon.getState();
+  if (st.lastBlock === 0 && st.lastLogIndex === -1 && cfg.startBlock > 0) {
+    st.lastBlock = cfg.startBlock - 1; // resumeCursor → startBlock
+  }
+
+  async function start({ signal } = {}) {
+    log(`indexer up: chain ${cfg.chainId}, ${knownVaults.length} known vaults, resume block ${resumeCursor(daemon.getState()).fromBlock}`);
+    for (;;) {
+      if (signal?.aborted) return;
+      try {
+        await daemon.catchUp();
+      } catch (err) {
+        log(`indexer poll error (will retry): ${err?.message ?? err}`);
+      }
+      await sleep(cfg.pollIntervalMs, signal);
+    }
+  }
+
+  return { daemon, source, start };
+}
+
+function sleep(ms, signal) {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(t); resolve(undefined); }, { once: true });
+  });
+}
+
+// ── entrypoint ──
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const cfg = resolveIndexerConfig(process.env);
+  buildIndexer(cfg).then(({ start }) => start()).catch((err) => {
+    console.error(err?.message ?? err);
+    process.exit(1);
+  });
+}

--- a/packages/indexer/src/rpc.mjs
+++ b/packages/indexer/src/rpc.mjs
@@ -1,0 +1,98 @@
+// @ts-check
+/**
+ * Production chain source: reads real logs from a Base RPC via viem and yields the NORMALIZED
+ * events daemon.mjs folds. viem is a lazy, OPTIONAL dependency — imported only when no `client`
+ * is injected — so this module (and anything importing it) stays loadable in a zero-dependency
+ * test environment. Tests inject a fake `client`; production passes an `rpcUrl`.
+ *
+ * Dynamic vault discovery: the factory / operator-registry / sub-vault-registry / governance
+ * addresses are singletons (fixed), but each vault (VaultCore) is deployed by the factory, so its
+ * address is not known up front. We poll the singletons, learn new vault addresses from
+ * VaultCreated logs, and poll VaultCore events across the accumulated vault set. On restart the
+ * runner seeds the known-vault set from the resumed snapshot (see index-runner.mjs).
+ */
+
+import { CONTRACT_ABIS, SINGLETON_LABELS } from './abis.mjs';
+import { normalizeLog, sortEvents } from './chain.mjs';
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const lc = (a) => (typeof a === 'string' ? a.toLowerCase() : a);
+
+/**
+ * @param {Object} cfg
+ * @param {any} [cfg.client]            an injected viem-style client (tests); built from rpcUrl if omitted
+ * @param {string} [cfg.rpcUrl]         HTTP RPC endpoint (required when no client is injected)
+ * @param {number} [cfg.chainId]        chain id for the viem client (e.g. 8453 Base, 84532 Base Sepolia)
+ * @param {string} [cfg.chainName]
+ * @param {{factory?:string, operatorRegistry?:string, subvaultRegistry?:string, governance?:string}} cfg.addresses
+ * @param {Iterable<string>} [cfg.knownVaults]  vault addresses already known (seed from resumed state)
+ */
+export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 'base', addresses, knownVaults = [] }) {
+  const addr = {};
+  for (const label of SINGLETON_LABELS) if (addresses?.[label]) addr[label] = lc(addresses[label]);
+  const vaults = new Set([...knownVaults].filter((v) => ADDRESS_RE.test(v)).map(lc));
+
+  let _client = client ?? null;
+  async function getClient() {
+    if (_client) return _client;
+    if (!rpcUrl) throw new Error('rpc: no client injected and no rpcUrl provided');
+    const { createPublicClient, http } = await import('viem').catch(() => {
+      throw new Error('rpc: viem is not installed — run `npm install viem` (it is an optional runtime dependency)');
+    });
+    const chain = {
+      id: chainId,
+      name: chainName,
+      nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+      rpcUrls: { default: { http: [rpcUrl] } },
+    };
+    _client = createPublicClient({ chain, transport: http(rpcUrl) });
+    return _client;
+  }
+
+  /** Current chain head (block number as a Number). */
+  async function headBlock() {
+    const c = await getClient();
+    return Number(await c.getBlockNumber());
+  }
+
+  /** Read + decode logs from one address (or address array) for one contract group's events. */
+  async function logsFor(c, address, events, from, to) {
+    if (Array.isArray(address) ? address.length === 0 : !address) return [];
+    const raw = await c.getLogs({ address, events, fromBlock: BigInt(from), toBlock: BigInt(to) });
+    return raw.filter((l) => l && l.eventName).map((l) => normalizeLog(l));
+  }
+
+  /**
+   * NORMALIZED events for [from, to], globally sorted by (blockNumber, logIndex). Discovers new
+   * vaults from VaultCreated in this same range before polling VaultCore events, so a vault
+   * created and used within one batch is captured.
+   * @returns {Promise<import('./projections.mjs').Event[]>}
+   */
+  async function fetchEvents(from, to) {
+    const c = await getClient();
+    const out = [];
+
+    for (const label of SINGLETON_LABELS) {
+      if (!addr[label]) continue;
+      const evts = await logsFor(c, addr[label], CONTRACT_ABIS[label], from, to);
+      for (const e of evts) {
+        if (e.name === 'VaultCreated' && ADDRESS_RE.test(e.vault)) vaults.add(e.vault);
+        out.push(e);
+      }
+    }
+
+    if (vaults.size > 0) {
+      const vaultEvts = await logsFor(c, [...vaults], CONTRACT_ABIS.vault, from, to);
+      out.push(...vaultEvts);
+    }
+
+    return sortEvents(out);
+  }
+
+  return {
+    headBlock,
+    fetchEvents,
+    /** The live known-vault set (grows as VaultCreated logs are seen). */
+    get knownVaults() { return new Set(vaults); },
+  };
+}

--- a/packages/indexer/test/abis.test.mjs
+++ b/packages/indexer/test/abis.test.mjs
@@ -1,0 +1,75 @@
+// @ts-check
+/**
+ * Drift guard for the embedded runtime event fragments (abis.mjs). Every fragment the indexer
+ * decodes logs with must match — name AND full type signature — a real event on the compiled
+ * contracts. This is the runtime twin of event-coverage.test.mjs (which guards HANDLED_EVENTS):
+ * a Solidity signature change (added arg, retyped field) breaks decoding at runtime, and this
+ * test catches it at build time instead. Skips gracefully when contracts/out is absent.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { CONTRACT_ABIS, allEventFragments, eventSignature } from '../src/abis.mjs';
+import { HANDLED_EVENTS } from '../src/projections.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = join(here, '../../../contracts/out');
+const built = existsSync(OUT);
+
+/** Map of eventName -> Set of canonical signatures declared across the projected contracts. */
+function compiledEventSignatures() {
+  const files = [
+    'VaultCore.sol/VaultCore.json',
+    'Governance.sol/Governance.json',
+    'OperatorRegistry.sol/OperatorRegistry.json',
+    'SubVaultRegistry.sol/SubVaultRegistry.json',
+    'VaultFactory.sol/VaultFactory.json',
+  ];
+  /** @type {Map<string, Set<string>>} */
+  const sigs = new Map();
+  for (const rel of files) {
+    const p = join(OUT, rel);
+    if (!existsSync(p)) continue;
+    const abi = JSON.parse(readFileSync(p, 'utf8')).abi ?? [];
+    for (const item of abi) {
+      if (item.type !== 'event') continue;
+      const sig = `${item.name}(${item.inputs.map((i) => i.type).join(',')})`;
+      if (!sigs.has(item.name)) sigs.set(item.name, new Set());
+      sigs.get(item.name).add(sig);
+    }
+  }
+  return sigs;
+}
+
+test('every embedded event fragment matches a real compiled contract event (name + signature)', { skip: !built ? 'contracts not built' : false }, () => {
+  const compiled = compiledEventSignatures();
+  assert.ok(compiled.size > 0, 'no ABIs found — build contracts first');
+  for (const frag of allEventFragments()) {
+    const forName = compiled.get(frag.name);
+    assert.ok(forName, `contract emits no event named ${frag.name}`);
+    assert.ok(
+      forName.has(eventSignature(frag)),
+      `signature drift for ${frag.name}: embedded ${eventSignature(frag)} not in [${[...forName].join(', ')}]`,
+    );
+  }
+});
+
+test('embedded fragments cover exactly the projection HANDLED_EVENTS set', () => {
+  const embedded = new Set(allEventFragments().map((f) => f.name));
+  const handled = new Set(HANDLED_EVENTS);
+  const missing = [...handled].filter((e) => !embedded.has(e));
+  const extra = [...embedded].filter((e) => !handled.has(e));
+  assert.deepEqual(missing, [], `projection handles events the runtime cannot decode: ${missing.join(', ')}`);
+  assert.deepEqual(extra, [], `runtime decodes events the projection ignores: ${extra.join(', ')}`);
+});
+
+test('no duplicate event names across contract groups (decodes are unambiguous by name)', () => {
+  const names = allEventFragments().map((f) => f.name);
+  assert.equal(new Set(names).size, names.length, 'a duplicate event name would make normalized events ambiguous');
+  // Sanity: the singleton groups and the dynamic vault group are all non-empty.
+  for (const [label, frags] of Object.entries(CONTRACT_ABIS)) {
+    assert.ok(frags.length > 0, `group ${label} has no events`);
+  }
+});

--- a/packages/indexer/test/index-runner.test.mjs
+++ b/packages/indexer/test/index-runner.test.mjs
@@ -1,0 +1,82 @@
+// @ts-check
+/**
+ * Tests the env-driven indexer entrypoint: config resolution (pure) and the full wiring via
+ * buildIndexer with an injected fake client (no viem, no RPC) — including resume seeding of the
+ * known-vault set and the START_BLOCK cursor floor.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { resolveIndexerConfig, buildIndexer } from '../src/index-runner.mjs';
+import { saveSnapshot } from '../src/store.mjs';
+import { applyAll, vaultView } from '../src/projections.mjs';
+
+const A40 = (c) => '0x' + c.repeat(40);
+const FULL_ENV = {
+  RPC_URL: 'https://rpc.example',
+  FACTORY_ADDRESS: A40('f'), OPERATOR_REGISTRY_ADDRESS: A40('e'),
+  SUBVAULT_REGISTRY_ADDRESS: A40('d'), GOVERNANCE_ADDRESS: A40('c'),
+};
+
+test('resolveIndexerConfig applies defaults and parses numbers', () => {
+  const cfg = resolveIndexerConfig(FULL_ENV);
+  assert.equal(cfg.chainId, 8453);
+  assert.equal(cfg.chainName, 'base');
+  assert.equal(cfg.confirmations, 5);
+  assert.equal(cfg.batchBlocks, 2000);
+  assert.equal(cfg.statePath, './data/indexer-state.json');
+  assert.equal(cfg.addresses.factory, A40('f'));
+});
+
+test('resolveIndexerConfig honors overrides', () => {
+  const cfg = resolveIndexerConfig({ ...FULL_ENV, CHAIN_ID: '84532', CHAIN_NAME: 'base-sepolia', START_BLOCK: '100', CONFIRMATIONS: '2', STATE_PATH: '/tmp/s.json' });
+  assert.equal(cfg.chainId, 84532);
+  assert.equal(cfg.chainName, 'base-sepolia');
+  assert.equal(cfg.startBlock, 100);
+  assert.equal(cfg.confirmations, 2);
+  assert.equal(cfg.statePath, '/tmp/s.json');
+});
+
+test('resolveIndexerConfig lists every missing required var', () => {
+  assert.throws(() => resolveIndexerConfig({}), /RPC_URL.*FACTORY_ADDRESS.*OPERATOR_REGISTRY_ADDRESS.*SUBVAULT_REGISTRY_ADDRESS.*GOVERNANCE_ADDRESS/s);
+});
+
+test('resolveIndexerConfig rejects a malformed address', () => {
+  assert.throws(() => resolveIndexerConfig({ ...FULL_ENV, GOVERNANCE_ADDRESS: '0xnothex' }), /governance is not a 20-byte address/);
+});
+
+test('buildIndexer resumes known vaults from the snapshot and indexes new VaultCore events', async () => {
+  const path = join(tmpdir(), `runner-${process.pid}-${Date.now()}.json`);
+  try {
+    const V = A40('1');
+    // Pre-seed a snapshot as if an earlier run already indexed this vault up to block 20.
+    const seeded = applyAll([
+      { name: 'VaultCreated', vault: V, blockNumber: 10, logIndex: 0, args: { vault: V, creator: A40('a'), usdc: A40('b'), capacityCapUsdc: 1000n } },
+    ]);
+    seeded.lastBlock = 20;
+    await saveSnapshot(path, seeded);
+
+    // A fake client returning only a later ExitSettled on the seeded vault (no VaultCreated now).
+    const client = {
+      async getBlockNumber() { return 40n; },
+      async getLogs({ address, events, fromBlock, toBlock }) {
+        const addrs = new Set((Array.isArray(address) ? address : [address]).map((a) => a.toLowerCase()));
+        if (!addrs.has(V) || !events.some((e) => e.name === 'DepositActivated')) return [];
+        if (25n < fromBlock || 25n > toBlock) return [];
+        return [{ address: V, eventName: 'DepositActivated', blockNumber: 25n, logIndex: 0, args: { member: A40('2'), amountUsdc: 50n, sharesMinted: 50n } }];
+      },
+    };
+
+    const cfg = resolveIndexerConfig({ ...FULL_ENV, STATE_PATH: path, CONFIRMATIONS: '0', BATCH_BLOCKS: '5000' });
+    const { daemon } = await buildIndexer(cfg, { log: () => {}, client });
+    await daemon.catchUp();
+
+    const v = vaultView(daemon.getState(), V);
+    assert.equal(v.totalShares, 50n, 'resumed vault must index its later deposit');
+    assert.equal(v.creator, A40('a'), 'resumed vault metadata preserved');
+  } finally {
+    await rm(path, { force: true });
+  }
+});

--- a/packages/indexer/test/rpc.test.mjs
+++ b/packages/indexer/test/rpc.test.mjs
@@ -1,0 +1,123 @@
+// @ts-check
+/**
+ * Integration test for the RPC chain source with a MOCKED viem client (no live RPC, no viem).
+ * The fake `getLogs` mimics viem's real return shape — `log.address` LOWERCASED, decoded address
+ * `args` EIP-55 CHECKSUMMED — which is exactly the split-state hazard the source must neutralize.
+ * Covers: address canonicalization, dynamic vault discovery, same-batch capture, global ordering,
+ * resume seeding, and the full fold through the daemon.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { createChainSource } from '../src/rpc.mjs';
+import { createIndexerDaemon } from '../src/daemon.mjs';
+import { leaderboard, vaultView } from '../src/projections.mjs';
+
+// Singleton addresses (config-supplied, canonical lowercase).
+const FACTORY = '0x' + 'f'.repeat(40);
+const OPREG = '0x' + 'e'.repeat(40);
+const SUBREG = '0x' + 'd'.repeat(40);
+const GOV = '0x' + 'c'.repeat(40);
+const ADDRESSES = { factory: FACTORY, operatorRegistry: OPREG, subvaultRegistry: SUBREG, governance: GOV };
+
+// A vault whose address has mixed case. viem gives us the checksummed form in decoded args and
+// the lowercased form as the emitting log.address — the two must collapse to ONE projection key.
+const V_CHECKSUM = '0xAbCdEf0000000000000000000000000000000001';
+const V_LOWER = V_CHECKSUM.toLowerCase();
+const MEMBER = '0x' + '2'.repeat(40);
+const OPERATOR = '0x' + 'a'.repeat(40);
+
+const L = (address, eventName, blockNumber, logIndex, args) => ({ address, eventName, blockNumber: BigInt(blockNumber), logIndex, args });
+
+/** Build a fake viem client over a fixed log fixture. */
+function fakeClient(logs, head) {
+  return {
+    async getBlockNumber() { return BigInt(head); },
+    async getLogs({ address, events, fromBlock, toBlock }) {
+      const wanted = new Set(events.map((e) => e.name));
+      const addrs = (Array.isArray(address) ? address : [address]).map((a) => a.toLowerCase());
+      const addrSet = new Set(addrs);
+      return logs.filter(
+        (l) => addrSet.has(l.address.toLowerCase()) &&
+          wanted.has(l.eventName) &&
+          l.blockNumber >= fromBlock && l.blockNumber <= toBlock,
+      );
+    },
+  };
+}
+
+// Deliberately OUT OF (block,logIndex) ORDER to prove fetchEvents sorts globally.
+function fixture() {
+  return [
+    L(V_LOWER, 'DepositActivated', 12, 0, { member: MEMBER, amountUsdc: 100n, sharesMinted: 100n }),
+    L(OPREG, 'OperatorRegistered', 5, 0, { opId: 1n, operator: OPERATOR }),
+    L(FACTORY, 'VaultCreated', 10, 0, { vault: V_CHECKSUM, creator: OPERATOR, usdc: ('0x' + 'b'.repeat(40)), capacityCapUsdc: 6_000_000n }),
+    L(OPREG, 'VaultAttested', 11, 0, { vault: V_CHECKSUM, opId: 1n }),
+    L(OPREG, 'RealizationRecorded', 13, 0, { vault: V_CHECKSUM, opId: 1n, member: MEMBER, gainUsdc: 300n, lossUsdc: 100n, carryAfter: 0n }),
+  ];
+}
+
+test('fetchEvents returns globally sorted, canonicalized events (checksum args + lowercased address collapse)', async () => {
+  const src = createChainSource({ client: fakeClient(fixture(), 20), addresses: ADDRESSES });
+  const events = await src.fetchEvents(1, 20);
+
+  // Sorted by (blockNumber, logIndex) regardless of fixture order.
+  const keys = events.map((e) => e.blockNumber);
+  assert.deepEqual(keys, [...keys].sort((a, b) => a - b), 'events not globally sorted');
+
+  // Every vault reference is the ONE lowercase key — no checksummed leakage.
+  const created = events.find((e) => e.name === 'VaultCreated');
+  assert.equal(created.vault, V_LOWER);
+  const attested = events.find((e) => e.name === 'VaultAttested');
+  assert.equal(attested.vault, V_LOWER, 'VaultAttested vault must be canonicalized to match VaultCreated');
+  const deposit = events.find((e) => e.name === 'DepositActivated');
+  assert.equal(deposit.vault, V_LOWER, 'vault-scoped event must key off lowercased log.address');
+});
+
+test('dynamic discovery: a vault created and used in the SAME batch is fully captured', async () => {
+  const src = createChainSource({ client: fakeClient(fixture(), 20), addresses: ADDRESSES });
+  const events = await src.fetchEvents(1, 20);
+  // VaultCreated (block 10) then DepositActivated on that vault (block 12), both in one fetch.
+  assert.ok(events.some((e) => e.name === 'VaultCreated' && e.vault === V_LOWER));
+  assert.ok(events.some((e) => e.name === 'DepositActivated' && e.vault === V_LOWER));
+  assert.deepEqual([...src.knownVaults], [V_LOWER]);
+});
+
+test('folds through the daemon into a single, correct vault + leaderboard', async () => {
+  const path = join(tmpdir(), `rpc-${process.pid}-${Date.now()}.json`);
+  try {
+    const src = createChainSource({ client: fakeClient(fixture(), 20), addresses: ADDRESSES });
+    const d = createIndexerDaemon({ statePath: path, fetchEvents: src.fetchEvents, headBlock: src.headBlock, confirmations: 0, batchBlocks: 5000 });
+    await d.catchUp();
+    const state = d.getState();
+
+    assert.equal(state.vaults.size, 1, 'casing split would produce 2 vault entries');
+    const v = vaultView(state, V_LOWER);
+    assert.ok(v, 'vault must be reachable by its canonical lowercase key');
+    assert.equal(v.creator, OPERATOR);
+    assert.equal(v.operatorId, 1);
+    assert.equal(v.totalShares, 100n);
+    assert.equal(v.capacityCapUsdc, 6_000_000n);
+
+    const lb = leaderboard(state);
+    assert.equal(lb[0].operatorId, 1);
+    assert.equal(lb[0].netRealizedUsdc, 200n); // gain 300 - loss 100
+    assert.equal(lb[0].vaultCount, 1);
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test('resume seeding: VaultCore events index even with no VaultCreated in the current range', async () => {
+  // Simulate a restart: the vault was created & indexed in an earlier range; only a later
+  // ExitSettled falls in this range. Seeding knownVaults from the resumed snapshot lets the
+  // source poll VaultCore events without re-seeing VaultCreated.
+  const laterLogs = [L(V_LOWER, 'ExitSettled', 30, 0, { member: MEMBER, sharesBurned: 40n, usdcPaid: 40n, exitFeeBps: 0n, perfFeeUsdc: 0n })];
+  const src = createChainSource({ client: fakeClient(laterLogs, 40), addresses: ADDRESSES, knownVaults: [V_CHECKSUM] });
+  const events = await src.fetchEvents(25, 35);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].name, 'ExitSettled');
+  assert.equal(events[0].vault, V_LOWER, 'seeded vault key must be canonicalized to lowercase');
+});


### PR DESCRIPTION
Makes the tested projection core, x402 gate, and SDK **RUN** against real infra — end-to-end and live-configurable — without ever holding a key or moving funds.

## What ships

**1. Runnable indexer** (`packages/indexer/`)
- `abis.mjs` — embedded viem-decodable event fragments for the 5 projected contracts, with a drift test cross-checking name+signature against `contracts/out` and coverage-matching `HANDLED_EVENTS` exactly.
- `rpc.mjs` — viem chain source with dynamic vault discovery (learns VaultCore addresses from `VaultCreated`), same-batch capture, resume seeding, and a global `(block,logIndex)` sort. viem is a lazy optional dep; an injected-client seam keeps it testable with no RPC.
- `chain.mjs` — `normalizeLog` canonicalizes every address (viem lowercases `log.address` but checksums decoded args — otherwise a vault splits into two projection keys). Dead `createPoller` removed.
- `index-runner.mjs` — env-driven entrypoint, resumes from snapshot, polls forever.

**2. Production x402 facilitator** (`apps/api/src/facilitator.mjs`)
- `createHttpFacilitator` (remote, non-custodial — the API server's default), `createSettlingFacilitator` (run-your-own: recover EIP-712 payer → check on-chain nonce → simulate → settle `USDC.transferWithAuthorization` with an **operator-supplied** account), `createStubFacilitator` (dev). chainId/USDC come from construction config, never the `{price}` call arg.

**3. API server entrypoint** (`apps/api/src/serve.mjs`)
- Env-driven; loads + reloads the indexer snapshot in place (fault-tolerant: keeps stale-but-valid state on a corrupt reload). Address lookups canonicalized to lowercase. Opt-in CORS + preflight for the browser live mode. `Dockerfile` + `docker-compose.yml` + `.env.example`.

**4. Web live mode** (`apps/web/`)
- `?api=<url>` pulls real indexed data over x402 (`live-adapter.mjs` maps API JSON → UI shapes, base-units → dollars); **any** failure falls back to the embedded demo. No `?api` → nothing imported → the artifact build stays self-contained.

**5. `docs/RUNTIME.md`** — operator runbook: wiring order, local + prod runs, full env reference, run-your-own settler, non-custodial guarantees.

## Verification
- **81/81 backend tests with viem present; 80 + 1 viem-gated skip with `node_modules` absent** (CI runs the suite dependency-free — every new test stays zero-dep).
- **Real viem validated against live Base Sepolia** (publicnode): `createPublicClient`, `getBlockNumber`, and the multi-event `getLogs` arg shape all accepted.
- **Browser-verified all three web modes** against a locally-run API + seeded snapshot: live (real data + banner), dead-URL fallback (demo + notice), standalone (demo, unchanged).

## Constraints honored
Non-custodial throughout — no process here holds a key or moves funds; the settling facilitator takes an injected account. The 48 pre-existing tests are untouched (CORS is opt-in, off by default). The self-contained artifact build is unchanged.

Closes #3
