### PR TITLE
Canary: read-only post-launch watcher for the DEPLOYMENT §6 signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,21 @@ CONFIRMATIONS=5                          # lag behind head for reorg safety
 BATCH_BLOCKS=2000                        # max blocks per getLogs batch
 POLL_INTERVAL_MS=12000                   # ~one Base block
 
+# ── Canary (docs/CANARY.md) ──
+# Read-only post-launch monitor. No key, no wallet, never sends a transaction. Silent while
+# healthy; one line per signal transition. Reuses RPC_URL / CHAIN_ID / CHAIN_NAME / CONFIRMATIONS
+# and OPERATOR_REGISTRY_ADDRESS from above, and STATE_PATH for the indexer snapshot it reads.
+CANARY_STATE_PATH=./data/canary-state.json  # its OWN transition state (compose overrides to /data/...)
+CANARY_POLL_INTERVAL_MS=30000            # sweep cadence — deliberately slower than the indexer poll
+NAV_DIVERGENCE_BPS=50                    # alert when navWad vs recomputed holdings diverge > 0.5%
+ORACLE_MIN_MARGIN=0                      # alert when (fresh sources - quorum) <= this; 0 = "one failure from frozen"
+MAX_LOG_SPAN_BLOCKS=2000                 # cap on one sweep's getLogs range
+LOG_LOOKBACK_BLOCKS=0                    # cold-start event lookback
+# VAULTS=                                # optional explicit vault list; omit to discover from the snapshot
+# EXTRA_OPERATOR_ADDRESSES=              # extra operator addresses the fee-routing signal treats as prohibited
+# ALERT_WEBHOOK_URL=https://hooks.example/canary   # optional: POST one JSON body per transition
+# HEARTBEAT_MS=3600000                   # optional: hourly "still watching" line so silence is provably alive
+
 # ── API pricing (x402) ──
 PRICE_ASSET=0x036CbD53842c5426634e7929541eC2318f3dCF7e   # USDC on the chain above
 PRICE_PAYTO=0x0000000000000000000000000000000000000000   # who receives metered-read payments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,4 @@ jobs:
       # by hand against a live chain. Parse them so a syntax error can't reach a
       # 6-hour smoke run or a production boot.
       - name: Syntax-check entrypoints and operational scripts
-        run: node --check scripts/smoke-test.mjs && node --check apps/api/src/serve.mjs && node --check packages/indexer/src/index-runner.mjs
+        run: node --check scripts/smoke-test.mjs && node --check apps/api/src/serve.mjs && node --check packages/indexer/src/index-runner.mjs && node --check packages/canary/src/canary-runner.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-# Single image for both runtime processes (indexer + API). Pick which to run via the compose
-# service command or a `docker run` override. Both are non-custodial: no keys, no fund movement.
+# Single image for all three runtime processes (indexer + API + canary). Pick which to run via
+# the compose service command or a `docker run` override. All three are non-custodial: no keys,
+# no fund movement. The canary is additionally read-only against the chain — it never sends.
 #
 #   docker build -t vault-runtime .
 #   docker run --env-file .env vault-runtime npm run start:indexer
 #   docker run --env-file .env -p 8402:8402 vault-runtime npm run start:api
+#   docker run --env-file .env vault-runtime npm run start:canary
 FROM node:24-slim
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ chain-agnostic contracts, no CEX integrations.
 | `contracts/` | Foundry project — the protocol (immutable, no proxies). |
 | `packages/indexer/` | Chain-agnostic event projections + persistence + a runnable daemon. |
 | `packages/agent-sdk/` | Env-agnostic client: the x402 402→authorize→retry loop + typed methods. |
+| `packages/canary/` | Read-only post-launch watcher for the DEPLOYMENT §6 signals ([docs/CANARY.md](docs/CANARY.md)). |
 | `apps/api/` | x402-metered read API (challenge → EIP-3009 authorize → facilitator settle). |
 | `apps/web/` | Vault Atlas — consumer app: discover, inspect governance/fees, deposit/exit. |
 | `scripts/` | Operational runners — `smoke-test.mjs` drives the full on-chain lifecycle via `cast`. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,23 @@ services:
       - indexer
     restart: unless-stopped
 
+  # Post-launch canary (docs/CANARY.md). Read-only against the chain: no key, no wallet, no
+  # transaction — it only reads. It mounts the shared volume because two of its signals compare
+  # the indexer's projection against chain state; it reads that snapshot and never writes it.
+  # Silent while healthy: one line per signal transition, nothing otherwise. Set ALERT_WEBHOOK_URL
+  # in .env to also POST each transition.
+  canary:
+    build: .
+    command: npm run start:canary
+    env_file: .env
+    environment:
+      STATE_PATH: /data/indexer-state.json        # the indexer snapshot (read-only to this service)
+      CANARY_STATE_PATH: /data/canary-state.json  # its OWN transition state — never the indexer's
+    volumes:
+      - vault-state:/data
+    depends_on:
+      - indexer
+    restart: unless-stopped
+
 volumes:
   vault-state:

--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -283,6 +283,12 @@ signals have the hole. Raise `MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
   logged and stepped over; the sweep continues.
 - **One broken vault does not blind the others.** A signal that errors becomes a DEGRADED result for
   that vault and the sweep carries on.
+- **Cold start sees no history.** With the default `LOG_LOOKBACK_BLOCKS=0`, the first sweep scans a
+  single block, so `ModuleCallFailed`, `SliceEscrowed`, and fee outflows from *before* the canary
+  started are never reported. That is deliberate — starting a monitor should not replay a backlog as
+  fresh pages — but if you are standing the canary up after a vault has been live for a while, set
+  `LOG_LOOKBACK_BLOCKS` to cover the gap for the first run. The level signals (a–d) read current
+  state and are complete from the first sweep regardless.
 - **Sizing.** A sweep is `O(vaults × basket assets × oracle sources)` reads. The default 30s cadence
   is comfortable for a handful of vaults on a normal RPC; raise `CANARY_POLL_INTERVAL_MS` before
   raising your rate limit.

--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -1,0 +1,290 @@
+# Canary — post-launch monitoring
+
+The canary watches a deployed vault set and **stays silent while healthy**. It prints one line per
+signal *transition* (OK→ALERT, ALERT→OK, OK→DEGRADED), so anything it says is worth reading. It is
+the runnable form of the signal table in [DEPLOYMENT.md §6](DEPLOYMENT.md).
+
+It is **strictly read-only**: a viem *public* client, `eth_call` / `eth_getLogs` /
+`eth_blockNumber` / `eth_getBlockByNumber` and nothing else. There is no wallet client, no account,
+and no key anywhere in `packages/canary`. It reads the indexer's snapshot but never writes it — its
+own transition state lives at a separate path.
+
+```bash
+RPC_URL=… OPERATOR_REGISTRY_ADDRESS=… STATE_PATH=./data/indexer-state.json npm run start:canary
+```
+
+---
+
+## 1. What it needs
+
+| Var | Required | Default | Meaning |
+|---|---|---|---|
+| `RPC_URL` | ✅ | — | Base (or Base Sepolia) HTTP RPC endpoint |
+| `STATE_PATH` | | `./data/indexer-state.json` | the indexer snapshot; the vault set is discovered from it |
+| `VAULTS` | | — | explicit comma-separated vault list, to run without an indexer |
+| `OPERATOR_REGISTRY_ADDRESS` | | — | enables the fee-routing signal |
+| `EXTRA_OPERATOR_ADDRESSES` | | — | extra operator addresses to treat as prohibited fee destinations |
+| `CANARY_STATE_PATH` | | `./data/canary-state.json` | transition state, so a restart does not re-page |
+| `ALERT_WEBHOOK_URL` | | — | POST one JSON body per transition |
+| `CANARY_POLL_INTERVAL_MS` | | `30000` | sweep cadence (named apart from the indexer's `POLL_INTERVAL_MS` — compose feeds both one `.env`, and a sweep is heavier than an indexer poll) |
+| `CONFIRMATIONS` | | `5` | blocks to lag head, matching the indexer |
+| `NAV_DIVERGENCE_BPS` | | `50` | NAV composition bar, 50 = 0.5% |
+| `ORACLE_MIN_MARGIN` | | `0` | alert when `freshSources - quorum <= this` |
+| `MAX_LOG_SPAN_BLOCKS` | | `2000` | cap on one sweep's `getLogs` range |
+| `LOG_LOOKBACK_BLOCKS` | | `0` | cold-start event lookback |
+| `HEARTBEAT_MS` | | `0` (off) | periodic "still watching" line, so silence is provably alive |
+
+**Signals (c) and (d) need the indexer projection.** With `VAULTS` alone and no snapshot they report
+DEGRADED, not OK — see §4.
+
+---
+
+## 2. Reading the output
+
+```
+2026-08-19T04:12:07.881Z ALERT [exit-liveness] EXIT LIVENESS BROKEN on vault 0xa1a1…cafe (H-1
+regression): requestExit(1) as member 0x6666…6666 reverts with Reentrancy — a non-gate revert
+means members cannot exit (measured Reentrancy, threshold no non-gate revert)
+```
+
+Every line carries the **vault**, the **signal**, and **measured vs threshold**. Alerts and
+degradations go to stderr, recoveries to stdout, so `2>` gives a pure problem feed. The webhook body
+carries the same fields plus the structured `detail` for routing.
+
+Three statuses:
+
+- **ALERT** — measured, out of threshold. Page.
+- **RECOVERED** — back within threshold.
+- **DEGRADED** — the check could not run at all. Deliberately *not* folded into OK: a sentinel that
+  has stopped being able to run is exactly the thing you would otherwise never notice.
+
+A standing problem is reported **once**, not every poll, and the state survives a restart.
+
+---
+
+## 3. The signals
+
+### (a) `oracle-freshness` — margin to the staleness breaker
+
+**What it measures.** Per basket asset: `margin = freshSources - quorum`, where a source is fresh iff
+`latestPrice()` returns `priceWad > 0` and `updatedAt >= chainNow - maxStaleness`. This reproduces
+`OracleAggregator.priceWad` exactly, including that a *reverting* source is simply not fresh. The
+clock is chain time, never the monitoring host's.
+
+**Threshold.** ALERT when `margin <= 0` (`ORACLE_MIN_MARGIN`).
+
+- `margin < 0` — the breaker is **already tripped**; `priceWad` reverts and every NAV path in the
+  vault, **including exits**, is frozen.
+- `margin == 0` — any single further source failure freezes the vault.
+
+> The bar is `<= 0` on purpose. A vault on the protocol floor (3 sources, `quorum` 2) sits at
+> margin 1 when perfectly healthy — it takes *two* failures to trip. Paging on margin 1 would page
+> forever and get the canary muted. Set `ORACLE_MIN_MARGIN=1` if you want the earlier warning.
+
+**When it fires.** Identify which sources went stale from `detail.staleSources`, then chase the feed
+operator. **There is no contract-side remedy** — the breaker is immutable and has no hatch by
+design ([SF-2 / K-4](THREAT-MODEL.md)); any exit-during-staleness escape *is* the stale-price exit
+the breaker exists to prevent. Restoring quorum on the sources is the only fix. Meanwhile: pending
+(observation-window) capital is **not** trapped — `cancelPending` reads no oracle — so tell members
+with un-activated deposits they can still reclaim them.
+
+Threat-model rows: [SF-1](THREAT-MODEL.md) (source independence), [SF-2](THREAT-MODEL.md) (the
+accepted freeze).
+
+### (b) `nav-backing` — is NAV actually backed?
+
+Two independently-keyed legs.
+
+**`composition`** recomputes `navWad()` from the vault's own component getters and compares. The
+recompute mirrors `VaultCore.navWad()` exactly, including the SV-7 look-through: descendants are
+valued from their *internal* `assetBalance`, priced through **this** vault's oracle and
+`assetUnit`/`usdcScalar`, recursing to `MAX_LOOKTHROUGH_DEPTH = 3`, multiply-then-divide so the
+truncation matches. Every read is pinned to one block height, so a healthy vault diverges by
+**exactly 0** — this is an invariant check, not an estimate.
+
+- **Threshold.** ALERT above `NAV_DIVERGENCE_BPS` (default 50 = 0.5%). Any nonzero divergence below
+  the bar still appears in `detail.divergenceBps` and is worth a look.
+- **What it catches.** A look-through that drops descendant value from the root (the shape of S6
+  Finding 1), a basket asset the oracle cannot price, a child whose share accounting moved under its
+  parent, an `assetUnit` that does not match a token's real decimals.
+
+**`custody`** compares internal accounting against the token balances the vault actually holds:
+`balanceOf(vault) >= idleUsdc + totalPendingUsdc` for USDC, and `balanceOf(vault) >= assetBalance[a]`
+per basket asset. **One-sided on purpose.** A *surplus* never alerts — donations, EE-6 escrowed
+in-kind slices, and EE-1 observation-window capital all sit in the token balance without being in
+NAV. A **shortfall** alerts: the vault believes it owns more than it holds.
+
+**When composition fires.** Compare `detail.navWad` against `detail.recomputedWad`. If the recompute
+is *higher*, value is being dropped from the reported NAV (look-through or pricing). If reported is
+higher, NAV is overstated and every `navPerShareWad` consumer — deposits minting shares, exits
+paying out — is mispricing. Treat an overstatement as capital-affecting: stop directing new deposits
+at the vault and reconcile before anything else.
+
+**When custody fires.** This is the serious one. Reconcile `detail.shortfalls` — token, `owed`
+(internal accounting), `held` (actual balance). A USDC shortfall on a vault whose address has been
+blacklisted is [PX-1](THREAT-MODEL.md), documented and accepted, not a bug; anything else means
+tokens left the vault without the accounting following.
+
+Threat-model rows: [EE-1](THREAT-MODEL.md), [SV-7](THREAT-MODEL.md), [PX-1](THREAT-MODEL.md).
+
+### (c) `share-conservation` — indexer vs chain
+
+**What it measures.** Against one chain read of `totalShares()`: the projection's folded
+`totalShares`, and the sum of its per-member share book. Either disagreeing alerts.
+
+**Threshold.** Exactly 0. Shares are conserved or they are not.
+
+**The height problem, and how it is handled.** The indexer lags head by `CONFIRMATIONS`, so comparing
+it against a `latest` read would false-alarm on every deposit in the confirmation window. The chain
+read is therefore **pinned to the snapshot's own `lastBlock`**. If the RPC cannot serve state at that
+height (a pruned, non-archive node) the check falls back to `latest`, marks itself `pinned: false`,
+and asks the runner for **two consecutive** observations before paging — alive on a pruned node
+rather than silently dead, without paging on ordinary lag.
+
+**When it fires.** Check `detail.pinned` first. If false, the mismatch may still be lag on a busy
+chain — point `RPC_URL` at an archive node for a definitive answer. If pinned, one of two things is
+true: the **indexer** missed or double-counted a `DepositActivated`/`ExitSettled` (re-index from the
+factory deploy block and see if it reconciles), or the **chain** state is genuinely inconsistent with
+its own event history, which is a contract-level finding and escalates immediately.
+
+### (d) `exit-liveness` — the H-1 regression sentinel
+
+**What it measures.** Static-calls `requestExit(shares)` **as a real member** and classifies the
+revert. The member comes from the indexer's share book (a non-creator holder preferred, since the
+creator hits the CM-1 stake gate); the amount is clamped to their balance.
+
+Why "as a real member" is load-bearing: `requestExit` reverts `ZeroAmount` on 0 shares and
+`InsufficientShares` unless the caller holds them. **Probing from an arbitrary address would revert
+with a gate error every time and the sentinel would report healthy forever while exits were
+bricked.** That is the failure mode this signal is designed against, and `test/exit-liveness.test.mjs`
+pins it.
+
+Three-way classification:
+
+| Revert | Status | Why |
+|---|---|---|
+| `ZeroAmount`, `InsufficientShares`, `ExitAlreadyQueued`, `CreatorStakeGate`, `ExitNeedsChildSettlement`, `ChildSettlementPending` | **OK** | gates on the caller's own position — expected |
+| `StaleOracle` | **DEGRADED** | the SF-2/K-4 breaker. By design, but it *is* a live capital freeze, so it never reads as OK. Attributed to the oracle signal, which pages for it — one root cause, one page |
+| anything else — `Reentrancy`, `Panic`, `Error(string)`, an unrecognized selector, or **empty returndata** | **ALERT** | a non-gate revert means members cannot exit |
+
+Empty returndata is the actual H-1 signature — a creator-chosen module that ran out of its 300k gas
+cap or bombed returndata. There is deliberately **no** "could not classify, assume healthy" branch.
+
+**Threshold.** No non-gate revert.
+
+**When it fires.** Members cannot leave. Check the `module-events` signal on the same vault: a
+concurrent `ModuleCallFailed` names the module that broke. `VaultCore` gas-caps module calls and
+falls back to Mode I on governance failure ([MO-1](THREAT-MODEL.md)), so a non-gate revert here
+means a mitigation has regressed — this is an escalate-now finding, not a watch item. There is no
+upgrade path on a deployed vault; the remedy is a contract fix on the *next* deployment plus getting
+members out of this one however the surviving paths allow.
+
+Threat-model row: [MO-1](THREAT-MODEL.md) (review H-1).
+
+### (e) `module-events` — ModuleCallFailed + SliceEscrowed
+
+**What it measures.** Both events over the poll window. Neither is folded by the indexer's
+projection, so the canary reads them itself.
+
+- `ModuleCallFailed(module, member)` — a creator-chosen bookkeeping module misbehaved on the exit
+  path. The exit still settled (the mitigation working) but the module's bookkeeping was
+  **forfeited**; for the `feeEngine.*` paths that means an operator's fee accounting silently did not
+  happen. It is also the leading indicator for signal (d).
+- `SliceEscrowed(member, asset, amount)` — an in-kind transfer failed, so that asset's slice was set
+  aside as `claimable` rather than reverting the whole redemption (EE-6 / MO-2). Also the mitigation
+  working — and also worth knowing, because a token that keeps failing transfers leaves members
+  holding claims instead of assets.
+
+**Threshold.** 0 events per window.
+
+**Shape.** This is an *occurrence* signal, not a level. One burst produces exactly two lines: the
+alert naming the events, then a recovery on the next quiet window. The recovery means "no further
+failures in the following window", **not** "the earlier failure was resolved."
+
+**When it fires.** `detail.moduleCallFailed[].module` is the decoded label
+(`feeEngine.onRealize`, `feeEngine.onFeeCollected`, `feeEngine.onFeeCollectedAsset`). Repeated
+failures on one module mean that module is broken for this vault — reconcile the operator's fee
+accounting by hand, and treat it as a strong hint to re-check signal (d). Repeated `SliceEscrowed`
+for one asset means that token is failing transfers; tell affected members to `claimEscrowed`.
+
+Threat-model rows: [MO-1](THREAT-MODEL.md), [MO-2](THREAT-MODEL.md), [EE-6](THREAT-MODEL.md).
+
+### (f) `fee-routing` — USDC straight to an operator
+
+**What it measures.** USDC `Transfer` logs with `from = vault` and `to` = a **registered operator
+address** (`operatorAddressOf(operatorOf(vault))`, plus `EXTRA_OPERATOR_ADDRESSES`).
+
+The invariant ([EE-9](THREAT-MODEL.md) / [MO-4](THREAT-MODEL.md)): performance fees reach the
+operator **only** through the FeeEngine — vault transfers to the engine, engine credits
+`claimableFees[operator]`, operator calls `claimFees`. Exit fees never route to the operator at all;
+they accrue to remaining members through the share price.
+
+**Operator-as-member is legitimate and is excused.** EE-9 says so explicitly: an operator who is also
+a member receives their pro-rata share like anyone else, because the prohibition is on *routing*, not
+identity. A transfer to the operator address is only a violation if there is no
+`ExitSettled(member=operator)` or `PendingCancelled(member=operator)` **in the same block**. Without
+that discriminator this signal would page every time an honest operator exited their own position.
+
+**Threshold.** 0 unexcused direct transfers.
+
+**Why this is the narrow check.** An inverse allowlist — alert on any destination that is not the
+engine, a member, a child, or an adapter — would fire on ordinary exit payouts to members the indexer
+has not projected yet, on rebalance transfers to adapters, and on `cancelPending` refunds. That
+signal cries wolf and gets muted, which is worse than not having it. This one alerts on exactly the
+destination the threat model prohibits. If you want the broad sweep, run it as a separate
+informational feed, not as the pager.
+
+**When it fires.** `detail.transfers[]` gives tx hash, block, and amount. Fees leaving to the
+operator outside the claim flow is a value-extraction finding: reconcile against `FeeCredited` /
+`FeesClaimed` on the FeeEngine for the same period, and treat the vault as compromised until the
+transfers are explained.
+
+---
+
+## 4. Signals that cannot run
+
+A DEGRADED line is not a false alarm to be tuned away — it means a check is **not covering** the
+vault. The cases:
+
+| Line | Cause | Fix |
+|---|---|---|
+| `exit-liveness sentinel CANNOT RUN … no member holding shares` | the projection lists no holder to probe with | wait for the first deposit, or check the indexer is caught up |
+| `… not in the indexer projection` | the vault is in `VAULTS` but not in the snapshot | point `STATE_PATH` at a caught-up indexer, or set `START_BLOCK` to the factory deploy block so the vault is discovered |
+| `… reverts StaleOracle` (NAV, exit liveness) | the oracle breaker is tripped | signal (a) is paging for the real cause; coverage resumes when the breaker clears |
+| `vault … is unreadable` | wrong address, wrong chain, or the RPC is failing | check `RPC_URL`/`CHAIN_ID` and the address |
+| `no vaults to watch` | empty watch set | set `VAULTS`, or point `STATE_PATH` at a snapshot that has seen a `VaultCreated` |
+
+An empty watch set is reported loudly rather than read as a clean bill of health.
+
+---
+
+## 5. Operating notes
+
+- **Silence is the healthy state**, which makes "is it alive?" a fair question. Set `HEARTBEAT_MS`
+  (e.g. `3600000`) for an hourly one-line summary of vault count, signals tracked, and how many are
+  not OK.
+- **Restarts do not re-page.** Transition state persists to `CANARY_STATE_PATH` (atomic
+  write-temp-then-rename, same discipline as the indexer snapshot). Delete that file to force a fresh
+  report of everything currently wrong.
+- **A paging outage is not a monitoring outage.** A webhook that throws, times out, or returns 500 is
+  logged and stepped over; the sweep continues.
+- **One broken vault does not blind the others.** A signal that errors becomes a DEGRADED result for
+  that vault and the sweep carries on.
+- **Sizing.** A sweep is `O(vaults × basket assets × oracle sources)` reads. The default 30s cadence
+  is comfortable for a handful of vaults on a normal RPC; raise `CANARY_POLL_INTERVAL_MS` before
+  raising your rate limit.
+
+## 6. Tests
+
+`npm run test:backend` includes `packages/canary/test/*.test.mjs` — 113 tests, every one with a
+mocked client. **No live RPC in CI.** Both a healthy and an alerting fixture exist for every signal.
+
+Two guards worth knowing about:
+
+- `test/abis.test.mjs` recomputes every embedded 4-byte selector with viem and cross-checks the
+  watched events, the views, and the gate errors against the **compiled** `VaultCore` ABI. A stale
+  gate selector would file a live fault as a benign gate and silence the H-1 sentinel, so this is not
+  optional bookkeeping. It skips gracefully when `contracts/out` or viem is absent.
+- `test/reader.test.mjs` asserts the chain reader exposes no send/sign/write surface, and
+  `test/abis.test.mjs` asserts the ABI table declares no non-`view` function. The read-only claim is
+  enforced, not just documented.

--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -256,6 +256,19 @@ vault. The cases:
 
 An empty watch set is reported loudly rather than read as a clean bill of health.
 
+**Event scan gaps.** If the canary is down long enough that the backlog exceeds
+`MAX_LOG_SPAN_BLOCKS`, it scans the most recent window and moves on — the older blocks are never
+scanned for `ModuleCallFailed`, `SliceEscrowed`, or fee outflows. It says so explicitly:
+
+```
+canary: event scan gap — blocks 996-1984 (989 blocks) were NOT scanned for
+ModuleCallFailed/SliceEscrowed/fee outflows. The backlog exceeded MAX_LOG_SPAN_BLOCKS=10;
+raise it or scan that range manually.
+```
+
+The level signals (a–d) read current state and are unaffected. Only the two window-scoped event
+signals have the hole. Raise `MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
+
 ---
 
 ## 5. Operating notes

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -99,7 +99,15 @@ Run each check against the live addresses:
 
 ## 6. Canary monitoring (post-launch)
 
-Watch continuously; page on any breach:
+Watch continuously; page on any breach. Every row below is implemented in `packages/canary` and runs
+as a service — see **[CANARY.md](CANARY.md)** for thresholds, tuning, and the response to each:
+
+```bash
+RPC_URL=… OPERATOR_REGISTRY_ADDRESS=… STATE_PATH=./data/indexer-state.json npm run start:canary
+```
+
+It is silent while healthy, emits one line per signal transition, and is read-only against the chain
+(no key, never sends). `docker compose up` starts it alongside the indexer and API.
 
 | Signal | Alert condition |
 | --- | --- |
@@ -108,7 +116,7 @@ Watch continuously; page on any breach:
 | Share conservation | `Σ sharesOf != totalShares` (indexer vs. chain read) |
 | Exit liveness | any `requestExit` reverting for a non-gate reason (H-1 regression sentinel) |
 | Fee routing | any USDC leaving a vault to an operator address outside the FeeEngine claim flow |
-| Module-call failures | `ModuleCallFailed` events (a creator-chosen module misbehaving) |
+| Module-call failures | `ModuleCallFailed` and `SliceEscrowed` events (a creator-chosen module or a basket token misbehaving) |
 
 ## 7. Mainnet gate
 

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -22,12 +22,12 @@ produces the addresses this guide consumes, [TESTNET-CHECKLIST.md](TESTNET-CHECK
 ```
    Base RPC ──logs──▶  indexer  ──snapshot file──▶  API  ──HTTP/x402──▶  web
  (viem getLogs)     (index-runner.mjs)  (JSON)   (serve.mjs)          (index.html?api=)
-                                                     │
-                                          verifyAndSettle │ (no key here)
-                                                     ▼
-                                            facilitator (external)
-                                          verifies EIP-712 sig + settles
-                                          USDC.transferWithAuthorization
+       │                                   │             │
+       │                          (reads)  │    verifyAndSettle │ (no key here)
+       │                                   ▼             ▼
+       └──eth_call / eth_getLogs──▶      canary    facilitator (external)
+              (read-only)         (canary-runner.mjs)  verifies EIP-712 sig + settles
+                                  alerts on transition  USDC.transferWithAuthorization
 ```
 
 - The **indexer** reads real logs from a Base RPC via viem, folds them into projection state, and
@@ -37,6 +37,11 @@ produces the addresses this guide consumes, [TESTNET-CHECKLIST.md](TESTNET-CHECK
   to verify+settle each payment.
 - The **facilitator** is where settlement (and the only key) lives. In production this is a
   **remote HTTP facilitator** you point the API at. You may also run your own settler (§6).
+- The **canary** watches the deployed contracts for the [DEPLOYMENT §6](DEPLOYMENT.md) signals and
+  alerts on transitions. It reads the chain directly (`eth_call`/`eth_getLogs`) and reads — never
+  writes — the indexer snapshot, which two of its signals compare against chain state. It is
+  read-only on top of being keyless: no wallet client, no account, never sends a transaction. Full
+  guide in [CANARY.md](CANARY.md).
 - The **web** app is self-contained demo by default; with `?api=<url>` it renders live data.
 
 **Wiring order** (each step needs the previous one's output):
@@ -46,6 +51,8 @@ produces the addresses this guide consumes, [TESTNET-CHECKLIST.md](TESTNET-CHECK
 2. Start the **indexer** with the RPC + those addresses. Let it catch up.
 3. Start the **API** pointed at the same snapshot file + a facilitator + the USDC price.
 4. Open the **web** app with `?api=<api-url>` (or ship the API URL into a deployed build).
+5. Start the **canary** against the same RPC + snapshot, once the indexer has caught up. It is
+   independent of the API and the web app — run it from step 2 onward if you prefer.
 
 ---
 
@@ -179,6 +186,25 @@ Production notes:
 | `RELOAD_MS` | | `5000` | snapshot re-read cadence |
 | `CORS` | | off | `1`/`true` to enable CORS + preflight (browser live mode) |
 
+### Canary (`npm run start:canary`)
+
+Read-only post-launch monitor — see [CANARY.md](CANARY.md) for what each signal means and what to do
+when one fires. Reuses `RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `CONFIRMATIONS`, `STATE_PATH`, and
+`OPERATOR_REGISTRY_ADDRESS` from the indexer block above.
+
+| Var | Required | Default | Meaning |
+|---|---|---|---|
+| `RPC_URL` | ✅ | — | Base HTTP RPC endpoint |
+| `STATE_PATH` | | `./data/indexer-state.json` | indexer snapshot; the vault set is discovered from it (read-only) |
+| `VAULTS` | | — | explicit vault list, to run without an indexer |
+| `OPERATOR_REGISTRY_ADDRESS` | | — | enables the fee-routing signal |
+| `CANARY_STATE_PATH` | | `./data/canary-state.json` | its OWN transition state — never the indexer's |
+| `CANARY_POLL_INTERVAL_MS` | | `30000` | sweep cadence; named apart from the indexer's `POLL_INTERVAL_MS` |
+| `ALERT_WEBHOOK_URL` | | — | POST one JSON body per transition |
+| `NAV_DIVERGENCE_BPS` | | `50` | NAV composition bar, 50 = 0.5% |
+| `ORACLE_MIN_MARGIN` | | `0` | alert when fresh sources minus quorum <= this |
+| `HEARTBEAT_MS` | | `0` (off) | periodic "still watching" line |
+
 The `PRICE_ASSET`/`PRICE_NETWORK`/`CHAIN_ID` must agree across the API and whatever wallet/agent
 pays: the challenge binds the payment to that exact asset + network.
 
@@ -206,6 +232,11 @@ id returned to the client is the settlement tx hash.
 ## 7. Non-custodial guarantees
 
 - The **indexer** is read-only: `getLogs` and `getBlockNumber` only. It never signs or sends.
+- The **canary** is read-only too: `eth_call`, `eth_getLogs`, `eth_blockNumber`,
+  `eth_getBlockByNumber`. It builds a viem *public* client — there is no wallet client, no account,
+  and no key in `packages/canary`. Its `requestExit` probe is an `eth_call` with an impersonated
+  `from`, which never touches a key and never changes chain state. Enforced by tests, not just
+  documented.
 - The **API** holds no key. It only asks a facilitator to `verifyAndSettle`; it serves the resource
   when settlement succeeds. USDC moves via EIP-3009 executed **by the facilitator**, from payer to
   `payTo`, never through the API.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "scripts": {
     "build:contracts": "cd contracts && forge build",
     "test:contracts": "cd contracts && forge test -vv",
-    "test:backend": "node --test packages/indexer/test/*.test.mjs packages/agent-sdk/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs",
+    "test:backend": "node --test packages/indexer/test/*.test.mjs packages/canary/test/*.test.mjs packages/agent-sdk/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs",
     "start:indexer": "node packages/indexer/src/index-runner.mjs",
-    "start:api": "node apps/api/src/serve.mjs"
+    "start:api": "node apps/api/src/serve.mjs",
+    "start:canary": "node packages/canary/src/canary-runner.mjs"
   },
   "dependencies": {
     "viem": "^2.21.0"

--- a/packages/canary/README.md
+++ b/packages/canary/README.md
@@ -1,0 +1,61 @@
+# @vault/canary
+
+Read-only post-launch watcher for a deployed vault set. Silent while healthy; one line per signal
+transition otherwise.
+
+Full operator guide — what each signal means, its threshold, and what to do when it fires — is in
+[docs/CANARY.md](../../docs/CANARY.md). This file is the code map.
+
+```bash
+RPC_URL=… OPERATOR_REGISTRY_ADDRESS=… STATE_PATH=./data/indexer-state.json npm run start:canary
+```
+
+## Non-custodial, and read-only on top of that
+
+The indexer and API are non-custodial (no keys). The canary is that **plus** read-only against the
+chain: it builds a viem *public* client and issues only `eth_blockNumber`, `eth_getBlockByNumber`,
+`eth_call`, and `eth_getLogs`. There is no wallet client, no account, no `PRIVATE_KEY` read, and no
+ABI fragment for a state-changing function anywhere in this package — `requestExit` appears solely to
+build calldata for `eth_call`, which never touches a key.
+
+Both claims are tested rather than asserted: `test/reader.test.mjs` checks the reader exposes no
+send/sign surface, and `test/abis.test.mjs` checks every declared function fragment is `view`.
+
+It also never writes the indexer's snapshot. That file is opened read-only; transition state lives at
+its own `CANARY_STATE_PATH`.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `src/canary-runner.mjs` | entrypoint: env config, the sweep, the poll loop |
+| `src/reader.mjs` | the only file that talks to an RPC; lazy/optional viem, same pattern as the indexer's `rpc.mjs` |
+| `src/abis.mjs` | views, watched events, and the embedded revert selectors — kept separate from the indexer's table on purpose (see the file header) |
+| `src/signal.mjs` | the `ok` / `alert` / `skipped` result vocabulary and integer bps math |
+| `src/transitions.mjs` | pure transition detection — the piece that makes the canary quiet |
+| `src/sinks.mjs` | console + optional webhook; a sink failure never propagates |
+| `src/signals/*.mjs` | one file per signal, each a pure function over an injected reader |
+
+## Design notes
+
+**Every signal is a pure function over an injected reader.** Nothing reaches for a global client, so
+every test injects a plain object literal and the suite needs no RPC. The reader interface is the
+five methods documented at the top of `src/reader.mjs`.
+
+**Three statuses, not two.** `skipped` exists because a check that *cannot run* has not passed. The
+exit-liveness sentinel with no member to probe with, or a NAV check behind a tripped oracle breaker,
+reports DEGRADED — never a false OK.
+
+**One root cause, one page.** A tripped oracle breaker makes `navWad()` and `requestExit` revert too.
+Those two attribute their `StaleOracle` reverts to the oracle signal and go DEGRADED, so the operator
+gets one alert instead of three.
+
+## Tests
+
+```bash
+node --test packages/canary/test/*.test.mjs
+```
+
+113 tests, all mocked. `test/helpers.mjs` carries the shared fixture: `healthyVault()` is healthy on
+every signal, so each test perturbs exactly one thing and proves the signal reacts to that and
+nothing else.

--- a/packages/canary/src/abis.mjs
+++ b/packages/canary/src/abis.mjs
@@ -1,0 +1,161 @@
+// @ts-check
+/**
+ * The read-only surface the canary touches: view functions, watched events, and the 4-byte
+ * selectors the exit-liveness sentinel classifies revert data with.
+ *
+ * DELIBERATELY SEPARATE from packages/indexer/src/abis.mjs. The indexer's table is asserted
+ * against `HANDLED_EVENTS` by its event-coverage test — adding ModuleCallFailed / SliceEscrowed
+ * there would fail that test, because the projection does not fold them. The canary watches
+ * events the projection ignores, so it carries its own table.
+ *
+ * Nothing here is state-changing. There is no ABI fragment in this file for any non-`view`
+ * function except `requestExit`, and that one exists ONLY to build calldata for `eth_call`
+ * (see signals/exit-liveness.mjs) — the canary never sends a transaction and holds no key.
+ *
+ * Selectors are EMBEDDED rather than computed so this module needs no keccak implementation and
+ * no viem at import time. test/abis.test.mjs recomputes every one of them with viem and fails on
+ * drift — the same guard the indexer's ABI table uses.
+ */
+
+/** @typedef {{type:'event', name:string, anonymous:boolean, inputs:Array<{name:string,type:string,indexed:boolean}>}} AbiEvent */
+
+const ev = (name, inputs) => ({ type: 'event', name, anonymous: false, inputs });
+const addr = (name, indexed = false) => ({ name, type: 'address', indexed });
+const u256 = (name, indexed = false) => ({ name, type: 'uint256', indexed });
+const view = (name, inputs, outputs) => ({
+  type: 'function',
+  name,
+  stateMutability: 'view',
+  inputs: inputs.map((t, i) => (typeof t === 'string' ? { name: `a${i}`, type: t } : t)),
+  outputs: outputs.map((t, i) => (typeof t === 'string' ? { name: `o${i}`, type: t } : t)),
+});
+
+/** VaultCore views the NAV / share / basket signals read. All `view`, all free. */
+export const VAULT_VIEWS = Object.freeze([
+  view('navWad', [], ['uint256']),
+  view('totalShares', [], ['uint256']),
+  view('idleUsdc', [], ['uint256']),
+  view('usdcScalar', [], ['uint256']),
+  view('usdc', [], ['address']),
+  view('oracle', [], ['address']),
+  view('feeEngine', [], ['address']),
+  view('creator', [], ['address']),
+  view('operatorRegistry', [], ['address']),
+  view('basketLength', [], ['uint256']),
+  view('basketAssets', ['uint256'], ['address']),
+  // assetUnit and assetBalance are PUBLIC mappings on VaultCore, so the canary reads the very
+  // same numbers navWad() multiplies — it re-derives nothing and assumes no token's decimals.
+  view('assetUnit', ['address'], ['uint256']),
+  view('assetBalance', ['address'], ['uint256']),
+  view('childVaultCount', [], ['uint256']),
+  view('childVaults', ['uint256'], ['address']),
+  view('sharesOf', ['address'], ['uint256']),
+  view('totalPendingUsdc', [], ['uint256']),
+]);
+
+/** OracleAggregator: the immutable per-asset source config the freshness margin is measured against. */
+export const ORACLE_VIEWS = Object.freeze([
+  view('priceWad', ['address'], ['uint256']),
+  view('assetConfig', ['address'], [
+    { name: 'sources', type: 'address[]' },
+    { name: 'maxStaleness', type: 'uint32' },
+    { name: 'quorum', type: 'uint8' },
+  ]),
+  view('assets', ['uint256'], ['address']),
+]);
+
+/** IPriceSource — polled per source to count how many are fresh right now. */
+export const PRICE_SOURCE_VIEWS = Object.freeze([
+  view('latestPrice', [], [
+    { name: 'priceWad', type: 'uint256' },
+    { name: 'updatedAt', type: 'uint256' },
+  ]),
+]);
+
+/** OperatorRegistry: maps a vault to the operator address fees must NEVER be paid to directly. */
+export const OPERATOR_REGISTRY_VIEWS = Object.freeze([
+  view('operatorOf', ['address'], ['uint256']),
+  view('operatorAddressOf', ['uint256'], ['address']),
+  view('operatorIdOf', ['address'], ['uint256']),
+]);
+
+/** ERC20 balance reads — the independent custody leg of the NAV-backing signal. */
+export const ERC20_VIEWS = Object.freeze([
+  view('balanceOf', ['address'], ['uint256']),
+]);
+
+/** ERC20 Transfer — the fee-routing signal's only log input. */
+export const ERC20_TRANSFER_EVENT = Object.freeze(
+  ev('Transfer', [addr('from', true), addr('to', true), u256('value')]),
+);
+
+/**
+ * VaultCore events the canary watches but the indexer's projection does not fold.
+ *
+ * `ModuleCallFailed.module` is a raw bytes32 holding a right-zero-padded ASCII label
+ * ("feeEngine.onRealize", "feeEngine.onFeeCollected", "feeEngine.onFeeCollectedAsset") — a
+ * literal, not a hash. decodeModuleLabel() below turns it back into text for the alert line.
+ */
+export const VAULT_WATCH_EVENTS = Object.freeze([
+  ev('ModuleCallFailed', [{ name: 'module', type: 'bytes32', indexed: true }, addr('member', true)]),
+  ev('SliceEscrowed', [addr('member', true), addr('asset', true), u256('amount')]),
+]);
+
+/** ExitSettled — not folded here, but needed to tell an operator's honest exit payout from a fee leak. */
+export const EXIT_SETTLED_EVENT = Object.freeze(
+  ev('ExitSettled', [
+    addr('member', true), u256('sharesBurned'), u256('usdcPaid'),
+    u256('exitFeeBps'), u256('perfFeeUsdc'),
+  ]),
+);
+
+/** `requestExit(uint256)` — eth_call ONLY. Never signed, never broadcast. */
+export const REQUEST_EXIT_SELECTOR = '0x721c6513';
+
+/**
+ * Revert selectors, classified for the H-1 exit-liveness sentinel.
+ *
+ * GATE — the caller's own position makes the call invalid. Expected, healthy, not an alert.
+ * FROZEN — the oracle staleness breaker (SF-2/K-4). By design, but it IS a live capital freeze,
+ *   so it gets its own status and is attributed to the oracle signal rather than reported as OK.
+ * Anything else — including empty returndata and an unrecognized selector — is the H-1
+ *   signature (a creator-chosen module reverting, gas-guzzling, or bombing returndata) and
+ *   ALERTS. There is no "could not classify, assume healthy" branch, on purpose.
+ */
+export const EXIT_GATE_SELECTORS = Object.freeze({
+  '0x1f2a2005': 'ZeroAmount',
+  '0xf2698fc0': 'ExitAlreadyQueued',
+  '0x39996567': 'InsufficientShares',
+  '0xa428ab2d': 'CreatorStakeGate',
+  '0x07b1ee59': 'ExitNeedsChildSettlement',
+  '0xb5ac4fd1': 'ChildSettlementPending',
+});
+
+export const EXIT_FROZEN_SELECTORS = Object.freeze({ '0xa2671f4b': 'StaleOracle' });
+
+/** Non-gate selectors we can NAME. Unnamed ones still alert — this only sharpens the message. */
+export const EXIT_FAULT_SELECTORS = Object.freeze({
+  '0xab143c06': 'Reentrancy',
+  '0xe752017c': 'NoQueuedExit',
+  '0x885cf1d7': 'ExecutionStillPending',
+  '0x08c379a0': 'Error(string)',
+  '0x4e487b71': 'Panic(uint256)',
+});
+
+/** Canonical `name(type,...)` signature for a fragment — used by the drift test. */
+export function signatureOf(fragment) {
+  return `${fragment.name}(${fragment.inputs.map((i) => i.type).join(',')})`;
+}
+
+/** Turn a right-zero-padded bytes32 string literal back into readable ASCII. */
+export function decodeModuleLabel(bytes32) {
+  if (typeof bytes32 !== 'string' || !bytes32.startsWith('0x')) return String(bytes32);
+  let out = '';
+  const hex = bytes32.slice(2);
+  for (let i = 0; i + 1 < hex.length; i += 2) {
+    const code = parseInt(hex.slice(i, i + 2), 16);
+    if (code === 0) break; // right-padded: the first zero byte ends the literal
+    out += String.fromCharCode(code);
+  }
+  return out || bytes32;
+}

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -1,0 +1,320 @@
+// @ts-check
+/**
+ * Runnable canary entrypoint. Point it at a deployed testnet and it stays SILENT until something
+ * is genuinely wrong: one line per signal TRANSITION (OK→ALERT, ALERT→OK, OK→DEGRADED), nothing
+ * at all while every signal is healthy.
+ *
+ * STRICTLY READ-ONLY. It builds a viem *public* client (see reader.mjs) and issues only
+ * eth_blockNumber / eth_getBlockByNumber / eth_call / eth_getLogs. It never sends a transaction,
+ * never signs anything, and holds no key — there is no wallet client, no account, and no
+ * PRIVATE_KEY read anywhere in packages/canary. It also never writes to the indexer's snapshot;
+ * that file is opened read-only, and the canary's own transition state lives at its own path.
+ *
+ * Required env:
+ *   RPC_URL                    Base (or Base Sepolia) HTTP RPC endpoint
+ * Vault discovery (one of):
+ *   STATE_PATH                 the indexer snapshot to read the vault set from
+ *                              (default ./data/indexer-state.json)
+ *   VAULTS                     comma-separated vault addresses, to run without an indexer.
+ *                              NOTE: signals (c) and (d) need the indexer's projection — with
+ *                              VAULTS only, they report DEGRADED rather than a false OK.
+ * Optional env:
+ *   OPERATOR_REGISTRY_ADDRESS  enables the fee-routing signal (skipped without it)
+ *   EXTRA_OPERATOR_ADDRESSES   comma-separated extra operator addresses to treat as prohibited
+ *   ALERT_WEBHOOK_URL          POST one JSON body per transition
+ *   CANARY_STATE_PATH (./data/canary-state.json)  transition state, so a restart does not re-page
+ *   CHAIN_ID (8453)  CHAIN_NAME (base)  CONFIRMATIONS (5)
+ *   CANARY_POLL_INTERVAL_MS (30000)  sweep cadence. Named apart from the indexer's
+ *                              POLL_INTERVAL_MS because docker-compose feeds both services one
+ *                              .env file, and a canary sweep is far heavier than an indexer poll.
+ *   NAV_DIVERGENCE_BPS (50)    composition-divergence bar, 50 = 0.5%
+ *   ORACLE_MIN_MARGIN (0)      alert when fresh-sources minus quorum <= this
+ *   LOG_LOOKBACK_BLOCKS (0)    on a cold start, how far back to scan for events
+ *   MAX_LOG_SPAN_BLOCKS (2000) cap on one poll's getLogs range
+ *   HEARTBEAT_MS (0)           if set, periodically print a one-line "still watching" summary
+ *
+ * Run: `RPC_URL=… STATE_PATH=… node packages/canary/src/canary-runner.mjs`
+ */
+
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { loadSnapshot } from '../../indexer/src/store.mjs';
+import { createChainReader } from './reader.mjs';
+import { createTransitionTracker } from './transitions.mjs';
+import { createConsoleSink, createWebhookSink, emitAll } from './sinks.mjs';
+import { VAULT_VIEWS } from './abis.mjs';
+import { skipped, shortAddr } from './signal.mjs';
+import { checkOracleFreshness } from './signals/oracle-freshness.mjs';
+import { checkNavBacking } from './signals/nav-backing.mjs';
+import { checkShareConservation } from './signals/share-conservation.mjs';
+import { checkExitLiveness } from './signals/exit-liveness.mjs';
+import { checkModuleEvents } from './signals/module-events.mjs';
+import { checkFeeRouting } from './signals/fee-routing.mjs';
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const lc = (a) => (typeof a === 'string' ? a.toLowerCase() : a);
+const list = (s) => String(s ?? '').split(',').map((x) => x.trim()).filter(Boolean);
+
+/**
+ * Parse + validate the canary config from a raw env object. Pure and testable (no I/O).
+ * @param {Record<string,string|undefined>} env
+ */
+export function resolveCanaryConfig(env) {
+  if (!env.RPC_URL) throw new Error('canary: missing required env: RPC_URL');
+
+  const num = (k, d) => (env[k] != null && env[k] !== '' ? Number(env[k]) : d);
+  const vaults = list(env.VAULTS).map(lc);
+  for (const v of vaults) {
+    if (!ADDRESS_RE.test(v)) throw new Error(`canary: VAULTS contains a non-address entry: ${v}`);
+  }
+  const extraOperators = list(env.EXTRA_OPERATOR_ADDRESSES).map(lc);
+  for (const a of extraOperators) {
+    if (!ADDRESS_RE.test(a)) throw new Error(`canary: EXTRA_OPERATOR_ADDRESSES contains a non-address entry: ${a}`);
+  }
+  const operatorRegistry = env.OPERATOR_REGISTRY_ADDRESS ? lc(env.OPERATOR_REGISTRY_ADDRESS) : null;
+  if (operatorRegistry && !ADDRESS_RE.test(operatorRegistry)) {
+    throw new Error(`canary: OPERATOR_REGISTRY_ADDRESS is not a 20-byte address: ${operatorRegistry}`);
+  }
+
+  return {
+    rpcUrl: env.RPC_URL,
+    chainId: num('CHAIN_ID', 8453),
+    chainName: env.CHAIN_NAME || 'base',
+    statePath: env.STATE_PATH || './data/indexer-state.json',
+    canaryStatePath: env.CANARY_STATE_PATH || './data/canary-state.json',
+    vaults,
+    operatorRegistry,
+    extraOperators,
+    webhookUrl: env.ALERT_WEBHOOK_URL || null,
+    confirmations: num('CONFIRMATIONS', 5),
+    pollIntervalMs: num('CANARY_POLL_INTERVAL_MS', 30_000),
+    navDivergenceBps: num('NAV_DIVERGENCE_BPS', 50),
+    oracleMinMargin: num('ORACLE_MIN_MARGIN', 0),
+    logLookbackBlocks: num('LOG_LOOKBACK_BLOCKS', 0),
+    maxLogSpanBlocks: num('MAX_LOG_SPAN_BLOCKS', 2000),
+    heartbeatMs: num('HEARTBEAT_MS', 0),
+  };
+}
+
+/** Atomic write, same write-temp-then-rename discipline the indexer's snapshot uses. */
+async function saveCanaryState(path, obj) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(obj), 'utf8');
+  await rename(tmp, path);
+}
+
+async function loadCanaryState(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { transitions: {}, lastScannedBlock: null };
+    throw err;
+  }
+}
+
+/**
+ * Run every signal over every watched vault ONCE and return the flat result list.
+ *
+ * Pure over its inputs in the way that matters: it touches the chain only through the injected
+ * `reader`, and reads the indexer projection only through the `state` object handed to it. A
+ * signal that throws is converted into a `skipped` result rather than aborting the sweep — one
+ * broken vault must not blind the operator to the other nine.
+ *
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {ReturnType<import('../../indexer/src/projections.mjs').emptyState>|null} ctx.state
+ * @param {string[]} ctx.vaults
+ * @param {ReturnType<typeof resolveCanaryConfig>} ctx.cfg
+ * @param {{fromBlock:number, toBlock:number, nowSec:number}} ctx.window
+ * @returns {Promise<import('./signal.mjs').SignalResult[]>}
+ */
+export async function collectSignals({ reader, state, vaults, cfg, window }) {
+  const out = [];
+  const { fromBlock, toBlock, nowSec } = window;
+
+  for (const vault of vaults) {
+    const projected = state?.vaults?.get(vault) ?? null;
+    const shareBook = state?.shares?.get(vault) ?? null;
+
+    /** Run one signal, converting a thrown error into a DEGRADED result instead of losing the sweep. */
+    const run = async (name, fn) => {
+      try {
+        out.push(...(await fn()));
+      } catch (err) {
+        out.push(skipped({
+          signal: name, vault,
+          message: `${name} check errored on vault ${shortAddr(vault)}: ${err?.message ?? err}`,
+          detail: { vault, error: String(err?.message ?? err) },
+        }));
+      }
+    };
+
+    // One config read per vault, shared by the signals that need it.
+    let meta = null;
+    try {
+      const [oracle, usdc, creator, basketLength] = await Promise.all([
+        reader.read(vault, VAULT_VIEWS, 'oracle'),
+        reader.read(vault, VAULT_VIEWS, 'usdc'),
+        reader.read(vault, VAULT_VIEWS, 'creator'),
+        reader.read(vault, VAULT_VIEWS, 'basketLength'),
+      ]);
+      const assets = [];
+      for (let i = 0; i < Number(basketLength); i += 1) {
+        assets.push(await reader.read(vault, VAULT_VIEWS, 'basketAssets', [i]));
+      }
+      meta = { oracle, usdc, creator, assets };
+    } catch (err) {
+      out.push(skipped({
+        signal: 'vault-config', vault,
+        message: `vault ${shortAddr(vault)} is unreadable at ${cfg.rpcUrl ? 'the configured RPC' : 'the injected client'}: ${err?.message ?? err} — every signal for this vault is suspended`,
+        detail: { vault, error: String(err?.message ?? err) },
+      }));
+      continue;
+    }
+
+    await run('oracle-freshness', () => checkOracleFreshness({
+      reader, vault, oracle: meta.oracle, assets: meta.assets, nowSec, minMargin: cfg.oracleMinMargin,
+    }));
+
+    await run('nav-backing', () => checkNavBacking({
+      reader, vault, atBlock: toBlock, thresholdBps: cfg.navDivergenceBps,
+    }));
+
+    if (projected) {
+      await run('share-conservation', () => checkShareConservation({
+        reader, vault,
+        projectedTotalShares: projected.totalShares,
+        shareBook,
+        atBlock: state?.lastBlock || undefined,
+      }));
+      await run('exit-liveness', () => checkExitLiveness({
+        reader, vault, shareBook, creator: meta.creator,
+      }));
+    } else {
+      // No projection for this vault. Say so — do NOT report these two as healthy.
+      for (const name of ['share-conservation', 'exit-liveness']) {
+        out.push(skipped({
+          signal: name, vault,
+          message: `${name} cannot run on vault ${shortAddr(vault)}: it is not in the indexer projection at ${cfg.statePath}. Point STATE_PATH at a caught-up indexer snapshot — this vault is unmonitored for that signal, not healthy`,
+          detail: { vault, reason: 'no-projection' },
+        }));
+      }
+    }
+
+    await run('module-events', () => checkModuleEvents({ reader, vault, fromBlock, toBlock }));
+
+    await run('fee-routing', () => checkFeeRouting({
+      reader, vault, usdc: meta.usdc,
+      operatorRegistry: cfg.operatorRegistry, extraOperators: cfg.extraOperators,
+      fromBlock, toBlock,
+    }));
+  }
+
+  return out;
+}
+
+/**
+ * Build a wired (but not started) canary. Returns `runOnce()` for a single sweep and `start()`
+ * for the forever loop.
+ */
+export async function buildCanary(cfg, { log = console.log, error = console.error, client, fetchImpl, now = () => new Date() } = {}) {
+  const reader = createChainReader({
+    client, rpcUrl: cfg.rpcUrl, chainId: cfg.chainId, chainName: cfg.chainName,
+  });
+
+  const persisted = await loadCanaryState(cfg.canaryStatePath);
+  const tracker = createTransitionTracker({ initial: persisted.transitions });
+  let lastScannedBlock = persisted.lastScannedBlock ?? null;
+  let poll = 0;
+
+  const sinks = [createConsoleSink({ log, error })];
+  if (cfg.webhookUrl) sinks.push(createWebhookSink({ url: cfg.webhookUrl, fetchImpl, onError: error }));
+
+  /** The vault set: explicit VAULTS if given, else every vault the indexer has projected. */
+  async function resolveVaults() {
+    if (cfg.vaults.length > 0) return { vaults: cfg.vaults, state: await tryLoadState() };
+    const state = await tryLoadState();
+    return { vaults: [...(state?.vaults?.keys() ?? [])], state };
+  }
+
+  async function tryLoadState() {
+    try {
+      return await loadSnapshot(cfg.statePath);
+    } catch (err) {
+      error(`canary: could not read the indexer snapshot at ${cfg.statePath}: ${err?.message ?? err}`);
+      return null;
+    }
+  }
+
+  /** One sweep: resolve the window, collect signals, emit only what changed, persist. */
+  async function runOnce() {
+    poll += 1;
+    const head = await reader.headBlock();
+    const toBlock = Math.max(0, head - cfg.confirmations);
+    const fromBlock = lastScannedBlock != null
+      ? Math.max(0, Math.min(lastScannedBlock + 1, toBlock))
+      : Math.max(0, toBlock - cfg.logLookbackBlocks);
+    const span = Math.min(toBlock - fromBlock, cfg.maxLogSpanBlocks);
+    const windowFrom = toBlock - span;
+    const nowSec = await reader.chainNow();
+
+    const { vaults, state } = await resolveVaults();
+    if (vaults.length === 0) {
+      error(`canary: no vaults to watch — set VAULTS, or point STATE_PATH at an indexer snapshot that has seen a VaultCreated (currently ${cfg.statePath})`);
+      return { transitions: [], results: [], vaults: [] };
+    }
+
+    const results = await collectSignals({
+      reader, state, vaults, cfg,
+      window: { fromBlock: windowFrom, toBlock, nowSec },
+    });
+
+    const transitions = tracker.observe(results, { poll, timestamp: now().toISOString() });
+    await emitAll(sinks, transitions, { onError: error });
+
+    lastScannedBlock = toBlock;
+    await saveCanaryState(cfg.canaryStatePath, { transitions: tracker.snapshot(), lastScannedBlock });
+    return { transitions, results, vaults };
+  }
+
+  async function start({ signal } = {}) {
+    log(`canary up: chain ${cfg.chainId}, read-only, polling every ${cfg.pollIntervalMs}ms. Silence means healthy.`);
+    let lastHeartbeat = 0;
+    for (;;) {
+      if (signal?.aborted) return;
+      try {
+        const { vaults } = await runOnce();
+        if (cfg.heartbeatMs > 0 && Date.now() - lastHeartbeat >= cfg.heartbeatMs) {
+          lastHeartbeat = Date.now();
+          const bad = tracker.unhealthy();
+          log(`canary heartbeat: ${vaults.length} vault(s), ${tracker.size} signal(s) tracked, ${bad.length} not OK${bad.length ? `: ${bad.map((b) => b.id).join(', ')}` : ''}`);
+        }
+      } catch (err) {
+        // A poll failure is an RPC problem, not a protocol problem. Say so and keep watching.
+        error(`canary poll error (will retry): ${err?.message ?? err}`);
+      }
+      await sleep(cfg.pollIntervalMs, signal);
+    }
+  }
+
+  return { reader, tracker, runOnce, start };
+}
+
+function sleep(ms, signal) {
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(t); resolve(undefined); }, { once: true });
+  });
+}
+
+// ── entrypoint ──
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const cfg = resolveCanaryConfig(process.env);
+  buildCanary(cfg).then(({ start }) => start()).catch((err) => {
+    console.error(err?.message ?? err);
+    process.exit(1);
+  });
+}

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -258,6 +258,14 @@ export async function buildCanary(cfg, { log = console.log, error = console.erro
       : Math.max(0, toBlock - cfg.logLookbackBlocks);
     const span = Math.min(toBlock - fromBlock, cfg.maxLogSpanBlocks);
     const windowFrom = toBlock - span;
+    // After downtime the backlog can exceed one window. We scan the most recent MAX_LOG_SPAN_BLOCKS
+    // and move on, which SKIPS the older blocks — the event signals (module-events, fee-routing)
+    // never see them. Say so: a silent coverage gap is precisely what this package exists to
+    // prevent, and an operator who sees this line can widen MAX_LOG_SPAN_BLOCKS or sweep the gap
+    // by hand before it scrolls away.
+    if (windowFrom > fromBlock) {
+      error(`canary: event scan gap — blocks ${fromBlock}-${windowFrom - 1} (${windowFrom - fromBlock} blocks) were NOT scanned for ModuleCallFailed/SliceEscrowed/fee outflows. The backlog exceeded MAX_LOG_SPAN_BLOCKS=${cfg.maxLogSpanBlocks}; raise it or scan that range manually.`);
+    }
     const nowSec = await reader.chainNow();
 
     const { vaults, state } = await resolveVaults();

--- a/packages/canary/src/reader.mjs
+++ b/packages/canary/src/reader.mjs
@@ -1,0 +1,160 @@
+// @ts-check
+/**
+ * The canary's chain adapter — the ONLY file in this package that talks to an RPC.
+ *
+ * Every signal check is a pure function over a `reader` shaped like the object this builds, so
+ * the tests inject a plain literal and no signal ever needs a live chain. viem is a lazy,
+ * OPTIONAL import (built only when no `client` is injected), mirroring packages/indexer/src/rpc.mjs
+ * so this package stays loadable in a bare checkout.
+ *
+ * READ-ONLY BY CONSTRUCTION. This module builds a viem *public* client — there is no
+ * `createWalletClient`, no account, no signer, and no key anywhere in packages/canary. The five
+ * methods below map to `eth_blockNumber`, `eth_getBlockByNumber`, `eth_call`, and `eth_getLogs`;
+ * nothing else is reachable through this object.
+ *
+ * The reader interface (what a mock must implement):
+ *   headBlock()                                        -> Promise<number>
+ *   chainNow()                                         -> Promise<number>   (latest block ts, seconds)
+ *   read(address, abi, fn, args, opts)                 -> Promise<any>      (throws on revert)
+ *   tryRead(address, abi, fn, args, opts)              -> Promise<ReadResult>   (never throws)
+ *   getLogs({address, event, args, fromBlock, toBlock})-> Promise<Log[]>
+ *   staticCall({to, from, data})                       -> Promise<CallResult>   (never throws)
+ *
+ * @typedef {{ok:boolean, value?:any, revertData?:string|null, error?:string}} ReadResult
+ * @typedef {{ok:boolean, data:string|null, error?:string}} CallResult
+ */
+
+const HEX_RE = /0x[0-9a-fA-F]{8,}/;
+
+/**
+ * Dig the raw revert returndata out of whatever the provider or viem threw.
+ *
+ * Pure and unit-tested, because the whole exit-liveness sentinel hinges on it: a bug here that
+ * silently returned null would downgrade a real H-1 fault into "unclassifiable". Callers treat
+ * `null` as "reverted with no data", which ALERTS — so the failure mode here is loud, not silent.
+ *
+ * Walks the `cause` chain (viem nests RpcRequestError inside CallExecutionError inside
+ * ContractFunctionExecutionError) and falls back to scraping a hex blob out of the message.
+ * @param {any} err
+ * @returns {string|null} lowercased 0x-prefixed returndata, or null if there was none
+ */
+export function extractRevertData(err) {
+  const seen = new Set();
+  let node = err;
+  for (let depth = 0; node && typeof node === 'object' && depth < 12; depth += 1) {
+    if (seen.has(node)) break;
+    seen.add(node);
+    for (const key of ['data', 'raw', 'returnData']) {
+      const v = node[key];
+      if (typeof v === 'string' && v.startsWith('0x') && v.length >= 10) return v.toLowerCase();
+      // viem sometimes nests the decoded shape as { data: { data: '0x…' } }
+      if (v && typeof v === 'object' && typeof v.data === 'string' && v.data.startsWith('0x')) {
+        return v.data.toLowerCase();
+      }
+    }
+    node = node.cause;
+  }
+  const text = [err?.details, err?.shortMessage, err?.message]
+    .filter((s) => typeof s === 'string')
+    .join(' ');
+  const m = HEX_RE.exec(text);
+  return m ? m[0].toLowerCase() : null;
+}
+
+/**
+ * @param {Object} cfg
+ * @param {any} [cfg.client]    an injected viem-style public client (tests); built from rpcUrl if omitted
+ * @param {string} [cfg.rpcUrl] HTTP RPC endpoint (required when no client is injected)
+ * @param {number} [cfg.chainId]
+ * @param {string} [cfg.chainName]
+ */
+export function createChainReader({ client, rpcUrl, chainId = 8453, chainName = 'base' } = {}) {
+  let _client = client ?? null;
+
+  async function getClient() {
+    if (_client) return _client;
+    if (!rpcUrl) throw new Error('canary: no client injected and no rpcUrl provided');
+    const { createPublicClient, http } = await import('viem').catch(() => {
+      throw new Error('canary: viem is not installed — run `npm install viem` (optional runtime dependency)');
+    });
+    const chain = {
+      id: chainId,
+      name: chainName,
+      nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+      rpcUrls: { default: { http: [rpcUrl] } },
+    };
+    _client = createPublicClient({ chain, transport: http(rpcUrl) });
+    return _client;
+  }
+
+  async function headBlock() {
+    const c = await getClient();
+    return Number(await c.getBlockNumber());
+  }
+
+  /**
+   * Latest block timestamp, seconds. Oracle freshness is measured against CHAIN time, never the
+   * canary host's clock — a skewed monitoring box must not invent (or hide) staleness.
+   */
+  async function chainNow() {
+    const c = await getClient();
+    const block = await c.getBlock();
+    return Number(block.timestamp);
+  }
+
+  /** @param {{blockNumber?:number}} [opts] pin the read to a height (share conservation does) */
+  async function read(address, abi, functionName, args = [], opts = {}) {
+    const c = await getClient();
+    const at = opts.blockNumber != null ? { blockNumber: BigInt(opts.blockNumber) } : {};
+    return c.readContract({ address, abi, functionName, args, ...at });
+  }
+
+  /** read() that reports a revert as data instead of throwing — signals branch on the reason. */
+  async function tryRead(address, abi, functionName, args = [], opts = {}) {
+    try {
+      return { ok: true, value: await read(address, abi, functionName, args, opts) };
+    } catch (err) {
+      return {
+        ok: false,
+        revertData: extractRevertData(err),
+        error: err?.shortMessage ?? err?.message ?? String(err),
+      };
+    }
+  }
+
+  async function getLogs({ address, event, args, fromBlock, toBlock }) {
+    const c = await getClient();
+    if (Array.isArray(address) ? address.length === 0 : !address) return [];
+    return c.getLogs({
+      address,
+      event,
+      ...(args ? { args } : {}),
+      fromBlock: BigInt(fromBlock),
+      toBlock: BigInt(toBlock),
+    });
+  }
+
+  /**
+   * Raw `eth_call`. No `gas` is passed on purpose: VaultCore gas-caps its own module calls at
+   * 300k (MODULE_CALL_GAS), and supplying a low call gas here would manufacture failures the
+   * chain would not produce. Let the node use the block gas limit, exactly like a real caller.
+   *
+   * `from` is an address the canary IMPERSONATES for the duration of one eth_call. It is not an
+   * account, it is not unlocked, and nothing is signed — `eth_call` never touches a key.
+   */
+  async function staticCall({ to, from, data }) {
+    const c = await getClient();
+    try {
+      const res = await c.call({ to, account: from, data });
+      return { ok: true, data: res?.data ?? '0x' };
+    } catch (err) {
+      return {
+        ok: false,
+        data: extractRevertData(err),
+        error: err?.shortMessage ?? err?.message ?? String(err),
+      };
+    }
+  }
+
+  return { headBlock, chainNow, read, tryRead, getLogs, staticCall };
+}

--- a/packages/canary/src/signal.mjs
+++ b/packages/canary/src/signal.mjs
@@ -1,0 +1,68 @@
+// @ts-check
+/**
+ * The vocabulary every signal check returns. Kept tiny and pure so a signal module can be read,
+ * tested, and reasoned about without knowing anything about the runner, the sinks, or the RPC.
+ *
+ * Three statuses, and the third one matters:
+ *   ok      — measured, within threshold.
+ *   alert   — measured, out of threshold. Pages.
+ *   skipped — could NOT be measured (no eligible member to probe with, oracle breaker tripped,
+ *             archive state unavailable…). A check that cannot run is not a check that passed,
+ *             so it never collapses into `ok`. The runner reports OK→SKIPPED as its own
+ *             transition line, which is how a dead sentinel becomes visible instead of silent.
+ *
+ * @typedef {'ok'|'alert'|'skipped'} SignalStatus
+ * @typedef {Object} SignalResult
+ * @property {string} id            stable identity for transition tracking: signal|vault|key
+ * @property {string} signal        signal name (e.g. 'oracle-freshness')
+ * @property {string} vault         the vault this observation is about
+ * @property {string} [key]         sub-key when a signal fans out (e.g. per basket asset)
+ * @property {SignalStatus} status
+ * @property {string} message       one actionable line: what is wrong, measured vs threshold
+ * @property {string} [measured]    the measured value, formatted
+ * @property {string} [threshold]   the threshold it was compared against, formatted
+ * @property {Record<string, any>} [detail]  structured extras for the webhook payload
+ */
+
+/** Stable transition key. Per-asset fan-out gets its own key so one stale asset cannot flap a vault. */
+export function signalId(signal, vault, key) {
+  return key ? `${signal}|${vault}|${key}` : `${signal}|${vault}`;
+}
+
+const build = (status) => (
+  /**
+   * @param {{signal:string, vault:string, key?:string, message:string,
+   *          measured?:string, threshold?:string, detail?:Record<string,any>}} fields
+   * @returns {SignalResult}
+   */
+  (fields) => ({ ...fields, status, id: signalId(fields.signal, fields.vault, fields.key) })
+);
+
+export const ok = build('ok');
+export const alert = build('alert');
+export const skipped = build('skipped');
+
+/** Short vault label for alert lines: 0x1234…cdef. Full address always rides in `detail`. */
+export function shortAddr(a) {
+  return typeof a === 'string' && a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : String(a);
+}
+
+/**
+ * |a - b| as a fraction of max(a, b), in basis points. Integer math end to end — divergence
+ * thresholds must never round through a float. Returns 0 when both sides are zero.
+ * @param {bigint} a @param {bigint} b @returns {bigint}
+ */
+export function divergenceBps(a, b) {
+  const hi = a > b ? a : b;
+  if (hi === 0n) return 0n;
+  const diff = a > b ? a - b : b - a;
+  return (diff * 10000n) / hi;
+}
+
+/** Render integer basis points as a percentage string, e.g. 137n -> "1.37%". */
+export function bpsToPct(bps) {
+  const n = typeof bps === 'bigint' ? bps : BigInt(bps);
+  const whole = n / 100n;
+  const frac = (n < 0n ? -n : n) % 100n;
+  return `${whole}.${String(frac).padStart(2, '0')}%`;
+}

--- a/packages/canary/src/signals/exit-liveness.mjs
+++ b/packages/canary/src/signals/exit-liveness.mjs
@@ -1,0 +1,134 @@
+// @ts-check
+/**
+ * Signal (d) — EXIT LIVENESS. The H-1 regression sentinel.
+ *
+ * H-1 / MO-1: a creator-chosen bookkeeping module (governance, feeEngine, registry) that reverts,
+ * burns gas, or bombs returndata could brick every exit in a vault forever, with no upgrade path.
+ * The contract mitigates it — module calls are gas-capped at 300k and returndata-bounded to one
+ * word, and a failing governance falls back to Mode I. This signal is the sentinel that proves
+ * the mitigation still holds on the deployed bytecode: it static-calls `requestExit` as a REAL
+ * member and classifies the revert.
+ *
+ * ── The failure mode this design exists to avoid ──
+ * `requestExit` reverts `ZeroAmount` on 0 shares and `InsufficientShares` unless the CALLER holds
+ * them. Probing from an arbitrary address therefore always reverts with a gate error, and the
+ * sentinel would report healthy forever while exits were bricked. So the probe requires a member
+ * who actually holds shares — supplied from the indexer's projection share book. With no such
+ * member the result is `skipped`, never `ok`: a check that cannot run has not passed.
+ *
+ * ── Classification (three-way, not two) ──
+ *   GATE   (ZeroAmount, InsufficientShares, ExitAlreadyQueued, CreatorStakeGate,
+ *           ExitNeedsChildSettlement, ChildSettlementPending) — the caller's own position makes
+ *           the call invalid. Expected. OK.
+ *   FROZEN (StaleOracle) — the SF-2/K-4 breaker. By design, but it IS a live capital freeze, so it
+ *           is `skipped` and attributed to the oracle signal, which pages for it. Never reported
+ *           as OK — an operator must not read "exits fine" while capital is frozen.
+ *   FAULT  (everything else: Reentrancy, Panic, Error(string), an unrecognized selector, or
+ *           EMPTY returndata) — ALERT. Empty/unrecognized returndata is the actual H-1 signature
+ *           (a module that ran out of its gas cap or bombed returndata), so it must land here.
+ *           There is deliberately no "could not classify, assume healthy" branch.
+ *   SUCCESS — the call did not revert. Exits are live. OK.
+ *
+ * READ-ONLY: `eth_call` with an impersonated `from`. Nothing is signed, nothing is broadcast, and
+ * no key exists in this package. The chain state is never touched.
+ */
+
+import { REQUEST_EXIT_SELECTOR, EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS } from '../abis.mjs';
+import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'exit-liveness';
+
+/**
+ * ABI-encode `requestExit(uint256 shares)`. Hand-rolled so the module needs no encoder dependency;
+ * one static uint256 argument is the whole encoding. test/abis.test.mjs cross-checks the selector.
+ * @param {bigint} shares
+ */
+export function encodeRequestExit(shares) {
+  return REQUEST_EXIT_SELECTOR + BigInt(shares).toString(16).padStart(64, '0');
+}
+
+/**
+ * Choose which member to probe with. Prefers a non-creator holder (the creator hits the CM-1
+ * stake gate, which is a gate revert and so a weaker probe), largest balance first for stability
+ * across polls. Falls back to the creator if they are the only holder — with no other members
+ * `nonCreatorMemberCount == 0`, so the gate does not apply and the probe is still meaningful.
+ * Pure and separately tested.
+ * @param {Iterable<[string,bigint]>} shareBook
+ * @param {string} [creator]
+ * @returns {{member:string, shares:bigint}|null}
+ */
+export function pickProbeMember(shareBook, creator) {
+  const c = typeof creator === 'string' ? creator.toLowerCase() : null;
+  const holders = [...(shareBook ?? [])]
+    .map(([member, shares]) => ({ member, shares: BigInt(shares) }))
+    .filter((h) => h.shares > 0n);
+  if (holders.length === 0) return null;
+  const rank = (h) => (h.member.toLowerCase() === c ? 1 : 0); // non-creator first
+  holders.sort((a, b) => rank(a) - rank(b) || (b.shares > a.shares ? 1 : b.shares < a.shares ? -1 : 0));
+  return holders[0];
+}
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {Map<string,bigint>|Iterable<[string,bigint]>} [ctx.shareBook]  state.shares.get(vault)
+ * @param {string} [ctx.creator]  the vault creator, so the probe can prefer a non-creator member
+ * @param {bigint} [ctx.probeShares]  amount to probe with (default 1 — the smallest valid request)
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkExitLiveness({ reader, vault, shareBook, creator, probeShares = 1n }) {
+  const probe = pickProbeMember(shareBook, creator);
+  if (!probe) {
+    return [skipped({
+      signal: SIGNAL, vault,
+      message: `exit-liveness sentinel CANNOT RUN on vault ${shortAddr(vault)}: the indexer projection lists no member holding shares, so requestExit has no valid caller to probe with — this vault is unmonitored for H-1, it is not healthy`,
+      detail: { vault, reason: 'no-eligible-member' },
+    })];
+  }
+
+  const shares = probeShares < probe.shares ? probeShares : probe.shares;
+  const res = await reader.staticCall({
+    to: vault,
+    from: probe.member,
+    data: encodeRequestExit(shares),
+  });
+  const detail = { vault, probeMember: probe.member, probeShares: shares.toString(), revertData: res.data ?? null };
+
+  if (res.ok) {
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `exits live on vault ${shortAddr(vault)}: requestExit(${shares}) static-calls clean as ${shortAddr(probe.member)}`,
+      measured: 'no revert', threshold: 'no non-gate revert', detail,
+    })];
+  }
+
+  const selector = typeof res.data === 'string' && res.data.length >= 10 ? res.data.slice(0, 10).toLowerCase() : null;
+
+  if (selector && selector in EXIT_GATE_SELECTORS) {
+    const name = EXIT_GATE_SELECTORS[selector];
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `exits live on vault ${shortAddr(vault)}: requestExit reverted ${name}, a caller-position gate, not a fault`,
+      measured: name, threshold: 'no non-gate revert', detail: { ...detail, revertName: name },
+    })];
+  }
+
+  if (selector && selector in EXIT_FROZEN_SELECTORS) {
+    return [skipped({
+      signal: SIGNAL, vault,
+      message: `exit-liveness sentinel cannot run on vault ${shortAddr(vault)}: requestExit reverts StaleOracle — the oracle breaker has frozen exits (SF-2/K-4, by design). The oracle-freshness signal pages for this; H-1 coverage is suspended until the breaker clears`,
+      detail: { ...detail, revertName: 'StaleOracle', attributedTo: 'oracle-freshness' },
+    })];
+  }
+
+  // Everything else is a fault. Empty returndata and unrecognized selectors land HERE, not in ok.
+  const name = (selector && EXIT_FAULT_SELECTORS[selector])
+    || (selector ? `unrecognized revert ${selector}` : 'EMPTY returndata (out-of-gas or returndata bomb)');
+  return [alert({
+    signal: SIGNAL, vault,
+    message: `EXIT LIVENESS BROKEN on vault ${shortAddr(vault)} (H-1 regression): requestExit(${shares}) as member ${shortAddr(probe.member)} reverts with ${name} — a non-gate revert means members cannot exit`,
+    measured: name, threshold: 'no non-gate revert',
+    detail: { ...detail, revertName: name, threatModelRow: 'MO-1 (review H-1)' },
+  })];
+}

--- a/packages/canary/src/signals/fee-routing.mjs
+++ b/packages/canary/src/signals/fee-routing.mjs
@@ -1,0 +1,132 @@
+// @ts-check
+/**
+ * Signal (f) — FEE ROUTING. "Any USDC leaving a vault to an operator address outside the
+ * FeeEngine claim flow."
+ *
+ * The invariant (EE-9 / MO-4): performance fees route to the operator ONLY through the FeeEngine —
+ * the vault transfers to the engine, the engine credits `claimableFees[operator]`, and the
+ * operator calls `claimFees`. Exit fees never route to the operator at all; they accrue to
+ * remaining members through the share price. So a USDC transfer straight from a vault to a
+ * registered operator address is the shape of a fee leak.
+ *
+ * WHY THIS IS THE NARROW CHECK. An inverse allowlist — alert on any destination that is not the
+ * engine, a member, a child, or an adapter — would fire on ordinary exit payouts to members the
+ * indexer has not projected yet, on rebalance transfers to adapters, and on cancelPending
+ * refunds. That signal cries wolf and gets muted, which is worse than not having it. This one
+ * alerts on the specific destination the threat model prohibits. The broad sweep is available as
+ * `informational: true` results, which the runner logs but never pages on.
+ *
+ * OPERATOR-AS-MEMBER IS LEGITIMATE. EE-9 says so explicitly: an operator who is also a member
+ * receives their pro-rata share like anyone else, and the prohibition is on ROUTING, not identity.
+ * So a transfer to the operator address is only a leak if it is NOT an exit settlement or a
+ * pending-deposit refund. The discriminator is same-block `ExitSettled(member=operator)` or
+ * `PendingCancelled(member=operator)` on that vault — cheap, and without it this signal would
+ * page every time an honest operator exits their own position.
+ */
+
+import { ERC20_TRANSFER_EVENT, EXIT_SETTLED_EVENT, OPERATOR_REGISTRY_VIEWS } from '../abis.mjs';
+import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'fee-routing';
+
+/** PendingCancelled — the other legitimate vault→member USDC outflow (deposit refund). */
+const PENDING_CANCELLED = Object.freeze({
+  type: 'event', name: 'PendingCancelled', anonymous: false,
+  inputs: [
+    { name: 'member', type: 'address', indexed: true },
+    { name: 'amountUsdc', type: 'uint256', indexed: false },
+  ],
+});
+
+const lc = (a) => (typeof a === 'string' ? a.toLowerCase() : a);
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {string} ctx.usdc                the vault's settlement token
+ * @param {string} [ctx.operatorRegistry]  used to resolve this vault's operator address
+ * @param {string[]} [ctx.extraOperators]  additional operator addresses to treat as prohibited
+ * @param {number} ctx.fromBlock
+ * @param {number} ctx.toBlock
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkFeeRouting({ reader, vault, usdc, operatorRegistry, extraOperators = [], fromBlock, toBlock }) {
+  const prohibited = new Set(extraOperators.map(lc).filter(Boolean));
+
+  if (operatorRegistry) {
+    const idRes = await reader.tryRead(operatorRegistry, OPERATOR_REGISTRY_VIEWS, 'operatorOf', [vault]);
+    if (!idRes.ok) {
+      return [skipped({
+        signal: SIGNAL, vault,
+        message: `fee routing skipped on vault ${shortAddr(vault)}: operatorOf() is unreadable on the registry: ${idRes.error}`,
+        detail: { vault, operatorRegistry },
+      })];
+    }
+    const opId = BigInt(idRes.value ?? 0);
+    if (opId !== 0n) {
+      const addrRes = await reader.tryRead(operatorRegistry, OPERATOR_REGISTRY_VIEWS, 'operatorAddressOf', [opId]);
+      if (addrRes.ok && addrRes.value) prohibited.add(lc(addrRes.value));
+    }
+  }
+
+  if (prohibited.size === 0) {
+    // An unattested vault (operatorId 0) has no operator to leak to. PX-3 quarantine, not a fee risk.
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `fee routing on vault ${shortAddr(vault)}: no registered operator address to check against (unattested vault)`,
+      measured: '0 prohibited destinations', threshold: '0 direct operator transfers', detail: { vault, fromBlock, toBlock },
+    })];
+  }
+
+  const outflows = await reader.getLogs({
+    address: usdc, event: ERC20_TRANSFER_EVENT, args: { from: vault }, fromBlock, toBlock,
+  });
+  const toOperator = outflows.filter((l) => prohibited.has(lc(l.args?.to)));
+
+  const window = { vault, usdc, fromBlock, toBlock, operatorAddresses: [...prohibited] };
+  if (toOperator.length === 0) {
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `fee routing on vault ${shortAddr(vault)}: ${outflows.length} USDC outflow(s) in blocks ${fromBlock}-${toBlock}, none to an operator address`,
+      measured: '0 direct operator transfers', threshold: '0 direct operator transfers', detail: window,
+    })];
+  }
+
+  // EE-9: an operator exiting or cancelling their own member position is legitimate. Only a
+  // transfer with no settlement event behind it in the same block is a routing violation.
+  const [exits, cancels] = await Promise.all([
+    reader.getLogs({ address: vault, event: EXIT_SETTLED_EVENT, fromBlock, toBlock }),
+    reader.getLogs({ address: vault, event: PENDING_CANCELLED, fromBlock, toBlock }),
+  ]);
+  const settled = new Set([...exits, ...cancels].map((l) => `${Number(l.blockNumber)}|${lc(l.args?.member)}`));
+
+  const leaks = toOperator.filter((l) => !settled.has(`${Number(l.blockNumber)}|${lc(l.args?.to)}`));
+  const excused = toOperator.length - leaks.length;
+
+  if (leaks.length === 0) {
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `fee routing on vault ${shortAddr(vault)}: ${excused} USDC transfer(s) to the operator address, all matched to an ExitSettled/PendingCancelled in the same block (operator-as-member, EE-9)`,
+      measured: '0 direct operator transfers', threshold: '0 direct operator transfers',
+      detail: { ...window, excusedAsMemberSettlement: excused },
+    })];
+  }
+
+  const total = leaks.reduce((s, l) => s + BigInt(l.args?.value ?? 0), 0n);
+  const first = leaks[0];
+  return [alert({
+    signal: SIGNAL, vault,
+    message: `FEE ROUTING VIOLATION on vault ${shortAddr(vault)}: ${leaks.length} USDC transfer(s) totalling ${total} base units went directly to operator address ${shortAddr(first.args?.to)} with no ExitSettled/PendingCancelled behind them (first at block ${Number(first.blockNumber)}, tx ${first.transactionHash ?? 'unknown'}) — fees must reach the operator only via FeeEngine.claimFees`,
+    measured: `${leaks.length} transfer(s), ${total} USDC base units`, threshold: '0 direct operator transfers',
+    detail: {
+      ...window,
+      excusedAsMemberSettlement: excused,
+      transfers: leaks.map((l) => ({
+        to: l.args?.to, value: String(l.args?.value ?? 0),
+        blockNumber: Number(l.blockNumber), txHash: l.transactionHash ?? null,
+      })),
+      threatModelRows: ['EE-9', 'MO-4'],
+    },
+  })];
+}

--- a/packages/canary/src/signals/module-events.mjs
+++ b/packages/canary/src/signals/module-events.mjs
@@ -1,0 +1,85 @@
+// @ts-check
+/**
+ * Signal (e) — MODULE-CALL FAILURES and IN-KIND ESCROW.
+ *
+ * `ModuleCallFailed(bytes32 module, address member)` is VaultCore telling you a creator-chosen
+ * bookkeeping module misbehaved on the exit path (MO-1). The exit itself still settled — that is
+ * the mitigation working — but the module's bookkeeping was FORFEITED. For the feeEngine paths
+ * that means an operator's fee accounting silently did not happen, and it is also the leading
+ * indicator of the H-1 failure the exit-liveness sentinel watches for.
+ *
+ * `SliceEscrowed(member, asset, amount)` is the EE-6 / MO-2 escrow path: an in-kind transfer
+ * failed, so that asset's slice was set aside as `claimable` instead of reverting the whole
+ * redemption. Also the mitigation working, and also worth knowing: a token that keeps failing
+ * transfers (blacklist, pause, malformed return) leaves members holding claims, not assets.
+ *
+ * Neither event is folded by the indexer's projection, which is why the canary reads them itself.
+ *
+ * SHAPE: this is an OCCURRENCE signal over one poll window, not a level. A burst of events
+ * therefore produces exactly two lines — OK→ALERT naming the events, then ALERT→OK on the next
+ * quiet window. That is bounded and intentional; the recovery line means "no further failures in
+ * the following window", not "the earlier failure was resolved".
+ */
+
+import { VAULT_WATCH_EVENTS, decodeModuleLabel } from '../abis.mjs';
+import { ok, alert, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'module-events';
+
+const MODULE_CALL_FAILED = VAULT_WATCH_EVENTS[0];
+const SLICE_ESCROWED = VAULT_WATCH_EVENTS[1];
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {number} ctx.fromBlock
+ * @param {number} ctx.toBlock
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkModuleEvents({ reader, vault, fromBlock, toBlock }) {
+  const [failures, escrows] = await Promise.all([
+    reader.getLogs({ address: vault, event: MODULE_CALL_FAILED, fromBlock, toBlock }),
+    reader.getLogs({ address: vault, event: SLICE_ESCROWED, fromBlock, toBlock }),
+  ]);
+
+  const window = { vault, fromBlock, toBlock };
+  if (failures.length === 0 && escrows.length === 0) {
+    return [ok({
+      signal: SIGNAL, vault,
+      message: `no ModuleCallFailed or SliceEscrowed on vault ${shortAddr(vault)} in blocks ${fromBlock}-${toBlock}`,
+      measured: '0 events', threshold: '0 events', detail: window,
+    })];
+  }
+
+  const failed = failures.map((l) => ({
+    module: decodeModuleLabel(l.args?.module),
+    member: l.args?.member,
+    blockNumber: Number(l.blockNumber),
+    txHash: l.transactionHash ?? null,
+  }));
+  const escrowed = escrows.map((l) => ({
+    member: l.args?.member,
+    asset: l.args?.asset,
+    amount: String(l.args?.amount ?? 0),
+    blockNumber: Number(l.blockNumber),
+    txHash: l.transactionHash ?? null,
+  }));
+
+  const parts = [];
+  if (failed.length) {
+    const modules = [...new Set(failed.map((f) => f.module))].join(', ');
+    parts.push(`${failed.length}x ModuleCallFailed (${modules}; first at block ${failed[0].blockNumber} for member ${shortAddr(failed[0].member)})`);
+  }
+  if (escrowed.length) {
+    const assets = [...new Set(escrowed.map((e) => shortAddr(e.asset)))].join(', ');
+    parts.push(`${escrowed.length}x SliceEscrowed (assets ${assets}; first at block ${escrowed[0].blockNumber} for member ${shortAddr(escrowed[0].member)})`);
+  }
+
+  return [alert({
+    signal: SIGNAL, vault,
+    message: `module/escrow failures on vault ${shortAddr(vault)} in blocks ${fromBlock}-${toBlock}: ${parts.join('; ')}`,
+    measured: `${failed.length + escrowed.length} events`, threshold: '0 events',
+    detail: { ...window, moduleCallFailed: failed, sliceEscrowed: escrowed, threatModelRows: ['MO-1', 'MO-2', 'EE-6'] },
+  })];
+}

--- a/packages/canary/src/signals/nav-backing.mjs
+++ b/packages/canary/src/signals/nav-backing.mjs
@@ -1,0 +1,227 @@
+// @ts-check
+/**
+ * Signal (b) — NAV BACKING. "navWad diverges from independently-computed holdings > 0.5%."
+ *
+ * Two legs, both keyed separately so they alert independently:
+ *
+ * COMPOSITION — recompute navWad from the vault's own component getters and compare.
+ *   This reproduces VaultCore.navWad() exactly, including the SV-7 look-through:
+ *     nav = idleUsdc*usdcScalar
+ *         + Σ assetBalance[a] * oracle.priceWad(a) / assetUnit[a]
+ *         + Σ _fullNavWad(child,1) * sharesOf(this) / child.totalShares()
+ *   with descendants valued through THIS vault's oracle and THIS vault's assetUnit/usdcScalar,
+ *   recursing to MAX_LOOKTHROUGH_DEPTH = 3. `assetUnit` and `usdcScalar` are public getters, so
+ *   nothing is re-derived from token decimals and nothing is assumed about USDC being 6dp.
+ *
+ *   Every read is pinned to ONE block height, so a healthy vault diverges by exactly 0 — this is
+ *   an invariant check, not an estimate. It catches the class of bug S6 Finding 1 was (a
+ *   look-through that silently dropped grandchild value from the root NAV), an unpriceable basket
+ *   asset, and any child whose share accounting has moved out from under its parent.
+ *
+ * CUSTODY — compare the vault's INTERNAL accounting against the token balances it actually holds.
+ *   This is the genuinely independent leg. The comparison is one-sided on purpose:
+ *     balanceOf(vault) >= idleUsdc + totalPendingUsdc      (USDC)
+ *     balanceOf(vault) >= assetBalance[a]                  (each basket asset)
+ *   A SURPLUS is normal and never alerts — donations, escrowed in-kind slices (EE-6 `claimable`),
+ *   and observation-window capital (EE-1 `totalPendingUsdc`, deliberately outside NAV) all sit in
+ *   the token balance without being in NAV. A SHORTFALL is the alarming direction: the vault
+ *   believes it owns more than it holds, so members' NAV is not backed.
+ *
+ * If the oracle breaker is tripped, navWad() reverts StaleOracle. That is `skipped`, attributed to
+ * the oracle signal — not a NAV divergence alert. Never double-page for one root cause.
+ */
+
+import { VAULT_VIEWS, ORACLE_VIEWS, ERC20_VIEWS, EXIT_FROZEN_SELECTORS } from '../abis.mjs';
+import { ok, alert, skipped, shortAddr, divergenceBps, bpsToPct } from '../signal.mjs';
+
+export const SIGNAL = 'nav-backing';
+
+/** Matches VaultCore.MAX_LOOKTHROUGH_DEPTH. */
+const MAX_LOOKTHROUGH_DEPTH = 3;
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {number} [ctx.atBlock]        pin every read to this height (the runner supplies head)
+ * @param {number} [ctx.thresholdBps]   composition divergence bar, default 50 = 0.5%
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkNavBacking({ reader, vault, atBlock, thresholdBps = 50 }) {
+  const at = atBlock != null ? { blockNumber: atBlock } : {};
+  const V = (address, fn, args = []) => reader.read(address, VAULT_VIEWS, fn, args, at);
+  const results = [];
+
+  const reportedRes = await reader.tryRead(vault, VAULT_VIEWS, 'navWad', [], at);
+  if (!reportedRes.ok) {
+    const frozen = isFrozen(reportedRes.revertData);
+    results.push(skipped({
+      signal: SIGNAL, vault, key: 'composition',
+      message: frozen
+        ? `NAV check skipped on vault ${shortAddr(vault)}: navWad() reverts StaleOracle — the oracle breaker is tripped (see the oracle-freshness signal for the asset)`
+        : `NAV check skipped on vault ${shortAddr(vault)}: navWad() is unreadable: ${reportedRes.error}`,
+      detail: { vault, revertData: reportedRes.revertData, attributedTo: frozen ? 'oracle-freshness' : null },
+    }));
+    return results;
+  }
+
+  const oracle = await V(vault, 'oracle');
+  const usdcScalar = BigInt(await V(vault, 'usdcScalar'));
+  const priceOf = memoPrice(reader, oracle, at);
+
+  let recomputed;
+  try {
+    recomputed = await selfValue(V, priceOf, vault, usdcScalar, vault);
+    for (const child of await childrenOf(V, vault)) {
+      const myShares = BigInt(await V(child, 'sharesOf', [vault]));
+      if (myShares === 0n) continue;
+      const childTotal = BigInt(await V(child, 'totalShares'));
+      if (childTotal === 0n) continue;
+      // Multiply-then-divide, matching _childValueWad's truncation exactly.
+      recomputed += (await fullNav(V, priceOf, child, vault, usdcScalar, 1)) * myShares / childTotal;
+    }
+  } catch (err) {
+    const frozen = isFrozen(err?.revertData);
+    results.push(skipped({
+      signal: SIGNAL, vault, key: 'composition',
+      message: frozen
+        ? `NAV recompute skipped on vault ${shortAddr(vault)}: a basket asset price reverts StaleOracle (see the oracle-freshness signal)`
+        : `NAV recompute failed on vault ${shortAddr(vault)}: ${err?.message ?? err}`,
+      detail: { vault, attributedTo: frozen ? 'oracle-freshness' : null },
+    }));
+    return results;
+  }
+
+  const reported = BigInt(reportedRes.value);
+  const bps = divergenceBps(reported, recomputed);
+  const detail = {
+    vault, atBlock: atBlock ?? null,
+    navWad: reported.toString(), recomputedWad: recomputed.toString(),
+    divergenceBps: Number(bps),
+  };
+  const line = `navWad ${reported} vs recomputed ${recomputed} (${bpsToPct(bps)})`;
+
+  results.push(bps > BigInt(thresholdBps)
+    ? alert({
+      signal: SIGNAL, vault, key: 'composition',
+      message: `NAV backing divergence on vault ${shortAddr(vault)}: ${line} — exceeds ${bpsToPct(thresholdBps)}`,
+      measured: bpsToPct(bps), threshold: bpsToPct(thresholdBps), detail,
+    })
+    : ok({
+      signal: SIGNAL, vault, key: 'composition',
+      message: `NAV backing on vault ${shortAddr(vault)}: ${line}`,
+      measured: bpsToPct(bps), threshold: bpsToPct(thresholdBps), detail,
+    }));
+
+  results.push(await custodyLeg(reader, V, vault, at));
+  return results;
+}
+
+/**
+ * Custody: does the vault actually hold what its internal accounting claims? Shortfall only —
+ * a surplus is EE-1 pending capital, EE-6 escrow, or a donation, none of which are faults.
+ */
+async function custodyLeg(reader, V, vault, at) {
+  const shortfalls = [];
+  const checked = [];
+  try {
+    const usdc = await V(vault, 'usdc');
+    const owedUsdc = BigInt(await V(vault, 'idleUsdc')) + BigInt(await V(vault, 'totalPendingUsdc'));
+    const heldUsdc = BigInt(await reader.read(usdc, ERC20_VIEWS, 'balanceOf', [vault], at));
+    checked.push({ token: usdc, owed: owedUsdc.toString(), held: heldUsdc.toString() });
+    if (heldUsdc < owedUsdc) shortfalls.push({ token: usdc, label: 'USDC', owed: owedUsdc, held: heldUsdc });
+
+    for (const asset of await basketOf(V, vault)) {
+      const owed = BigInt(await V(vault, 'assetBalance', [asset]));
+      if (owed === 0n) continue;
+      const held = BigInt(await reader.read(asset, ERC20_VIEWS, 'balanceOf', [vault], at));
+      checked.push({ token: asset, owed: owed.toString(), held: held.toString() });
+      if (held < owed) shortfalls.push({ token: asset, label: shortAddr(asset), owed, held });
+    }
+  } catch (err) {
+    return skipped({
+      signal: SIGNAL, vault, key: 'custody',
+      message: `custody check skipped on vault ${shortAddr(vault)}: a token balance is unreadable: ${err?.message ?? err}`,
+      detail: { vault },
+    });
+  }
+
+  if (shortfalls.length === 0) {
+    return ok({
+      signal: SIGNAL, vault, key: 'custody',
+      message: `custody on vault ${shortAddr(vault)}: ${checked.length} token balances cover internal accounting`,
+      measured: 'no shortfall', threshold: 'held >= accounted', detail: { vault, checked },
+    });
+  }
+  const worst = shortfalls[0];
+  return alert({
+    signal: SIGNAL, vault, key: 'custody',
+    message: `BACKING SHORTFALL on vault ${shortAddr(vault)}: ${worst.label} accounting says ${worst.owed} but the vault holds ${worst.held} (short ${worst.owed - worst.held})${shortfalls.length > 1 ? ` and ${shortfalls.length - 1} more token(s)` : ''}`,
+    measured: `${worst.held} held`, threshold: `>= ${worst.owed} accounted`,
+    detail: { vault, shortfalls: shortfalls.map((s) => ({ token: s.token, owed: s.owed.toString(), held: s.held.toString() })), checked },
+  });
+}
+
+/** idleUsdc + priced basket, for `target`, using `payer`'s scalar/units and oracle (mirrors _fullNavWad). */
+async function selfValue(V, priceOf, target, usdcScalar, payer) {
+  let nav = BigInt(await V(target, 'idleUsdc')) * usdcScalar;
+  for (const asset of await basketOf(V, target)) {
+    const bal = BigInt(await V(target, 'assetBalance', [asset]));
+    if (bal === 0n) continue;
+    const unit = BigInt(await V(payer, 'assetUnit', [asset]));
+    if (unit === 0n) throw new Error(`asset ${asset} has no assetUnit on vault ${payer} — it is not in this vault's basket, so navWad cannot price it`);
+    nav += bal * (await priceOf(asset)) / unit;
+  }
+  return nav;
+}
+
+/** VaultCore._fullNavWad(v, depth) — descendants priced through the ROOT payer's oracle and units. */
+async function fullNav(V, priceOf, target, payer, usdcScalar, depth) {
+  let nav = await selfValue(V, priceOf, target, usdcScalar, payer);
+  if (depth >= MAX_LOOKTHROUGH_DEPTH) return nav;
+  for (const grandchild of await childrenOf(V, target)) {
+    const shares = BigInt(await V(grandchild, 'sharesOf', [target]));
+    if (shares === 0n) continue;
+    const total = BigInt(await V(grandchild, 'totalShares'));
+    if (total === 0n) continue;
+    nav += (await fullNav(V, priceOf, grandchild, payer, usdcScalar, depth + 1)) * shares / total;
+  }
+  return nav;
+}
+
+async function basketOf(V, target) {
+  const n = Number(await V(target, 'basketLength'));
+  const out = [];
+  for (let i = 0; i < n; i += 1) out.push(await V(target, 'basketAssets', [i]));
+  return out;
+}
+
+async function childrenOf(V, target) {
+  const n = Number(await V(target, 'childVaultCount'));
+  const out = [];
+  for (let i = 0; i < n; i += 1) out.push(await V(target, 'childVaults', [i]));
+  return out;
+}
+
+/** One priceWad read per asset per check, not one per appearance in the look-through tree. */
+function memoPrice(reader, oracle, at) {
+  const cache = new Map();
+  return async (asset) => {
+    const k = String(asset).toLowerCase();
+    if (cache.has(k)) return cache.get(k);
+    const res = await reader.tryRead(oracle, ORACLE_VIEWS, 'priceWad', [asset], at);
+    if (!res.ok) {
+      const err = new Error(`priceWad(${asset}) reverted: ${res.error}`);
+      // @ts-ignore — carried so the caller can attribute a StaleOracle revert to the oracle signal
+      err.revertData = res.revertData;
+      throw err;
+    }
+    const p = BigInt(res.value);
+    cache.set(k, p);
+    return p;
+  };
+}
+
+function isFrozen(revertData) {
+  return typeof revertData === 'string' && revertData.slice(0, 10) in EXIT_FROZEN_SELECTORS;
+}

--- a/packages/canary/src/signals/oracle-freshness.mjs
+++ b/packages/canary/src/signals/oracle-freshness.mjs
@@ -1,0 +1,126 @@
+// @ts-check
+/**
+ * Signal (a) — ORACLE FRESHNESS. "Any basket asset within 1 breaker-trip of StaleOracle."
+ *
+ * OracleAggregator.priceWad(asset) reverts StaleOracle when fewer than `quorum` of the asset's
+ * sources are fresh, and that revert freezes every NAV path in the vault INCLUDING EXITS — by
+ * design, with no hatch (SF-2/K-4). So the operator must see the breaker coming, not learn about
+ * it from trapped members.
+ *
+ * MARGIN = freshSources - quorum: how many FURTHER sources can go dark before capital freezes.
+ *   margin >  0  ->  healthy: it takes margin+1 more failures to trip
+ *   margin == 0  ->  ALERT: the vault is within ONE breaker-trip — any single source failure freezes it
+ *   margin <  0  ->  ALERT: already tripped, priceWad reverts right now
+ *
+ * So the default bar is `margin <= 0`, which is exactly the runbook's "within 1 breaker-trip of
+ * StaleOracle". Calibration matters here: a vault running the protocol minimum (3 sources,
+ * quorum 2) sits at margin 1 when perfectly healthy, and alerting on that would page forever and
+ * get the canary muted. Operators who want the earlier warning set ORACLE_MIN_MARGIN=1.
+ *
+ * Freshness is reproduced exactly as the contract computes it (OracleAggregator.priceWad):
+ *   a source counts as fresh iff latestPrice() returns priceWad > 0 AND updatedAt >= now - maxStaleness,
+ *   and a REVERTING source is simply not fresh — it must not be treated as an error here either,
+ *   or one broken feed would page while quorum still holds.
+ *
+ * The staleness clock is CHAIN time (latest block timestamp), never the monitoring host's clock.
+ *
+ * Fans out one result per (vault, asset) so a single stale asset cannot flap the whole vault.
+ */
+
+import { ORACLE_VIEWS, PRICE_SOURCE_VIEWS } from '../abis.mjs';
+import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'oracle-freshness';
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader            injected chain reader (see ../reader.mjs)
+ * @param {string} ctx.vault          the vault being watched
+ * @param {string} ctx.oracle         its OracleAggregator address
+ * @param {string[]} ctx.assets       the vault's basket assets (what navWad actually prices)
+ * @param {number} ctx.nowSec         chain time, seconds
+ * @param {number} [ctx.minMargin]    alert when freshSources - quorum <= this (default 0)
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkOracleFreshness({ reader, vault, oracle, assets, nowSec, minMargin = 0 }) {
+  const out = [];
+
+  for (const asset of assets) {
+    const cfg = await reader.tryRead(oracle, ORACLE_VIEWS, 'assetConfig', [asset]);
+    if (!cfg.ok) {
+      out.push(skipped({
+        signal: SIGNAL, vault, key: asset,
+        message: `oracle config unreadable for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${cfg.error}`,
+        detail: { vault, asset, oracle },
+      }));
+      continue;
+    }
+
+    const { sources, maxStaleness, quorum } = normalizeConfig(cfg.value);
+    if (sources.length === 0) {
+      // priceWad() reverts StaleOracle for an unlisted asset — the breaker, not a zero price.
+      // A basket asset the oracle does not list means the vault is already frozen for that asset.
+      out.push(alert({
+        signal: SIGNAL, vault, key: asset,
+        message: `oracle has NO sources listed for basket asset ${shortAddr(asset)} on vault ${shortAddr(vault)} — priceWad reverts StaleOracle, NAV and exits are frozen`,
+        measured: '0 sources', threshold: '>= 3 sources',
+        detail: { vault, asset, oracle, sources: 0 },
+      }));
+      continue;
+    }
+
+    const minUpdated = nowSec > maxStaleness ? nowSec - maxStaleness : 0;
+    let fresh = 0;
+    const stale = [];
+    for (const source of sources) {
+      const res = await reader.tryRead(source, PRICE_SOURCE_VIEWS, 'latestPrice', []);
+      // A reverting source is not fresh. Same rule the aggregator applies in its try/catch.
+      if (!res.ok) { stale.push({ source, reason: 'reverted' }); continue; }
+      const [priceWad, updatedAt] = normalizePrice(res.value);
+      if (priceWad > 0n && Number(updatedAt) >= minUpdated) fresh += 1;
+      else stale.push({ source, reason: priceWad > 0n ? `stale by ${minUpdated - Number(updatedAt)}s` : 'zero price' });
+    }
+
+    const margin = fresh - quorum;
+    const detail = {
+      vault, asset, oracle, freshSources: fresh, totalSources: sources.length,
+      quorum, margin, maxStalenessSec: maxStaleness, staleSources: stale,
+    };
+
+    if (margin < 0) {
+      out.push(alert({
+        signal: SIGNAL, vault, key: asset,
+        message: `oracle breaker TRIPPED for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${fresh}/${sources.length} sources fresh, quorum ${quorum} — priceWad reverts StaleOracle, NAV and exits are frozen`,
+        measured: `${fresh} fresh`, threshold: `>= ${quorum} (quorum)`, detail,
+      }));
+    } else if (margin <= minMargin) {
+      out.push(alert({
+        signal: SIGNAL, vault, key: asset,
+        message: `oracle freshness margin ${margin} for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${fresh}/${sources.length} sources fresh, quorum ${quorum} — ${margin === 0 ? 'ANY' : `${margin + 1} more`} source failure freezes NAV and exits`,
+        measured: `margin ${margin}`, threshold: `> ${minMargin}`, detail,
+      }));
+    } else {
+      out.push(ok({
+        signal: SIGNAL, vault, key: asset,
+        message: `oracle margin ${margin} for ${shortAddr(asset)} on vault ${shortAddr(vault)} (${fresh}/${sources.length} fresh, quorum ${quorum})`,
+        measured: `margin ${margin}`, threshold: `> ${minMargin}`, detail,
+      }));
+    }
+  }
+
+  return out;
+}
+
+/** assetConfig returns a 3-tuple; viem hands back an array or an object depending on ABI shape. */
+function normalizeConfig(v) {
+  const [sources, maxStaleness, quorum] = Array.isArray(v)
+    ? v
+    : [v.sources, v.maxStaleness, v.quorum];
+  return { sources: [...(sources ?? [])], maxStaleness: Number(maxStaleness), quorum: Number(quorum) };
+}
+
+/** latestPrice returns (priceWad, updatedAt). */
+function normalizePrice(v) {
+  const [p, u] = Array.isArray(v) ? v : [v.priceWad, v.updatedAt];
+  return [BigInt(p ?? 0), BigInt(u ?? 0)];
+}

--- a/packages/canary/src/signals/share-conservation.mjs
+++ b/packages/canary/src/signals/share-conservation.mjs
@@ -1,0 +1,97 @@
+// @ts-check
+/**
+ * Signal (c) — SHARE CONSERVATION. "Σ sharesOf != totalShares (indexer vs chain read)."
+ *
+ * Two comparisons against one chain read of VaultCore.totalShares():
+ *   projection.totalShares — the folded running total. A mismatch means the indexer missed or
+ *     double-counted a DepositActivated / ExitSettled.
+ *   Σ projection share book — the per-member balances summed. A mismatch against the folded
+ *     total means the projection is internally inconsistent, which is a different bug.
+ * Both are reported; either one alerting alerts the signal.
+ *
+ * THE HEIGHT PROBLEM. The indexer deliberately lags the head by CONFIRMATIONS blocks (reorg
+ * safety), so comparing its state against a `latest` chain read guarantees a false alarm every
+ * time a deposit or exit lands in the confirmation window. So the chain read is PINNED to the
+ * snapshot's own `lastBlock`, which makes the comparison exact rather than approximate.
+ *
+ * If the RPC cannot serve state at that height (a pruned, non-archive node), the check falls back
+ * to `latest` and marks itself unpinned. An unpinned mismatch is racy by construction, so the
+ * runner is told to require repeated observations before paging — see `minConsecutive` in
+ * transitions.mjs. That keeps the signal alive on a pruned node instead of silently dead, without
+ * paging on ordinary indexer lag.
+ */
+
+import { VAULT_VIEWS } from '../abis.mjs';
+import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'share-conservation';
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {bigint} ctx.projectedTotalShares  state.vaults.get(vault).totalShares
+ * @param {Map<string,bigint>|Iterable<[string,bigint]>} [ctx.shareBook]  state.shares.get(vault)
+ * @param {number} [ctx.atBlock]  the snapshot's lastBlock — pins the chain read to the indexer's height
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkShareConservation({ reader, vault, projectedTotalShares, shareBook, atBlock }) {
+  let pinned = atBlock != null;
+  let res = pinned
+    ? await reader.tryRead(vault, VAULT_VIEWS, 'totalShares', [], { blockNumber: atBlock })
+    : await reader.tryRead(vault, VAULT_VIEWS, 'totalShares', []);
+
+  if (!res.ok && pinned) {
+    // Almost always "missing trie node" / "state unavailable" on a pruned node, not a real fault.
+    pinned = false;
+    res = await reader.tryRead(vault, VAULT_VIEWS, 'totalShares', []);
+  }
+  if (!res.ok) {
+    return [skipped({
+      signal: SIGNAL, vault,
+      message: `share conservation skipped on vault ${shortAddr(vault)}: totalShares() is unreadable: ${res.error}`,
+      detail: { vault },
+    })];
+  }
+
+  const onChain = BigInt(res.value);
+  const projected = BigInt(projectedTotalShares ?? 0n);
+  let bookSum = 0n;
+  let holders = 0;
+  for (const [, bal] of shareBook ?? []) { bookSum += BigInt(bal); holders += 1; }
+
+  const detail = {
+    vault,
+    atBlock: pinned ? atBlock : null,
+    pinned,
+    onChainTotalShares: onChain.toString(),
+    projectedTotalShares: projected.toString(),
+    shareBookSum: bookSum.toString(),
+    holders,
+    // The runner requires two consecutive observations before paging an unpinned mismatch,
+    // because an unpinned read races the indexer's confirmation lag.
+    minConsecutive: pinned ? 1 : 2,
+  };
+  const where = pinned ? `at block ${atBlock}` : 'at chain head (UNPINNED — the RPC has no archive state at the indexer height)';
+
+  const projDiff = onChain - projected;
+  const bookDiff = onChain - bookSum;
+  if (projDiff !== 0n || bookDiff !== 0n) {
+    const parts = [];
+    if (projDiff !== 0n) parts.push(`indexer totalShares ${projected} vs chain ${onChain} (off by ${abs(projDiff)})`);
+    if (bookDiff !== 0n) parts.push(`Σ sharesOf over ${holders} holders = ${bookSum} vs chain ${onChain} (off by ${abs(bookDiff)})`);
+    return [alert({
+      signal: SIGNAL, vault,
+      message: `share conservation broken on vault ${shortAddr(vault)} ${where}: ${parts.join('; ')}`,
+      measured: `Δ ${abs(projDiff !== 0n ? projDiff : bookDiff)} shares`, threshold: 'exactly 0', detail,
+    })];
+  }
+
+  return [ok({
+    signal: SIGNAL, vault,
+    message: `share conservation on vault ${shortAddr(vault)} ${where}: ${onChain} shares across ${holders} holders`,
+    measured: 'Δ 0 shares', threshold: 'exactly 0', detail,
+  })];
+}
+
+const abs = (x) => (x < 0n ? -x : x);

--- a/packages/canary/src/sinks.mjs
+++ b/packages/canary/src/sinks.mjs
@@ -1,0 +1,81 @@
+// @ts-check
+/**
+ * Where transition lines go. Two sinks, both optional-failure-tolerant: a sink that throws must
+ * never take the canary down, because a paging outage is not a reason to stop watching the chain.
+ *
+ * console  — always on. stdout for recoveries, stderr for alerts and degradations, so a `2>` split
+ *            gives you a pure problem feed.
+ * webhook  — on iff ALERT_WEBHOOK_URL is set. POSTs one JSON body per transition, carrying the
+ *            structured `detail` from the signal so a receiver can route on vault or signal
+ *            without parsing the human line.
+ */
+
+/** @param {{log?:Function, error?:Function}} [io] */
+export function createConsoleSink({ log = console.log, error = console.error } = {}) {
+  return {
+    name: 'console',
+    /** @param {import('./transitions.mjs').Transition} t */
+    async emit(t) {
+      (t.to === 'ok' ? log : error)(t.line);
+    },
+  };
+}
+
+/**
+ * @param {Object} cfg
+ * @param {string} cfg.url
+ * @param {typeof fetch} [cfg.fetchImpl]  injected in tests
+ * @param {number} [cfg.timeoutMs]
+ * @param {Function} [cfg.onError]        how to report a delivery failure (default: console.error)
+ */
+export function createWebhookSink({ url, fetchImpl = globalThis.fetch, timeoutMs = 5000, onError = console.error }) {
+  return {
+    name: 'webhook',
+    /** @param {import('./transitions.mjs').Transition} t */
+    async emit(t) {
+      const body = {
+        text: t.line,
+        status: t.to,
+        previousStatus: t.from,
+        signal: t.signal,
+        vault: t.vault,
+        key: t.key ?? null,
+        measured: t.result.measured ?? null,
+        threshold: t.result.threshold ?? null,
+        detail: t.result.detail ?? {},
+      };
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(), timeoutMs);
+      try {
+        const res = await fetchImpl(url, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)),
+          signal: ac.signal,
+        });
+        if (!res?.ok) onError(`canary: webhook returned ${res?.status ?? '?'} for ${t.id}`);
+      } catch (err) {
+        onError(`canary: webhook delivery failed for ${t.id}: ${err?.message ?? err}`);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+/**
+ * Fan one transition out to every sink. A throwing sink is reported and skipped, never fatal.
+ * @param {Array<{name:string, emit:Function}>} sinks
+ * @param {import('./transitions.mjs').Transition[]} transitions
+ */
+export async function emitAll(sinks, transitions, { onError = console.error } = {}) {
+  for (const t of transitions) {
+    for (const sink of sinks) {
+      try {
+        await sink.emit(t);
+      } catch (err) {
+        onError(`canary: sink ${sink.name} threw on ${t.id}: ${err?.message ?? err}`);
+      }
+    }
+  }
+}

--- a/packages/canary/src/transitions.mjs
+++ b/packages/canary/src/transitions.mjs
@@ -1,0 +1,120 @@
+// @ts-check
+/**
+ * Transition detection: turn a stream of per-poll signal observations into the handful of lines an
+ * operator should actually read. Pure — no I/O, no clock, no formatting of its own beyond the
+ * alert line. Persistence is the runner's job (see canary-runner.mjs).
+ *
+ * RULES
+ *  - One line per TRANSITION only. A signal that stays OK poll after poll emits nothing, which is
+ *    the entire point: silence means healthy, so any output is worth looking at.
+ *  - State is keyed by the signal's full id — `signal|vault|key` — so per-asset oracle freshness
+ *    tracks each asset separately and one stale asset cannot flap a whole vault's signal.
+ *  - The FIRST observation of an ALERT emits. The first observation of an OK does not: a canary
+ *    starting up against a healthy chain must not announce every signal it is watching.
+ *  - `skipped` is its own state, not a silent `ok`. OK→SKIPPED emits, because a sentinel that has
+ *    stopped being able to run is exactly the thing you would otherwise never notice.
+ *  - `minConsecutive` (carried on a result's `detail`) requires N consecutive same-status
+ *    observations before a transition is emitted. Used by share-conservation when it cannot pin
+ *    its chain read to the indexer's height, where a one-poll mismatch is ordinary lag.
+ */
+
+/**
+ * @typedef {{status:'ok'|'alert'|'skipped', since:number, pendingStatus:string|null, pendingCount:number}} TrackedState
+ * @typedef {Object} Transition
+ * @property {string} id
+ * @property {string} signal
+ * @property {string} vault
+ * @property {string} [key]
+ * @property {'ok'|'alert'|'skipped'} from
+ * @property {'ok'|'alert'|'skipped'} to
+ * @property {string} line       the operator-facing one-liner
+ * @property {import('./signal.mjs').SignalResult} result
+ */
+
+/** Rendered prefix per destination status. */
+const MARK = { alert: 'ALERT', ok: 'RECOVERED', skipped: 'DEGRADED' };
+
+/**
+ * Format one transition line. Every alert line carries vault, signal, and measured-vs-threshold,
+ * so it is actionable without opening a dashboard.
+ * @param {'ok'|'alert'|'skipped'} to
+ * @param {import('./signal.mjs').SignalResult} r
+ * @param {string} [timestamp] ISO time; the runner supplies it so this stays clock-free
+ */
+export function formatLine(to, r, timestamp) {
+  const bits = [timestamp, MARK[to] ?? to.toUpperCase(), `[${r.signal}]`, r.message];
+  const mt = r.measured != null && r.threshold != null ? `(measured ${r.measured}, threshold ${r.threshold})` : null;
+  return [...bits.filter(Boolean), mt].filter(Boolean).join(' ');
+}
+
+/**
+ * @param {Object} [opts]
+ * @param {Record<string, TrackedState>} [opts.initial] restored state from disk
+ */
+export function createTransitionTracker({ initial = {} } = {}) {
+  /** @type {Map<string, TrackedState>} */
+  const states = new Map(Object.entries(initial ?? {}));
+
+  /**
+   * Feed one poll's worth of results; get back only what changed.
+   * @param {import('./signal.mjs').SignalResult[]} results
+   * @param {{poll?:number, timestamp?:string}} [ctx]
+   * @returns {Transition[]}
+   */
+  function observe(results, { poll = 0, timestamp } = {}) {
+    /** @type {Transition[]} */
+    const out = [];
+
+    for (const r of results) {
+      const need = Math.max(1, Number(r.detail?.minConsecutive ?? 1));
+      const prev = states.get(r.id);
+
+      if (!prev) {
+        // First sighting. Record it; announce only if it is already wrong.
+        states.set(r.id, { status: r.status, since: poll, pendingStatus: null, pendingCount: 0 });
+        if (r.status !== 'ok') {
+          out.push({
+            id: r.id, signal: r.signal, vault: r.vault, key: r.key,
+            from: 'ok', to: r.status, line: formatLine(r.status, r, timestamp), result: r,
+          });
+        }
+        continue;
+      }
+
+      if (r.status === prev.status) {
+        prev.pendingStatus = null;
+        prev.pendingCount = 0;
+        continue;
+      }
+
+      // Status differs. Require `need` consecutive observations of the new status before flipping.
+      prev.pendingCount = prev.pendingStatus === r.status ? prev.pendingCount + 1 : 1;
+      prev.pendingStatus = r.status;
+      if (prev.pendingCount < need) continue;
+
+      const from = prev.status;
+      prev.status = r.status;
+      prev.since = poll;
+      prev.pendingStatus = null;
+      prev.pendingCount = 0;
+      out.push({
+        id: r.id, signal: r.signal, vault: r.vault, key: r.key,
+        from, to: r.status, line: formatLine(r.status, r, timestamp), result: r,
+      });
+    }
+
+    return out;
+  }
+
+  /** Serializable snapshot — the runner persists this so a restart does not re-page. */
+  function snapshot() {
+    return Object.fromEntries(states.entries());
+  }
+
+  /** Currently-not-OK signals, for the periodic heartbeat summary. */
+  function unhealthy() {
+    return [...states.entries()].filter(([, s]) => s.status !== 'ok').map(([id, s]) => ({ id, ...s }));
+  }
+
+  return { observe, snapshot, unhealthy, get size() { return states.size; } };
+}

--- a/packages/canary/test/abis.test.mjs
+++ b/packages/canary/test/abis.test.mjs
@@ -1,0 +1,129 @@
+// @ts-check
+/**
+ * Drift guard for the embedded 4-byte selectors.
+ *
+ * abis.mjs hardcodes selectors so it needs no keccak and no viem at import time. That is only
+ * safe if something recomputes them: this file does, with viem, and fails if a Solidity signature
+ * ever moves out from under the exit-liveness classifier. A wrong selector there would silently
+ * reclassify a real H-1 fault as a benign gate revert — the exact failure this package exists to
+ * prevent — so the guard is not optional bookkeeping.
+ *
+ * Skips itself when viem is absent, matching packages/indexer/test/abis.test.mjs, so a bare
+ * checkout still runs the suite. CI installs viem (`npm ci`), so the guard bites there.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  REQUEST_EXIT_SELECTOR, EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS,
+  VAULT_VIEWS, ORACLE_VIEWS, VAULT_WATCH_EVENTS, ERC20_TRANSFER_EVENT, EXIT_SETTLED_EVENT,
+  signatureOf,
+} from '../src/abis.mjs';
+
+const viem = await import('viem').catch(() => null);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = join(here, '../../../contracts/out');
+const vaultAbiPath = join(OUT, 'VaultCore.sol/VaultCore.json');
+const built = existsSync(vaultAbiPath);
+const vaultAbi = built ? JSON.parse(readFileSync(vaultAbiPath, 'utf8')).abi ?? [] : [];
+const canonical = (item) => `${item.name}(${item.inputs.map((i) => i.type).join(',')})`;
+
+/** Every embedded selector, mapped to the Solidity signature it must equal. */
+const EXPECTED = {
+  'requestExit(uint256)': REQUEST_EXIT_SELECTOR,
+  'ZeroAmount()': '0x1f2a2005',
+  'ExitAlreadyQueued()': '0xf2698fc0',
+  'InsufficientShares()': '0x39996567',
+  'CreatorStakeGate()': '0xa428ab2d',
+  'ExitNeedsChildSettlement()': '0x07b1ee59',
+  'ChildSettlementPending()': '0xb5ac4fd1',
+  'StaleOracle(address)': '0xa2671f4b',
+  'Reentrancy()': '0xab143c06',
+  'NoQueuedExit()': '0xe752017c',
+  'ExecutionStillPending()': '0x885cf1d7',
+  'Error(string)': '0x08c379a0',
+  'Panic(uint256)': '0x4e487b71',
+};
+
+test('every embedded selector matches the keccak of its signature', { skip: !viem && 'viem not installed' }, () => {
+  for (const [sig, selector] of Object.entries(EXPECTED)) {
+    assert.equal(viem.toFunctionSelector(sig), selector, `selector drift for ${sig}`);
+  }
+});
+
+test('the classification tables are disjoint — no selector can be both a gate and a fault', () => {
+  const tables = [EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS];
+  const seen = new Set();
+  for (const table of tables) {
+    for (const sel of Object.keys(table)) {
+      assert.ok(!seen.has(sel), `selector ${sel} appears in more than one classification table`);
+      seen.add(sel);
+    }
+  }
+  assert.equal(seen.size, 12);
+});
+
+test('StaleOracle is NOT filed as a gate — it must never read as a healthy exit', () => {
+  assert.ok(!('0xa2671f4b' in EXIT_GATE_SELECTORS));
+  assert.ok('0xa2671f4b' in EXIT_FROZEN_SELECTORS);
+});
+
+test('the ABI table declares no state-changing function — the canary is read-only by construction', () => {
+  for (const frag of [...VAULT_VIEWS, ...ORACLE_VIEWS]) {
+    assert.equal(frag.stateMutability, 'view', `${frag.name} is not a view function`);
+  }
+});
+
+test('watched event signatures match the contracts they are read from', { skip: !viem && 'viem not installed' }, () => {
+  // These must equal the Solidity declarations in VaultCore.sol / the ERC20 standard, or getLogs
+  // silently matches nothing and every event signal reports a permanent, false "0 events".
+  const expected = {
+    'ModuleCallFailed(bytes32,address)': VAULT_WATCH_EVENTS[0],
+    'SliceEscrowed(address,address,uint256)': VAULT_WATCH_EVENTS[1],
+    'Transfer(address,address,uint256)': ERC20_TRANSFER_EVENT,
+    'ExitSettled(address,uint256,uint256,uint256,uint256)': EXIT_SETTLED_EVENT,
+  };
+  for (const [sig, frag] of Object.entries(expected)) {
+    assert.equal(signatureOf(frag), sig);
+    assert.equal(viem.toEventSelector(sig), viem.toEventSelector(signatureOf(frag)));
+  }
+});
+
+// ── the real drift guard: compare against the COMPILED contracts, not just against ourselves ──
+
+test('watched events exist on the compiled VaultCore with the same signature', { skip: !built && 'contracts/out absent — run `cd contracts && forge build`' }, () => {
+  const declared = new Set(vaultAbi.filter((i) => i.type === 'event').map(canonical));
+  for (const frag of [...VAULT_WATCH_EVENTS, EXIT_SETTLED_EVENT]) {
+    assert.ok(declared.has(signatureOf(frag)), `${signatureOf(frag)} is not an event on the compiled VaultCore`);
+  }
+});
+
+test('classified revert selectors correspond to errors the compiled VaultCore can actually throw', { skip: (!built || !viem) && 'needs contracts/out and viem', }, () => {
+  const errors = new Set(vaultAbi.filter((i) => i.type === 'error').map(canonical));
+  // Every GATE selector must be a real VaultCore error. If one of these silently stopped
+  // existing, the classifier would file a live fault as a benign gate and the sentinel would
+  // go quiet during an outage.
+  for (const [selector, name] of Object.entries(EXIT_GATE_SELECTORS)) {
+    const sig = `${name}()`;
+    assert.ok(errors.has(sig), `${sig} is no longer an error on VaultCore — the gate classification is stale`);
+    assert.equal(viem.toFunctionSelector(sig), selector);
+  }
+});
+
+test('the views the signals read exist on the compiled VaultCore', { skip: !built && 'contracts/out absent' }, () => {
+  const fns = new Map(vaultAbi.filter((i) => i.type === 'function').map((i) => [canonical(i), i]));
+  for (const frag of VAULT_VIEWS) {
+    const sig = signatureOf(frag);
+    const onChain = fns.get(sig);
+    assert.ok(onChain, `VaultCore has no ${sig} — the canary would read a reverting selector`);
+    assert.equal(onChain.stateMutability, 'view', `${sig} is not a view on the compiled contract`);
+  }
+});
+
+test('requestExit(uint256) is a real VaultCore function — the sentinel probes a live selector', { skip: !built && 'contracts/out absent' }, () => {
+  const fns = vaultAbi.filter((i) => i.type === 'function').map(canonical);
+  assert.ok(fns.includes('requestExit(uint256)'));
+});

--- a/packages/canary/test/exit-liveness.test.mjs
+++ b/packages/canary/test/exit-liveness.test.mjs
@@ -1,0 +1,142 @@
+// @ts-check
+/**
+ * Signal (d) — the H-1 exit-liveness sentinel.
+ *
+ * This is the signal that can ship looking green and be worthless, so it gets the most adversarial
+ * coverage in the package. The three cases that prove the sentinel is REAL rather than vacuous:
+ *   1. a non-gate revert (Reentrancy) ALERTS
+ *   2. EMPTY returndata — the actual H-1 out-of-gas / returndata-bomb signature — ALERTS
+ *   3. no member holding shares is SKIPPED, never OK
+ * If those three hold, the sentinel cannot silently pass while exits are bricked.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkExitLiveness, pickProbeMember, encodeRequestExit } from '../src/signals/exit-liveness.mjs';
+import { mockReader, VAULT, MEMBER, CREATOR } from './helpers.mjs';
+
+const REENTRANCY = '0xab143c06';
+const STALE_ORACLE = '0xa2671f4b';
+const INSUFFICIENT_SHARES = '0x39996567';
+const CREATOR_GATE = '0xa428ab2d';
+
+const book = new Map([[MEMBER, 400n], [CREATOR, 100n]]);
+
+/** @param {{ok:boolean,data?:string|null}} outcome */
+function readerReturning(outcome) {
+  return mockReader({ contracts: {}, onStaticCall: () => outcome });
+}
+
+test('encodes requestExit(uint256) with the right selector and a padded argument', () => {
+  assert.equal(encodeRequestExit(1n), `0x721c6513${'0'.repeat(63)}1`);
+  assert.equal(encodeRequestExit(255n).slice(0, 10), '0x721c6513');
+  assert.ok(encodeRequestExit(255n).endsWith('ff'));
+  assert.equal(encodeRequestExit(255n).length, 10 + 64);
+});
+
+test('probe member: prefers a non-creator holder, largest balance first', () => {
+  const picked = pickProbeMember(book, CREATOR);
+  assert.equal(picked.member, MEMBER);
+  assert.equal(picked.shares, 400n);
+});
+
+test('probe member: falls back to the creator when they are the only holder', () => {
+  const picked = pickProbeMember(new Map([[CREATOR, 100n]]), CREATOR);
+  assert.equal(picked.member, CREATOR);
+});
+
+test('probe member: ignores zero balances, returns null when nobody holds shares', () => {
+  assert.equal(pickProbeMember(new Map([[MEMBER, 0n]]), CREATOR), null);
+  assert.equal(pickProbeMember(new Map(), CREATOR), null);
+  assert.equal(pickProbeMember(undefined, CREATOR), null);
+});
+
+// ── HEALTHY ──────────────────────────────────────────────────────────────────
+
+test('OK when the static call succeeds — exits are live', async () => {
+  const reader = readerReturning({ ok: true, data: '0x' });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  assert.equal(r.status, 'ok');
+  assert.match(r.message, /exits live/);
+});
+
+test('OK on a gate revert — InsufficientShares is the caller position, not a fault', async () => {
+  const reader = readerReturning({ ok: false, data: INSUFFICIENT_SHARES });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.revertName, 'InsufficientShares');
+});
+
+test('OK on the creator stake gate (CM-1) — a gate, not a liveness fault', async () => {
+  const reader = readerReturning({ ok: false, data: CREATOR_GATE });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: new Map([[CREATOR, 100n]]), creator: CREATOR });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.revertName, 'CreatorStakeGate');
+});
+
+test('probes as a real member, with a nonzero share amount, against the vault', async () => {
+  const reader = readerReturning({ ok: true, data: '0x' });
+  await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  const call = reader.calls.find((c) => c.kind === 'staticCall');
+  assert.equal(call.to, VAULT);
+  assert.equal(call.from, MEMBER, 'must impersonate a holder, or every probe hits InsufficientShares');
+  assert.notEqual(call.data, `0x721c6513${'0'.repeat(64)}`, 'must not probe with 0 shares — that always reverts ZeroAmount');
+});
+
+// ── THE THREE CASES THAT PROVE THE SENTINEL IS REAL ──────────────────────────
+
+test('ALERTS on a non-gate revert (Reentrancy) — H-1 regression', async () => {
+  const reader = readerReturning({ ok: false, data: REENTRANCY });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.revertName, 'Reentrancy');
+  assert.match(r.message, /EXIT LIVENESS BROKEN/);
+  assert.match(r.message, /H-1 regression/);
+  assert.ok(r.message.includes(VAULT.slice(0, 6)), 'alert line must name the vault');
+  assert.ok(r.measured && r.threshold, 'alert line must carry measured vs threshold');
+});
+
+test('ALERTS on EMPTY returndata — the out-of-gas / returndata-bomb H-1 signature', async () => {
+  for (const data of [null, '0x', '0x00']) {
+    const reader = readerReturning({ ok: false, data });
+    const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+    assert.equal(r.status, 'alert', `empty returndata ${JSON.stringify(data)} must alert, never pass`);
+    assert.match(r.message, /EMPTY returndata/);
+  }
+});
+
+test('SKIPPED — not ok — when no member holds shares, so the probe cannot run', async () => {
+  const reader = readerReturning({ ok: true, data: '0x' });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: new Map(), creator: CREATOR });
+  assert.equal(r.status, 'skipped');
+  assert.notEqual(r.status, 'ok', 'a check that cannot run has NOT passed');
+  assert.match(r.message, /CANNOT RUN/);
+  assert.equal(r.detail.reason, 'no-eligible-member');
+  assert.equal(reader.calls.filter((c) => c.kind === 'staticCall').length, 0, 'must not call at all');
+});
+
+// ── FROZEN: attributed to the oracle, never reported healthy ─────────────────
+
+test('SKIPPED and attributed to the oracle on StaleOracle — never OK during a capital freeze', async () => {
+  const reader = readerReturning({ ok: false, data: STALE_ORACLE });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  assert.equal(r.status, 'skipped');
+  assert.notEqual(r.status, 'ok');
+  assert.equal(r.detail.attributedTo, 'oracle-freshness');
+  assert.match(r.message, /StaleOracle/);
+});
+
+test('ALERTS on an unrecognized selector rather than assuming it is benign', async () => {
+  const reader = readerReturning({ ok: false, data: '0xdeadbeef' });
+  const [r] = await checkExitLiveness({ reader, vault: VAULT, shareBook: book, creator: CREATOR });
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /unrecognized revert 0xdeadbeef/);
+});
+
+test('probe amount is clamped to the member balance so it never self-inflicts InsufficientShares', async () => {
+  const reader = readerReturning({ ok: true, data: '0x' });
+  await checkExitLiveness({
+    reader, vault: VAULT, shareBook: new Map([[MEMBER, 1n]]), creator: CREATOR, probeShares: 10n,
+  });
+  const call = reader.calls.find((c) => c.kind === 'staticCall');
+  assert.equal(BigInt(`0x${call.data.slice(10)}`), 1n);
+});

--- a/packages/canary/test/fee-routing.test.mjs
+++ b/packages/canary/test/fee-routing.test.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+/**
+ * Signal (f) — fee routing (EE-9 / MO-4).
+ *
+ * The tests that matter most are the two that keep this signal from crying wolf:
+ *   - an operator who is ALSO a member exiting their own position is legitimate (EE-9), and
+ *   - a USDC transfer to the FeeEngine is the claim flow working, not a leak.
+ * A signal that pages on either of those gets muted, and a muted signal catches nothing.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkFeeRouting } from '../src/signals/fee-routing.mjs';
+import { mockReader, healthyVault, log, VAULT, USDC, REGISTRY, OPERATOR, MEMBER, FEE_ENGINE } from './helpers.mjs';
+
+const W = { fromBlock: 100, toBlock: 200 };
+const transfer = (to, value, block = 150) => log(USDC, 'Transfer', block, { from: VAULT, to, value });
+
+const run = (logs, contracts = healthyVault()) => checkFeeRouting({
+  reader: mockReader({ contracts, logs }),
+  vault: VAULT, usdc: USDC, operatorRegistry: REGISTRY, ...W,
+});
+
+test('OK when no USDC leaves the vault at all', async () => {
+  const [r] = await run([]);
+  assert.equal(r.status, 'ok');
+});
+
+test('OK when USDC goes to the FeeEngine — that IS the claim flow', async () => {
+  const [r] = await run([transfer(FEE_ENGINE, 1_000_000n)]);
+  assert.equal(r.status, 'ok');
+  assert.match(r.message, /none to an operator address/);
+});
+
+test('OK when USDC goes to an ordinary member (an exit payout)', async () => {
+  const [r] = await run([transfer(MEMBER, 5_000_000n)]);
+  assert.equal(r.status, 'ok');
+});
+
+test('ALERTS on a direct USDC transfer to the registered operator address', async () => {
+  const [r] = await run([transfer(OPERATOR, 250_000n)]);
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /FEE ROUTING VIOLATION/);
+  assert.match(r.message, /FeeEngine\.claimFees/);
+  assert.equal(r.measured, '1 transfer(s), 250000 USDC base units');
+  assert.equal(r.detail.transfers[0].to, OPERATOR);
+  assert.equal(r.detail.transfers[0].blockNumber, 150);
+  assert.deepEqual(r.detail.threatModelRows, ['EE-9', 'MO-4']);
+});
+
+test('OK when the operator is also a MEMBER exiting their own position (EE-9)', async () => {
+  const [r] = await run([
+    transfer(OPERATOR, 250_000n, 150),
+    log(VAULT, 'ExitSettled', 150, { member: OPERATOR, sharesBurned: 1n, usdcPaid: 250_000n, exitFeeBps: 0n, perfFeeUsdc: 0n }),
+  ]);
+  assert.equal(r.status, 'ok', 'operator-as-member is explicitly legitimate — the prohibition is on ROUTING');
+  assert.equal(r.detail.excusedAsMemberSettlement, 1);
+});
+
+test('OK when the operator cancels their own pending deposit (a refund, not a fee)', async () => {
+  const [r] = await run([
+    transfer(OPERATOR, 250_000n, 150),
+    log(VAULT, 'PendingCancelled', 150, { member: OPERATOR, amountUsdc: 250_000n }),
+  ]);
+  assert.equal(r.status, 'ok');
+});
+
+test('still ALERTS when a settlement in a DIFFERENT block is used as cover', async () => {
+  const [r] = await run([
+    transfer(OPERATOR, 250_000n, 150),
+    log(VAULT, 'ExitSettled', 151, { member: OPERATOR, sharesBurned: 1n, usdcPaid: 1n, exitFeeBps: 0n, perfFeeUsdc: 0n }),
+  ]);
+  assert.equal(r.status, 'alert', 'the discriminator is same-block, so an unrelated exit cannot excuse a leak');
+});
+
+test('excuses the settled transfer and still alerts on the unsettled one in the same window', async () => {
+  const [r] = await run([
+    transfer(OPERATOR, 100n, 150),
+    log(VAULT, 'ExitSettled', 150, { member: OPERATOR, sharesBurned: 1n, usdcPaid: 100n, exitFeeBps: 0n, perfFeeUsdc: 0n }),
+    transfer(OPERATOR, 900n, 160),
+  ]);
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.excusedAsMemberSettlement, 1);
+  assert.equal(r.detail.transfers.length, 1);
+  assert.equal(r.detail.transfers[0].value, '900');
+});
+
+test('honours EXTRA_OPERATOR_ADDRESSES for operators the registry does not name', async () => {
+  const ROGUE = '0x' + 'f'.repeat(40);
+  const [r] = await checkFeeRouting({
+    reader: mockReader({ contracts: healthyVault(), logs: [transfer(ROGUE, 1n)] }),
+    vault: VAULT, usdc: USDC, operatorRegistry: REGISTRY, extraOperators: [ROGUE], ...W,
+  });
+  assert.equal(r.status, 'alert');
+});
+
+test('OK on an unattested vault — operatorId 0 means there is no operator to leak to', async () => {
+  const [r] = await run([transfer(OPERATOR, 1n)], healthyVault({ [REGISTRY]: { operatorOf: () => 0n } }));
+  assert.equal(r.status, 'ok');
+  assert.match(r.message, /unattested vault/);
+});
+
+test('DEGRADED, not OK, when the registry is unreadable', async () => {
+  const [r] = await run([transfer(OPERATOR, 1n)], healthyVault({ [REGISTRY]: { operatorOf: () => ({ revert: '0xdeadbeef' }) } }));
+  assert.equal(r.status, 'skipped');
+  assert.notEqual(r.status, 'ok');
+});
+
+test('matches the operator address case-insensitively', async () => {
+  const [r] = await run([transfer(OPERATOR.toUpperCase().replace('0X', '0x'), 1n)]);
+  assert.equal(r.status, 'alert', 'viem checksums decoded address args — a case-sensitive compare would miss the leak');
+});

--- a/packages/canary/test/helpers.mjs
+++ b/packages/canary/test/helpers.mjs
@@ -1,0 +1,166 @@
+// @ts-check
+/**
+ * Mocked chain plumbing shared by the canary tests. NO LIVE RPC ANYWHERE — every test in this
+ * package injects one of these readers, which is exactly the interface reader.mjs exposes.
+ *
+ * A contract is declared as `{ address: { fnName: value | fn(args) | {revert: '0xselector…'} } }`.
+ * Returning `{revert}` makes tryRead/read behave the way viem does on a revert, carrying the
+ * returndata, so the signals' revert-classification paths are exercised for real.
+ */
+
+export const A = (c) => `0x${String(c).repeat(40).slice(0, 40)}`;
+
+// Real 20-byte hex — resolveCanaryConfig validates addresses, so a fixture with a stray
+// non-hex character would fail config parsing rather than the behaviour under test.
+export const VAULT = `0x${'a1'.repeat(18)}cafe`;
+export const CHILD = `0x${'b2'.repeat(18)}beef`;
+export const ORACLE = A('1');
+export const USDC = A('2');
+export const ASSET = A('3');
+export const REGISTRY = A('4');
+export const CREATOR = A('5');
+export const MEMBER = A('6');
+export const OPERATOR = A('7');
+export const FEE_ENGINE = A('8');
+export const SRC1 = A('a');
+export const SRC2 = A('b');
+export const SRC3 = A('c');
+
+const lc = (x) => (typeof x === 'string' ? x.toLowerCase() : x);
+
+class MockRevert extends Error {
+  constructor(data) {
+    super(`execution reverted${data ? ` (${data})` : ''}`);
+    this.data = data ?? undefined;
+    this.shortMessage = this.message;
+  }
+}
+
+/**
+ * @param {Object} cfg
+ * @param {Record<string, Record<string, any>>} cfg.contracts
+ * @param {Array<any>} [cfg.logs]           each: {address, eventName, blockNumber, logIndex, args, transactionHash}
+ * @param {number} [cfg.head]
+ * @param {number} [cfg.nowSec]
+ * @param {(ctx:{to:string,from:string,data:string})=>{ok:boolean,data?:string|null}} [cfg.onStaticCall]
+ * @param {Set<number>} [cfg.archiveBlocks] heights whose state the mock node can serve (default: all)
+ */
+export function mockReader({ contracts, logs = [], head = 1000, nowSec = 1_700_000_000, onStaticCall, archiveBlocks }) {
+  /** every call the reader made, so tests can assert on read pinning */
+  const calls = [];
+
+  function resolve(address, fn, args, opts) {
+    const c = contracts[lc(address)];
+    if (!c) throw new MockRevert(null);
+    if (opts?.blockNumber != null && archiveBlocks && !archiveBlocks.has(Number(opts.blockNumber))) {
+      throw new Error(`missing trie node: no state for block ${opts.blockNumber}`);
+    }
+    if (!(fn in c)) throw new MockRevert(null);
+    const entry = c[fn];
+    const value = typeof entry === 'function' ? entry(...args) : entry;
+    if (value && typeof value === 'object' && 'revert' in value) throw new MockRevert(value.revert);
+    return value;
+  }
+
+  const reader = {
+    async headBlock() { return head; },
+    async chainNow() { return nowSec; },
+    async read(address, _abi, fn, args = [], opts = {}) {
+      calls.push({ kind: 'read', address: lc(address), fn, args, blockNumber: opts.blockNumber ?? null });
+      return resolve(address, fn, args, opts);
+    },
+    async tryRead(address, _abi, fn, args = [], opts = {}) {
+      try {
+        return { ok: true, value: await reader.read(address, _abi, fn, args, opts) };
+      } catch (err) {
+        return { ok: false, revertData: err.data ?? null, error: err.message };
+      }
+    },
+    async getLogs({ address, event, args, fromBlock, toBlock }) {
+      const addrs = new Set((Array.isArray(address) ? address : [address]).map(lc));
+      return logs.filter((l) => addrs.has(lc(l.address))
+        && l.eventName === event.name
+        && Number(l.blockNumber) >= Number(fromBlock)
+        && Number(l.blockNumber) <= Number(toBlock)
+        && (!args || Object.entries(args).every(([k, v]) => lc(l.args?.[k]) === lc(v))));
+    },
+    async staticCall(ctx) {
+      calls.push({ kind: 'staticCall', ...ctx });
+      return onStaticCall ? onStaticCall(ctx) : { ok: true, data: '0x' };
+    },
+    calls,
+  };
+  return reader;
+}
+
+/** A log in the shape viem's getLogs returns (bigint blockNumber, decoded args). */
+export function log(address, eventName, blockNumber, args, { logIndex = 0, transactionHash = '0xtx' } = {}) {
+  return { address, eventName, blockNumber: BigInt(blockNumber), logIndex, args, transactionHash };
+}
+
+/**
+ * A single-vault fixture that is HEALTHY on every signal, so each test can perturb exactly one
+ * thing and prove the signal reacts to that and nothing else.
+ *
+ * NAV arithmetic (mirrors VaultCore.navWad):
+ *   idleUsdc 1_000_000 (1 USDC, 6dp) * usdcScalar 1e12                       = 1e18
+ *   assetBalance[ASSET] 2e18 * priceWad 3e18 / assetUnit 1e18                = 6e18
+ *   navWad                                                                   = 7e18
+ */
+export function healthyVault(overrides = {}) {
+  const oracleSources = [SRC1, SRC2, SRC3];
+  const fresh = { latestPrice: [3_000000000000000000n, BigInt(1_699_999_000)] };
+
+  const contracts = {
+    [VAULT]: {
+      navWad: 7_000000000000000000n,
+      totalShares: 500_000000000000000000n,
+      idleUsdc: 1_000_000n,
+      totalPendingUsdc: 0n,
+      usdcScalar: 1_000000000000n,
+      usdc: USDC,
+      oracle: ORACLE,
+      feeEngine: FEE_ENGINE,
+      creator: CREATOR,
+      operatorRegistry: REGISTRY,
+      basketLength: 1n,
+      basketAssets: () => ASSET,
+      assetUnit: (a) => (lc(a) === lc(ASSET) ? 1_000000000000000000n : 0n),
+      assetBalance: (a) => (lc(a) === lc(ASSET) ? 2_000000000000000000n : 0n),
+      childVaultCount: 0n,
+      childVaults: () => { throw new Error('no children'); },
+      sharesOf: () => 0n,
+    },
+    [ORACLE]: {
+      priceWad: () => 3_000000000000000000n,
+      assetConfig: () => [oracleSources, 3600, 2],
+    },
+    [SRC1]: fresh,
+    [SRC2]: fresh,
+    [SRC3]: fresh,
+    [USDC]: { balanceOf: () => 1_000_000n },
+    [ASSET]: { balanceOf: () => 2_000000000000000000n },
+    [REGISTRY]: {
+      operatorOf: () => 7n,
+      operatorAddressOf: () => OPERATOR,
+    },
+  };
+
+  for (const [addr, patch] of Object.entries(overrides)) {
+    contracts[lc(addr)] = { ...(contracts[lc(addr)] ?? {}), ...patch };
+  }
+  return contracts;
+}
+
+/** The indexer projection state the canary reads, matching the healthy fixture. */
+export function healthyState({ totalShares = 500_000000000000000000n, book, lastBlock = 995 } = {}) {
+  return {
+    vaults: new Map([[VAULT, { vault: VAULT, totalShares, creator: CREATOR }]]),
+    shares: new Map([[VAULT, book ?? new Map([[MEMBER, 400_000000000000000000n], [CREATOR, 100_000000000000000000n]])]]),
+    operators: new Map(),
+    proposals: new Map(),
+    activeProposal: new Map(),
+    lastBlock,
+    lastLogIndex: 0,
+  };
+}

--- a/packages/canary/test/module-events.test.mjs
+++ b/packages/canary/test/module-events.test.mjs
@@ -1,0 +1,77 @@
+// @ts-check
+/**
+ * Signal (e) — ModuleCallFailed + SliceEscrowed watch (MO-1 / MO-2 / EE-6).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkModuleEvents } from '../src/signals/module-events.mjs';
+import { decodeModuleLabel } from '../src/abis.mjs';
+import { mockReader, log, VAULT, MEMBER, ASSET, FEE_ENGINE } from './helpers.mjs';
+
+/** bytes32("feeEngine.onRealize") — a right-zero-padded literal, not a hash. */
+const MODULE_ON_REALIZE = `0x${Buffer.from('feeEngine.onRealize', 'ascii').toString('hex').padEnd(64, '0')}`;
+
+test('decodes a bytes32 string literal back to a readable module label', () => {
+  assert.equal(decodeModuleLabel(MODULE_ON_REALIZE), 'feeEngine.onRealize');
+  assert.equal(decodeModuleLabel(`0x${'00'.repeat(32)}`), `0x${'00'.repeat(32)}`);
+});
+
+test('OK and silent when the window contains neither event', async () => {
+  const reader = mockReader({ contracts: {}, logs: [] });
+  const [r] = await checkModuleEvents({ reader, vault: VAULT, fromBlock: 100, toBlock: 200 });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.measured, '0 events');
+});
+
+test('ALERTS on ModuleCallFailed, naming the module and the member', async () => {
+  const reader = mockReader({
+    contracts: {},
+    logs: [log(VAULT, 'ModuleCallFailed', 150, { module: MODULE_ON_REALIZE, member: MEMBER })],
+  });
+  const [r] = await checkModuleEvents({ reader, vault: VAULT, fromBlock: 100, toBlock: 200 });
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /1x ModuleCallFailed \(feeEngine\.onRealize/);
+  assert.equal(r.detail.moduleCallFailed[0].module, 'feeEngine.onRealize');
+  assert.equal(r.detail.moduleCallFailed[0].blockNumber, 150);
+  assert.deepEqual(r.detail.threatModelRows, ['MO-1', 'MO-2', 'EE-6']);
+});
+
+test('ALERTS on SliceEscrowed, naming the asset (the EE-6 in-kind escrow path)', async () => {
+  const reader = mockReader({
+    contracts: {},
+    logs: [log(VAULT, 'SliceEscrowed', 180, { member: FEE_ENGINE, asset: ASSET, amount: 42n })],
+  });
+  const [r] = await checkModuleEvents({ reader, vault: VAULT, fromBlock: 100, toBlock: 200 });
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /1x SliceEscrowed/);
+  assert.equal(r.detail.sliceEscrowed[0].amount, '42');
+});
+
+test('reports both kinds in one line and counts them', async () => {
+  const reader = mockReader({
+    contracts: {},
+    logs: [
+      log(VAULT, 'ModuleCallFailed', 150, { module: MODULE_ON_REALIZE, member: MEMBER }),
+      log(VAULT, 'ModuleCallFailed', 151, { module: MODULE_ON_REALIZE, member: MEMBER }),
+      log(VAULT, 'SliceEscrowed', 152, { member: MEMBER, asset: ASSET, amount: 1n }),
+    ],
+  });
+  const [r] = await checkModuleEvents({ reader, vault: VAULT, fromBlock: 100, toBlock: 200 });
+  assert.equal(r.measured, '3 events');
+  assert.match(r.message, /2x ModuleCallFailed/);
+  assert.match(r.message, /1x SliceEscrowed/);
+});
+
+test('ignores events outside the poll window and events from other vaults', async () => {
+  const OTHER = '0x' + '7'.repeat(40);
+  const reader = mockReader({
+    contracts: {},
+    logs: [
+      log(VAULT, 'ModuleCallFailed', 99, { module: MODULE_ON_REALIZE, member: MEMBER }),
+      log(VAULT, 'ModuleCallFailed', 201, { module: MODULE_ON_REALIZE, member: MEMBER }),
+      log(OTHER, 'ModuleCallFailed', 150, { module: MODULE_ON_REALIZE, member: MEMBER }),
+    ],
+  });
+  const [r] = await checkModuleEvents({ reader, vault: VAULT, fromBlock: 100, toBlock: 200 });
+  assert.equal(r.status, 'ok');
+});

--- a/packages/canary/test/nav-backing.test.mjs
+++ b/packages/canary/test/nav-backing.test.mjs
@@ -1,0 +1,146 @@
+// @ts-check
+/**
+ * Signal (b) — NAV backing, both legs.
+ *
+ * The composition leg reproduces VaultCore.navWad() including the SV-7 look-through, so the
+ * headline test here is the S6 Finding-1 shape: a parent whose reported navWad omits grandchild
+ * value must diverge from the recompute. If that case passes, the look-through is real.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkNavBacking } from '../src/signals/nav-backing.mjs';
+import { mockReader, healthyVault, VAULT, CHILD, ORACLE, USDC, ASSET } from './helpers.mjs';
+
+const WAD = 1_000000000000000000n;
+const composition = (rs) => rs.find((r) => r.key === 'composition');
+const custody = (rs) => rs.find((r) => r.key === 'custody');
+
+test('OK on a healthy vault: navWad matches the recompute exactly (divergence 0)', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  const rs = await checkNavBacking({ reader, vault: VAULT, atBlock: 900 });
+  const c = composition(rs);
+  assert.equal(c.status, 'ok');
+  assert.equal(c.detail.divergenceBps, 0);
+  assert.equal(c.detail.navWad, (7n * WAD).toString());
+  assert.equal(c.detail.recomputedWad, (7n * WAD).toString());
+});
+
+test('every read is pinned to the requested block, so the two sides cannot race', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  await checkNavBacking({ reader, vault: VAULT, atBlock: 900 });
+  const reads = reader.calls.filter((c) => c.kind === 'read');
+  assert.ok(reads.length > 5);
+  assert.ok(reads.every((c) => c.blockNumber === 900), 'an unpinned read would make divergence racy');
+});
+
+test('ALERTS when navWad overstates the components by more than 0.5%', async () => {
+  // Reported NAV inflated by 1%: 7.07e18 vs a recompute of 7e18.
+  const reader = mockReader({ contracts: healthyVault({ [VAULT]: { navWad: 7_070000000000000000n } }) });
+  const c = composition(await checkNavBacking({ reader, vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'alert');
+  assert.match(c.message, /NAV backing divergence/);
+  assert.equal(c.measured, '0.99%');
+  assert.equal(c.threshold, '0.50%');
+});
+
+test('stays OK for a divergence under the threshold', async () => {
+  // 0.14% — real but below the runbook's 0.5% bar; reported, not paged.
+  const reader = mockReader({ contracts: healthyVault({ [VAULT]: { navWad: 7_010000000000000000n } }) });
+  const c = composition(await checkNavBacking({ reader, vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'ok');
+  assert.equal(c.detail.divergenceBps, 14);
+});
+
+test('look-through: a parent that omits grandchild value diverges (the S6 Finding-1 shape)', async () => {
+  const GRANDCHILD = '0x' + 'ab'.repeat(20);
+  // Parent holds 100% of CHILD; CHILD holds 100% of GRANDCHILD, which carries 4e18 of idle USDC.
+  // Reported navWad = 7e18 (parent's own holdings only) — the grandchild leg is missing.
+  const contracts = healthyVault({
+    [VAULT]: { childVaultCount: 1n, childVaults: () => CHILD },
+    [CHILD]: {
+      idleUsdc: 0n, basketLength: 0n, basketAssets: () => { throw new Error('none'); },
+      assetBalance: () => 0n, childVaultCount: 1n, childVaults: () => GRANDCHILD,
+      totalShares: 10n, sharesOf: () => 10n,
+    },
+    [GRANDCHILD]: {
+      idleUsdc: 4_000_000n, basketLength: 0n, basketAssets: () => { throw new Error('none'); },
+      assetBalance: () => 0n, childVaultCount: 0n, childVaults: () => { throw new Error('none'); },
+      totalShares: 10n, sharesOf: () => 10n,
+    },
+  });
+  const rs = await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 });
+  const c = composition(rs);
+  assert.equal(c.status, 'alert');
+  // Recompute = 7e18 (parent) + 4e18 (grandchild, priced through the PARENT's usdcScalar) = 11e18.
+  assert.equal(c.detail.recomputedWad, (11n * WAD).toString());
+  assert.equal(c.detail.navWad, (7n * WAD).toString());
+});
+
+test('look-through values a partial child position pro-rata, matching _childValueWad truncation', async () => {
+  // Parent holds 3 of the child's 10 shares; child NAV = 10e18 => the parent leg is 3e18.
+  const contracts = healthyVault({
+    [VAULT]: { navWad: 10_000000000000000000n, childVaultCount: 1n, childVaults: () => CHILD },
+    [CHILD]: {
+      idleUsdc: 10_000_000n, basketLength: 0n, basketAssets: () => { throw new Error('none'); },
+      assetBalance: () => 0n, childVaultCount: 0n, childVaults: () => { throw new Error('none'); },
+      totalShares: 10n, sharesOf: () => 3n,
+    },
+  });
+  const c = composition(await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.detail.recomputedWad, (10n * WAD).toString()); // 7e18 own + 3e18 child leg
+  assert.equal(c.status, 'ok');
+});
+
+test('DEGRADED, attributed to the oracle, when navWad reverts StaleOracle — not a NAV alert', async () => {
+  const reader = mockReader({ contracts: healthyVault({ [VAULT]: { navWad: { revert: '0xa2671f4b' } } }) });
+  const rs = await checkNavBacking({ reader, vault: VAULT, atBlock: 900 });
+  assert.equal(rs.length, 1);
+  assert.equal(rs[0].status, 'skipped');
+  assert.notEqual(rs[0].status, 'alert', 'a tripped breaker must not double-page as a NAV divergence');
+  assert.equal(rs[0].detail.attributedTo, 'oracle-freshness');
+});
+
+test('DEGRADED when a basket asset price reverts mid-recompute', async () => {
+  const reader = mockReader({ contracts: healthyVault({ [ORACLE]: { priceWad: () => ({ revert: '0xa2671f4b' }) } }) });
+  const c = composition(await checkNavBacking({ reader, vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'skipped');
+  assert.equal(c.detail.attributedTo, 'oracle-freshness');
+});
+
+// ── custody leg ──────────────────────────────────────────────────────────────
+
+test('custody OK when token balances cover internal accounting', async () => {
+  const c = custody(await checkNavBacking({ reader: mockReader({ contracts: healthyVault() }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'ok');
+});
+
+test('custody OK on a SURPLUS — EE-1 pending capital and EE-6 escrow are not faults', async () => {
+  const contracts = healthyVault({
+    [VAULT]: { totalPendingUsdc: 500_000n },
+    // The vault holds pending capital plus a donation on top of what it accounts for.
+    [USDC]: { balanceOf: () => 9_999_999n },
+    [ASSET]: { balanceOf: () => 50_000000000000000000n },
+  });
+  const c = custody(await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'ok', 'a surplus is normal — donations, escrow, and pending deposits all live here');
+});
+
+test('custody ALERTS on a USDC shortfall — the vault claims more than it holds', async () => {
+  const contracts = healthyVault({
+    [VAULT]: { totalPendingUsdc: 500_000n }, // accounts for 1_500_000 total
+    [USDC]: { balanceOf: () => 1_000_000n },
+  });
+  const c = custody(await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'alert');
+  assert.match(c.message, /BACKING SHORTFALL/);
+  assert.equal(c.detail.shortfalls[0].owed, '1500000');
+  assert.equal(c.detail.shortfalls[0].held, '1000000');
+});
+
+test('custody ALERTS on a basket-asset shortfall and names the token', async () => {
+  const contracts = healthyVault({ [ASSET]: { balanceOf: () => 1_000000000000000000n } });
+  const c = custody(await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'alert');
+  assert.equal(c.detail.shortfalls[0].token, ASSET);
+  assert.ok(c.message.includes(ASSET.slice(0, 6)), 'alert line must name the token');
+});

--- a/packages/canary/test/oracle-freshness.test.mjs
+++ b/packages/canary/test/oracle-freshness.test.mjs
@@ -1,0 +1,152 @@
+// @ts-check
+/**
+ * Signal (a) — oracle freshness. Healthy and alerting fixtures for every branch of the margin.
+ * The freshness rule is reproduced from OracleAggregator.priceWad, so these tests double as the
+ * executable statement of what "within one breaker-trip" means.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkOracleFreshness } from '../src/signals/oracle-freshness.mjs';
+import { mockReader, healthyVault, VAULT, ORACLE, ASSET, SRC1, SRC2, SRC3 } from './helpers.mjs';
+
+const NOW = 1_700_000_000;
+const FRESH = { latestPrice: [3_000000000000000000n, BigInt(NOW - 10)] };
+const STALE = { latestPrice: [3_000000000000000000n, BigInt(NOW - 99_999)] };
+const ZERO_PRICE = { latestPrice: [0n, BigInt(NOW - 10)] };
+const BROKEN = { latestPrice: { revert: '0xdeadbeef' } };
+
+/** 3 sources, quorum 2, 1h staleness — the shape the aggregator's floors enforce. */
+function withSources(s1, s2, s3, { quorum = 2, maxStaleness = 3600 } = {}) {
+  return mockReader({
+    contracts: healthyVault({
+      [ORACLE]: { assetConfig: () => [[SRC1, SRC2, SRC3], maxStaleness, quorum] },
+      [SRC1]: s1, [SRC2]: s2, [SRC3]: s3,
+    }),
+    nowSec: NOW,
+  });
+}
+
+const run = (reader) => checkOracleFreshness({
+  reader, vault: VAULT, oracle: ORACLE, assets: [ASSET], nowSec: NOW,
+});
+
+test('OK at the protocol MINIMUM source set (3 sources, quorum 2, all fresh)', () => runOk());
+
+// This is the calibration that decides whether the signal is usable. A vault on the protocol
+// floor sits at margin 1 when perfectly healthy: it takes TWO failures to trip the breaker, so it
+// is not "within 1 breaker-trip". Alerting here would page forever and get the canary muted.
+async function runOk() {
+  const [r] = await run(withSources(FRESH, FRESH, FRESH));
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.margin, 1);
+}
+
+test('an operator who wants the earlier warning can set minMargin=1', async () => {
+  const [r] = await checkOracleFreshness({
+    reader: withSources(FRESH, FRESH, FRESH), vault: VAULT, oracle: ORACLE,
+    assets: [ASSET], nowSec: NOW, minMargin: 1,
+  });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.margin, 1);
+});
+
+test('OK when the margin clears minMargin — 5 fresh sources at quorum 3', async () => {
+  const reader = mockReader({
+    contracts: healthyVault({
+      [ORACLE]: { assetConfig: () => [[SRC1, SRC2, SRC3, '0x' + 'd'.repeat(40), '0x' + 'e'.repeat(40)], 3600, 3] },
+      [SRC1]: FRESH, [SRC2]: FRESH, [SRC3]: FRESH,
+      ['0x' + 'd'.repeat(40)]: FRESH, ['0x' + 'e'.repeat(40)]: FRESH,
+    }),
+    nowSec: NOW,
+  });
+  const [r] = await run(reader);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.margin, 2);
+  assert.equal(r.detail.freshSources, 5);
+});
+
+test('ALERTS at margin 0 — any single source failure now freezes NAV and exits', async () => {
+  const [r] = await run(withSources(FRESH, FRESH, STALE));
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.margin, 0);
+  assert.match(r.message, /ANY source failure freezes NAV and exits/);
+  assert.equal(r.measured, 'margin 0');
+});
+
+test('ALERTS with "breaker TRIPPED" when fresh sources fall below quorum', async () => {
+  const [r] = await run(withSources(FRESH, STALE, STALE));
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.margin, -1);
+  assert.match(r.message, /breaker TRIPPED/);
+  assert.match(r.message, /NAV and exits are frozen/);
+});
+
+test('a REVERTING source counts as not-fresh, exactly as the aggregator try/catch does', async () => {
+  const [r] = await run(withSources(FRESH, FRESH, BROKEN));
+  assert.equal(r.detail.freshSources, 2, 'a broken feed is stale, not an error');
+  assert.equal(r.status, 'alert'); // margin 0
+  assert.deepEqual(r.detail.staleSources.map((s) => s.reason), ['reverted']);
+});
+
+test('a zero price counts as not-fresh (the ChainlinkSourceAdapter (0,0) path)', async () => {
+  const [r] = await run(withSources(FRESH, FRESH, ZERO_PRICE));
+  assert.equal(r.detail.freshSources, 2);
+  assert.deepEqual(r.detail.staleSources.map((s) => s.reason), ['zero price']);
+});
+
+test('freshness is measured against CHAIN time, not the host clock', async () => {
+  const reader = withSources(FRESH, FRESH, FRESH);
+  // Same fixture, but the chain is far ahead: every updatedAt is now beyond maxStaleness.
+  const [r] = await checkOracleFreshness({
+    reader, vault: VAULT, oracle: ORACLE, assets: [ASSET], nowSec: NOW + 100_000,
+  });
+  assert.equal(r.detail.freshSources, 0);
+  assert.match(r.message, /breaker TRIPPED/);
+});
+
+test('ALERTS when a basket asset is unlisted on the oracle — priceWad reverts StaleOracle', async () => {
+  const reader = mockReader({
+    contracts: healthyVault({ [ORACLE]: { assetConfig: () => [[], 0, 0] } }),
+    nowSec: NOW,
+  });
+  const [r] = await run(reader);
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /NO sources listed/);
+});
+
+test('fans out one result per asset so one stale asset cannot flap the whole vault', async () => {
+  const OTHER = '0x' + '9'.repeat(40);
+  const reader = mockReader({
+    contracts: healthyVault({
+      [ORACLE]: {
+        // ASSET: 5 sources at quorum 2 (4 fresh => margin 2, healthy).
+        // OTHER: 3 sources at quorum 3 (2 fresh => margin -1, breaker tripped).
+        assetConfig: (a) => (String(a).toLowerCase() === OTHER
+          ? [[SRC1, SRC2, SRC3], 3600, 3]
+          : [[SRC1, SRC2, SRC3, '0x' + 'd'.repeat(40), '0x' + 'e'.repeat(40)], 3600, 2]),
+      },
+      [SRC1]: FRESH, [SRC2]: FRESH, [SRC3]: STALE,
+      ['0x' + 'd'.repeat(40)]: FRESH, ['0x' + 'e'.repeat(40)]: FRESH,
+    }),
+    nowSec: NOW,
+  });
+  const results = await checkOracleFreshness({
+    reader, vault: VAULT, oracle: ORACLE, assets: [ASSET, OTHER], nowSec: NOW,
+  });
+  assert.equal(results.length, 2);
+  assert.equal(results[0].key, ASSET);
+  assert.equal(results[1].key, OTHER);
+  assert.notEqual(results[0].id, results[1].id, 'distinct transition keys per asset');
+  assert.equal(results[0].status, 'ok', '4 fresh of 5 at quorum 2 => margin 2, healthy');
+  assert.equal(results[1].status, 'alert', '2 fresh of 3 at quorum 3 => margin -1, tripped');
+});
+
+test('DEGRADED, not OK, when the oracle config itself is unreadable', async () => {
+  const reader = mockReader({
+    contracts: healthyVault({ [ORACLE]: { assetConfig: () => ({ revert: '0xdeadbeef' }) } }),
+    nowSec: NOW,
+  });
+  const [r] = await run(reader);
+  assert.equal(r.status, 'skipped');
+  assert.notEqual(r.status, 'ok');
+});

--- a/packages/canary/test/reader.test.mjs
+++ b/packages/canary/test/reader.test.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+/**
+ * The chain adapter. Two things are worth testing here without a live RPC:
+ *
+ * 1. extractRevertData — the whole exit-liveness classification rests on it. viem nests the raw
+ *    returndata several `cause` levels deep and the shape differs by transport, so a miss here
+ *    would turn a real H-1 fault into "no data". That still ALERTS (empty returndata is a fault),
+ *    so the failure is loud rather than silent — but it would lose the diagnosis, and these cases
+ *    pin the shapes viem actually produces.
+ * 2. The read-only guarantee: the reader exposes no way to send a transaction.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractRevertData, createChainReader } from '../src/reader.mjs';
+
+test('pulls returndata off a flat error', () => {
+  assert.equal(extractRevertData({ data: '0xAB143C06' }), '0xab143c06');
+});
+
+test('walks the cause chain viem builds (ContractFunctionExecutionError → … → RpcRequestError)', () => {
+  const err = { message: 'reverted', cause: { shortMessage: 'x', cause: { data: '0xa2671f4b' } } };
+  assert.equal(extractRevertData(err), '0xa2671f4b');
+});
+
+test('handles the nested { data: { data } } shape', () => {
+  assert.equal(extractRevertData({ cause: { data: { data: '0x08c379a0' } } }), '0x08c379a0');
+});
+
+test('falls back to scraping the message when no structured field carries it', () => {
+  assert.equal(
+    extractRevertData({ message: 'execution reverted, data: 0xab143c06 (Reentrancy)' }),
+    '0xab143c06',
+  );
+});
+
+test('returns null when there is genuinely no returndata — callers treat that as a FAULT', () => {
+  assert.equal(extractRevertData({ message: 'execution reverted' }), null);
+  assert.equal(extractRevertData(new Error('out of gas')), null);
+  assert.equal(extractRevertData(null), null);
+});
+
+test('does not loop forever on a self-referential cause chain', () => {
+  const a = { message: 'a' };
+  a.cause = a;
+  assert.equal(extractRevertData(a), null);
+});
+
+test('ignores a too-short hex value that cannot be a selector', () => {
+  assert.equal(extractRevertData({ data: '0x00' }), null);
+});
+
+test('the reader exposes reads only — there is no send/sign/write surface', () => {
+  const reader = createChainReader({ client: {} });
+  assert.deepEqual(Object.keys(reader).sort(), ['chainNow', 'getLogs', 'headBlock', 'read', 'staticCall', 'tryRead']);
+  for (const forbidden of ['sendTransaction', 'writeContract', 'signMessage', 'account', 'wallet']) {
+    assert.equal(reader[forbidden], undefined, `the canary must expose no ${forbidden}`);
+  }
+});
+
+test('refuses to build a client with neither an injection nor an rpcUrl', async () => {
+  await assert.rejects(() => createChainReader({}).headBlock(), /no client injected and no rpcUrl/);
+});
+
+test('getLogs short-circuits an empty address set instead of asking for every log on chain', async () => {
+  let called = false;
+  const reader = createChainReader({ client: { getLogs: async () => { called = true; return []; } } });
+  assert.deepEqual(await reader.getLogs({ address: [], event: {}, fromBlock: 0, toBlock: 1 }), []);
+  assert.equal(called, false);
+});
+
+test('passes a pinned block through to readContract, and omits it when unpinned', async () => {
+  const seen = [];
+  const reader = createChainReader({ client: { readContract: async (args) => { seen.push(args); return 1n; } } });
+  await reader.read('0xabc', [], 'totalShares', [], { blockNumber: 995 });
+  await reader.read('0xabc', [], 'totalShares', []);
+  assert.equal(seen[0].blockNumber, 995n);
+  assert.equal('blockNumber' in seen[1], false);
+});
+
+test('staticCall reports a revert as data rather than throwing', async () => {
+  const reader = createChainReader({
+    client: { call: async () => { throw { data: '0xab143c06' }; } },
+  });
+  const res = await reader.staticCall({ to: '0x1', from: '0x2', data: '0x3' });
+  assert.equal(res.ok, false);
+  assert.equal(res.data, '0xab143c06');
+});
+
+test('staticCall passes no explicit gas — a low cap would manufacture failures the chain never has', async () => {
+  const seen = [];
+  const reader = createChainReader({ client: { call: async (args) => { seen.push(args); return { data: '0x' }; } } });
+  await reader.staticCall({ to: '0x1', from: '0x2', data: '0x3' });
+  assert.equal('gas' in seen[0], false, 'VaultCore gas-caps its own module calls; the probe must not add a second cap');
+});

--- a/packages/canary/test/runner.test.mjs
+++ b/packages/canary/test/runner.test.mjs
@@ -263,3 +263,32 @@ test('the canary never writes to the indexer snapshot', async () => {
     assert.equal(await readFile(statePath, 'utf8'), before, 'the indexer snapshot must be read-only to the canary');
   });
 });
+
+test('a backlog larger than one window reports the unscanned gap instead of skipping it silently', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const canaryStatePath = join(dir, 'canary-state.json');
+    const err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: canaryStatePath, OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+      MAX_LOG_SPAN_BLOCKS: '10',
+    });
+    const canary = await buildCanary(cfg, { log: () => {}, error: (m) => err.push(m), client: {} });
+    let head = 1000;
+    canary.reader.headBlock = async () => head;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    await canary.runOnce();          // establishes lastScannedBlock = 995
+    assert.deepEqual(err, [], 'the first sweep is healthy and silent');
+
+    head = 2000;                     // the canary was down for ~1000 blocks
+    await canary.runOnce();
+    assert.equal(err.length, 1);
+    assert.match(err[0], /event scan gap/);
+    assert.match(err[0], /blocks 996-1984/);
+    assert.match(err[0], /MAX_LOG_SPAN_BLOCKS=10/);
+  });
+});

--- a/packages/canary/test/runner.test.mjs
+++ b/packages/canary/test/runner.test.mjs
@@ -1,0 +1,265 @@
+// @ts-check
+/**
+ * End-to-end sweeps with a mocked client and a real snapshot on disk — no live RPC.
+ *
+ * The headline test is the DONE criterion for the whole package: pointed at a healthy deployment,
+ * the canary emits NOTHING. Everything else here is the failure side of that: a single broken
+ * thing produces exactly one actionable line, and a signal that cannot run says so instead of
+ * reporting healthy.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, readFile } from 'node:fs/promises';
+import { resolveCanaryConfig, collectSignals, buildCanary } from '../src/canary-runner.mjs';
+import { saveSnapshot } from '../../indexer/src/store.mjs';
+import { emptyState } from '../../indexer/src/projections.mjs';
+import {
+  mockReader, healthyVault, healthyState, log,
+  VAULT, USDC, ORACLE, ASSET, REGISTRY, MEMBER, CREATOR, OPERATOR, SRC1, SRC2, SRC3,
+} from './helpers.mjs';
+
+const NOW = 1_700_000_000;
+const FRESH = { latestPrice: [3_000000000000000000n, BigInt(NOW - 10)] };
+
+/** A healthy fixture with a 5-source oracle, so the freshness margin clears the default bar. */
+function healthyFixture(overrides = {}) {
+  const SRC4 = '0x' + 'd'.repeat(40);
+  const SRC5 = '0x' + 'e'.repeat(40);
+  return healthyVault({
+    [ORACLE]: { priceWad: () => 3_000000000000000000n, assetConfig: () => [[SRC1, SRC2, SRC3, SRC4, SRC5], 3600, 2] },
+    [SRC1]: FRESH, [SRC2]: FRESH, [SRC3]: FRESH, [SRC4]: FRESH, [SRC5]: FRESH,
+    ...overrides,
+  });
+}
+
+const baseCfg = resolveCanaryConfig({ RPC_URL: 'http://localhost:8545', OPERATOR_REGISTRY_ADDRESS: REGISTRY });
+const WINDOW = { fromBlock: 900, toBlock: 995, nowSec: NOW };
+
+// ── config resolution ────────────────────────────────────────────────────────
+
+test('config: RPC_URL is required', () => {
+  assert.throws(() => resolveCanaryConfig({}), /missing required env: RPC_URL/);
+});
+
+test('config: defaults are the documented ones', () => {
+  const cfg = resolveCanaryConfig({ RPC_URL: 'http://x' });
+  assert.equal(cfg.chainId, 8453);
+  assert.equal(cfg.confirmations, 5);
+  assert.equal(cfg.pollIntervalMs, 30_000);
+  assert.equal(cfg.navDivergenceBps, 50);
+  assert.equal(cfg.oracleMinMargin, 0);
+  assert.equal(cfg.statePath, './data/indexer-state.json');
+  assert.equal(cfg.canaryStatePath, './data/canary-state.json');
+  assert.notEqual(cfg.canaryStatePath, cfg.statePath, 'the canary must never write to the indexer snapshot');
+  assert.equal(cfg.webhookUrl, null);
+});
+
+test('config: the poll interval is namespaced, so the indexer POLL_INTERVAL_MS cannot capture it', () => {
+  // compose feeds one .env to every service; a canary sweep is far heavier than an indexer poll.
+  const cfg = resolveCanaryConfig({ RPC_URL: 'http://x', POLL_INTERVAL_MS: '12000' });
+  assert.equal(cfg.pollIntervalMs, 30_000);
+  assert.equal(resolveCanaryConfig({ RPC_URL: 'http://x', CANARY_POLL_INTERVAL_MS: '60000' }).pollIntervalMs, 60_000);
+});
+
+test('config: rejects malformed addresses instead of silently watching nothing', () => {
+  assert.throws(() => resolveCanaryConfig({ RPC_URL: 'http://x', VAULTS: 'not-an-address' }), /non-address entry/);
+  assert.throws(() => resolveCanaryConfig({ RPC_URL: 'http://x', OPERATOR_REGISTRY_ADDRESS: '0xabc' }), /not a 20-byte address/);
+  assert.throws(() => resolveCanaryConfig({ RPC_URL: 'http://x', EXTRA_OPERATOR_ADDRESSES: `${OPERATOR},oops` }), /non-address entry/);
+});
+
+test('config: lowercases addresses so they key the projection consistently', () => {
+  const cfg = resolveCanaryConfig({ RPC_URL: 'http://x', VAULTS: VAULT.toUpperCase().replace('0X', '0x') });
+  assert.deepEqual(cfg.vaults, [VAULT]);
+});
+
+// ── a full healthy sweep ─────────────────────────────────────────────────────
+
+test('a healthy deployment produces ZERO alerts across every signal', async () => {
+  const results = await collectSignals({
+    reader: mockReader({ contracts: healthyFixture(), nowSec: NOW }),
+    state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const bad = results.filter((r) => r.status !== 'ok');
+  assert.deepEqual(bad.map((r) => `${r.signal}: ${r.message}`), [], 'every signal must read healthy');
+  assert.deepEqual(
+    [...new Set(results.map((r) => r.signal))].sort(),
+    ['exit-liveness', 'fee-routing', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
+    'all six signals must actually have run',
+  );
+});
+
+// ── one broken thing at a time ───────────────────────────────────────────────
+
+test('a tripped oracle alerts on freshness and DEGRADES the dependent signals, without double-paging NAV', async () => {
+  const contracts = healthyFixture({
+    [ORACLE]: { priceWad: () => ({ revert: '0xa2671f4b' }), assetConfig: () => [[SRC1, SRC2, SRC3], 3600, 3] },
+    [SRC1]: FRESH, [SRC2]: FRESH, [SRC3]: { latestPrice: [3n, 1n] },
+    [VAULT]: { ...healthyVault()[VAULT], navWad: { revert: '0xa2671f4b' } },
+  });
+  const results = await collectSignals({
+    reader: mockReader({ contracts, nowSec: NOW }), state: healthyState(),
+    vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const by = (s) => results.filter((r) => r.signal === s);
+  assert.equal(by('oracle-freshness')[0].status, 'alert');
+  assert.equal(by('nav-backing')[0].status, 'skipped', 'NAV must not double-page for the oracle');
+  assert.equal(by('nav-backing')[0].detail.attributedTo, 'oracle-freshness');
+  assert.equal(results.filter((r) => r.status === 'alert').length, 1, 'exactly one page for one root cause');
+});
+
+test('a fee leak produces exactly one alert and it names the vault and the amount', async () => {
+  const results = await collectSignals({
+    reader: mockReader({
+      contracts: healthyFixture(),
+      logs: [log(USDC, 'Transfer', 950, { from: VAULT, to: OPERATOR, value: 12_345n })],
+      nowSec: NOW,
+    }),
+    state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const alerts = results.filter((r) => r.status === 'alert');
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0].signal, 'fee-routing');
+  assert.ok(alerts[0].message.includes(VAULT.slice(0, 6)));
+  assert.ok(alerts[0].message.includes('12345'));
+});
+
+test('a vault absent from the projection DEGRADES its two projection-fed signals, never reports them OK', async () => {
+  const results = await collectSignals({
+    reader: mockReader({ contracts: healthyFixture(), nowSec: NOW }),
+    state: emptyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  for (const signal of ['share-conservation', 'exit-liveness']) {
+    const r = results.find((x) => x.signal === signal);
+    assert.equal(r.status, 'skipped', `${signal} must not claim health without a projection`);
+    assert.match(r.message, /not in the indexer projection|cannot run/);
+  }
+  // The chain-only signals still ran.
+  assert.equal(results.find((r) => r.signal === 'nav-backing').status, 'ok');
+});
+
+test('an unreadable vault suspends its signals with one line instead of blinding the whole sweep', async () => {
+  const OTHER = '0x' + '9'.repeat(40);
+  const results = await collectSignals({
+    reader: mockReader({ contracts: healthyFixture(), nowSec: NOW }),
+    state: healthyState(), vaults: [OTHER, VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const broken = results.filter((r) => r.vault === OTHER);
+  assert.equal(broken.length, 1);
+  assert.equal(broken[0].signal, 'vault-config');
+  assert.equal(broken[0].status, 'skipped');
+  assert.ok(results.some((r) => r.vault === VAULT && r.status === 'ok'), 'the healthy vault was still swept');
+});
+
+// ── the runner loop, end to end, against a real snapshot file ────────────────
+
+async function withTempDir(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'canary-'));
+  try { return await fn(dir); } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+/** Write a real indexer snapshot the canary will discover vaults from. */
+async function seedSnapshot(dir) {
+  const state = emptyState();
+  state.vaults.set(VAULT, {
+    vault: VAULT, creator: CREATOR, usdc: USDC, operatorId: 7,
+    totalShares: 500_000000000000000000n, idleUsdc: 1_000_000n, memberCount: 2,
+    pendingCount: 0, capacityCapUsdc: 0n, parent: null, depth: 0,
+  });
+  state.shares.set(VAULT, new Map([[MEMBER, 400_000000000000000000n], [CREATOR, 100_000000000000000000n]]));
+  state.lastBlock = 995;
+  const statePath = join(dir, 'indexer-state.json');
+  await saveSnapshot(statePath, state);
+  return statePath;
+}
+
+test('runOnce against a healthy deployment prints NOTHING — silence is the healthy state', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const out = [], err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: join(dir, 'canary-state.json'), OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+    });
+    const canary = await buildCanary(cfg, {
+      log: (m) => out.push(m), error: (m) => err.push(m),
+      client: {}, // unused: the reader below is what actually answers
+    });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    const { transitions, results } = await canary.runOnce();
+    assert.deepEqual(transitions, [], 'a healthy sweep must be completely silent');
+    assert.deepEqual(out, []);
+    assert.deepEqual(err, []);
+    assert.ok(results.length >= 6);
+  });
+});
+
+test('runOnce emits one line when something breaks, and stays quiet on the next poll', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const canaryStatePath = join(dir, 'canary-state.json');
+    const out = [], err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: canaryStatePath, OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+    });
+    const canary = await buildCanary(cfg, { log: (m) => out.push(m), error: (m) => err.push(m), client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    // navWad overstated by 1% — one broken thing, one expected line.
+    const mock = mockReader({ contracts: healthyFixture({ [VAULT]: { ...healthyVault()[VAULT], navWad: 7_070000000000000000n } }), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    await canary.runOnce();
+    assert.equal(err.length, 1, 'exactly one alert line');
+    assert.match(err[0], /ALERT \[nav-backing\]/);
+    assert.match(err[0], /measured 0\.99%, threshold 0\.50%/);
+
+    await canary.runOnce();
+    assert.equal(err.length, 1, 'a standing alert must not re-page every poll');
+
+    // And it survives a restart without re-paging.
+    const persisted = JSON.parse(await readFile(canaryStatePath, 'utf8'));
+    assert.equal(persisted.lastScannedBlock, 995);
+    assert.ok(Object.keys(persisted.transitions).length > 0);
+  });
+});
+
+test('runOnce says so, loudly, when there is nothing to watch', async () => {
+  await withTempDir(async (dir) => {
+    const err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545',
+      STATE_PATH: join(dir, 'absent.json'), CANARY_STATE_PATH: join(dir, 'canary-state.json'),
+    });
+    const canary = await buildCanary(cfg, { log: () => {}, error: (m) => err.push(m), client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const { vaults } = await canary.runOnce();
+    assert.deepEqual(vaults, []);
+    assert.match(err[0], /no vaults to watch/, 'an empty watch set must never look like a clean bill of health');
+  });
+});
+
+test('the canary never writes to the indexer snapshot', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const before = await readFile(statePath, 'utf8');
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: join(dir, 'canary-state.json'), OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+    });
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+    await canary.runOnce();
+    assert.equal(await readFile(statePath, 'utf8'), before, 'the indexer snapshot must be read-only to the canary');
+  });
+});

--- a/packages/canary/test/share-conservation.test.mjs
+++ b/packages/canary/test/share-conservation.test.mjs
@@ -1,0 +1,84 @@
+// @ts-check
+/**
+ * Signal (c) — share conservation, indexer projection vs chain read.
+ *
+ * The interesting coverage here is the HEIGHT handling: the indexer lags head by CONFIRMATIONS,
+ * so an unpinned comparison would false-alarm on every deposit in the confirmation window. These
+ * tests prove the read is pinned to the snapshot height, and that the pruned-node fallback stays
+ * alive rather than going silently dead.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkShareConservation } from '../src/signals/share-conservation.mjs';
+import { mockReader, healthyVault, VAULT, MEMBER, CREATOR } from './helpers.mjs';
+
+const TOTAL = 500_000000000000000000n;
+const book = new Map([[MEMBER, 400_000000000000000000n], [CREATOR, 100_000000000000000000n]]);
+
+test('OK when the projection, the share book, and the chain all agree', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL, shareBook: book, atBlock: 995,
+  });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.pinned, true);
+  assert.equal(r.detail.holders, 2);
+});
+
+test('pins the chain read to the indexer snapshot height, not to head', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL, shareBook: book, atBlock: 995,
+  });
+  assert.equal(reader.calls[0].blockNumber, 995, 'an unpinned read races the confirmation lag');
+});
+
+test('ALERTS when the projection total disagrees with the chain', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL - 1n, shareBook: book, atBlock: 995,
+  });
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /share conservation broken/);
+  assert.match(r.message, /indexer totalShares .* vs chain/);
+  assert.equal(r.measured, 'Δ 1 shares');
+  assert.equal(r.threshold, 'exactly 0');
+});
+
+test('ALERTS when Σ sharesOf disagrees with the chain even though the folded total matches', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  const skewed = new Map([[MEMBER, 399_000000000000000000n], [CREATOR, 100_000000000000000000n]]);
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL, shareBook: skewed, atBlock: 995,
+  });
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /Σ sharesOf over 2 holders/);
+});
+
+test('falls back to head when the RPC has no archive state, and asks for two observations', async () => {
+  const reader = mockReader({ contracts: healthyVault(), archiveBlocks: new Set() }); // pruned node
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL, shareBook: book, atBlock: 995,
+  });
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.pinned, false);
+  assert.equal(r.detail.minConsecutive, 2, 'an unpinned mismatch is racy — require it twice before paging');
+  assert.match(r.message, /UNPINNED/);
+});
+
+test('DEGRADED, not OK, when totalShares() cannot be read at all', async () => {
+  const reader = mockReader({ contracts: {} });
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: TOTAL, shareBook: book, atBlock: 995,
+  });
+  assert.equal(r.status, 'skipped');
+  assert.notEqual(r.status, 'ok');
+});
+
+test('an empty projection against a nonzero chain total ALERTS rather than reading as agreement', async () => {
+  const reader = mockReader({ contracts: healthyVault() });
+  const [r] = await checkShareConservation({
+    reader, vault: VAULT, projectedTotalShares: 0n, shareBook: new Map(), atBlock: 995,
+  });
+  assert.equal(r.status, 'alert');
+});

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -1,0 +1,77 @@
+// @ts-check
+/**
+ * Alert sinks. The load-bearing property is that a paging OUTAGE never becomes a monitoring
+ * outage: a sink that throws, times out, or returns 500 must be reported and stepped over, never
+ * allowed to take the canary down.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createConsoleSink, createWebhookSink, emitAll } from '../src/sinks.mjs';
+
+const tr = (to = 'alert') => ({
+  id: 'nav-backing|0xv', signal: 'nav-backing', vault: '0xv', key: undefined,
+  from: 'ok', to, line: `${to.toUpperCase()} [nav-backing] diverged`,
+  result: { measured: '1.20%', threshold: '0.50%', detail: { vault: '0xv', navWad: 7n } },
+});
+
+test('console sink sends alerts to stderr and recoveries to stdout', async () => {
+  const out = [], err = [];
+  const sink = createConsoleSink({ log: (m) => out.push(m), error: (m) => err.push(m) });
+  await sink.emit(tr('alert'));
+  await sink.emit(tr('skipped'));
+  await sink.emit(tr('ok'));
+  assert.equal(err.length, 2, 'alerts and degradations go to stderr so `2>` is a pure problem feed');
+  assert.equal(out.length, 1);
+});
+
+test('webhook posts one JSON body per transition, with the structured detail', async () => {
+  const calls = [];
+  const sink = createWebhookSink({
+    url: 'https://example.invalid/hook',
+    fetchImpl: async (url, opts) => { calls.push({ url, opts }); return { ok: true, status: 200 }; },
+  });
+  await sink.emit(tr('alert'));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].opts.method, 'POST');
+  const body = JSON.parse(calls[0].opts.body);
+  assert.equal(body.status, 'alert');
+  assert.equal(body.previousStatus, 'ok');
+  assert.equal(body.signal, 'nav-backing');
+  assert.equal(body.vault, '0xv');
+  assert.equal(body.measured, '1.20%');
+  assert.equal(body.detail.navWad, '7', 'bigints must survive JSON.stringify, not throw');
+});
+
+test('a webhook failure is reported but never propagates', async () => {
+  const errs = [];
+  const sink = createWebhookSink({
+    url: 'https://example.invalid/hook',
+    fetchImpl: async () => { throw new Error('ECONNREFUSED'); },
+    onError: (m) => errs.push(m),
+  });
+  await sink.emit(tr());
+  assert.equal(errs.length, 1);
+  assert.match(errs[0], /webhook delivery failed/);
+});
+
+test('a non-2xx webhook response is reported but never propagates', async () => {
+  const errs = [];
+  const sink = createWebhookSink({
+    url: 'https://example.invalid/hook',
+    fetchImpl: async () => ({ ok: false, status: 503 }),
+    onError: (m) => errs.push(m),
+  });
+  await sink.emit(tr());
+  assert.match(errs[0], /webhook returned 503/);
+});
+
+test('emitAll keeps going when one sink throws — a paging outage is not a monitoring outage', async () => {
+  const delivered = [];
+  const errs = [];
+  const broken = { name: 'broken', emit: async () => { throw new Error('boom'); } };
+  const good = { name: 'good', emit: async (t) => delivered.push(t.id) };
+  await emitAll([broken, good], [tr(), tr()], { onError: (m) => errs.push(m) });
+  assert.equal(delivered.length, 2, 'the working sink still received both transitions');
+  assert.equal(errs.length, 2);
+  assert.match(errs[0], /sink broken threw/);
+});

--- a/packages/canary/test/transitions.test.mjs
+++ b/packages/canary/test/transitions.test.mjs
@@ -1,0 +1,106 @@
+// @ts-check
+/**
+ * Transition detection — the piece that makes the canary quiet.
+ *
+ * The load-bearing property is NEGATIVE: a healthy chain must produce zero output, forever. If
+ * that breaks, operators mute the canary and every other signal in this package stops mattering.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTransitionTracker, formatLine } from '../src/transitions.mjs';
+import { ok, alert, skipped } from '../src/signal.mjs';
+
+const V = '0x' + '1'.repeat(40);
+const okR = (signal = 'nav-backing', key) => ok({ signal, vault: V, key, message: 'fine', measured: '0.00%', threshold: '0.50%' });
+const alertR = (signal = 'nav-backing', key) => alert({ signal, vault: V, key, message: 'diverged', measured: '1.20%', threshold: '0.50%' });
+const skipR = (signal = 'exit-liveness') => skipped({ signal, vault: V, message: 'cannot run' });
+
+test('SILENT while healthy — no output on the first poll or any poll after', () => {
+  const t = createTransitionTracker();
+  assert.deepEqual(t.observe([okR()], { poll: 1 }), []);
+  assert.deepEqual(t.observe([okR()], { poll: 2 }), []);
+  assert.deepEqual(t.observe([okR()], { poll: 3 }), []);
+});
+
+test('emits on the FIRST sighting of an alert, even with no prior OK to transition from', () => {
+  const t = createTransitionTracker();
+  const [tr] = t.observe([alertR()], { poll: 1 });
+  assert.equal(tr.to, 'alert');
+  assert.match(tr.line, /ALERT \[nav-backing\] diverged/);
+});
+
+test('one line per transition, not one per poll', () => {
+  const t = createTransitionTracker();
+  t.observe([okR()], { poll: 1 });
+  assert.equal(t.observe([alertR()], { poll: 2 }).length, 1);
+  assert.equal(t.observe([alertR()], { poll: 3 }).length, 0, 'a persisting alert must not re-page');
+  assert.equal(t.observe([alertR()], { poll: 4 }).length, 0);
+  const [rec] = t.observe([okR()], { poll: 5 });
+  assert.equal(rec.from, 'alert');
+  assert.equal(rec.to, 'ok');
+  assert.match(rec.line, /RECOVERED/);
+});
+
+test('OK→SKIPPED emits — a sentinel that has stopped being able to run must be visible', () => {
+  const t = createTransitionTracker();
+  t.observe([ok({ signal: 'exit-liveness', vault: V, message: 'live' })], { poll: 1 });
+  const [tr] = t.observe([skipR()], { poll: 2 });
+  assert.equal(tr.to, 'skipped');
+  assert.match(tr.line, /DEGRADED/);
+});
+
+test('per-asset keys track independently — one stale asset cannot flap the whole vault', () => {
+  const t = createTransitionTracker();
+  const A = '0xaaa', B = '0xbbb';
+  t.observe([okR('oracle-freshness', A), okR('oracle-freshness', B)], { poll: 1 });
+  const out = t.observe([alertR('oracle-freshness', A), okR('oracle-freshness', B)], { poll: 2 });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].key, A);
+});
+
+test('minConsecutive holds a flapping status back until it repeats', () => {
+  const t = createTransitionTracker();
+  const racy = (status) => ({
+    ...(status === 'ok' ? okR('share-conservation') : alertR('share-conservation')),
+    detail: { minConsecutive: 2 },
+  });
+  t.observe([racy('ok')], { poll: 1 });
+  assert.equal(t.observe([racy('alert')], { poll: 2 }).length, 0, 'one racy observation is not enough');
+  assert.equal(t.observe([racy('alert')], { poll: 3 }).length, 1, 'two in a row pages');
+});
+
+test('minConsecutive resets when the status flaps back before confirming', () => {
+  const t = createTransitionTracker();
+  const racy = (status) => ({
+    ...(status === 'ok' ? okR('share-conservation') : alertR('share-conservation')),
+    detail: { minConsecutive: 3 },
+  });
+  t.observe([racy('ok')], { poll: 1 });
+  t.observe([racy('alert')], { poll: 2 });
+  t.observe([racy('ok')], { poll: 3 });
+  assert.equal(t.observe([racy('alert')], { poll: 4 }).length, 0, 'the streak restarted');
+});
+
+test('state round-trips through a snapshot, so a restart does not re-page a standing alert', () => {
+  const t1 = createTransitionTracker();
+  t1.observe([alertR()], { poll: 1 });
+  const t2 = createTransitionTracker({ initial: JSON.parse(JSON.stringify(t1.snapshot())) });
+  assert.deepEqual(t2.observe([alertR()], { poll: 1 }), [], 'the alert was already reported before the restart');
+  assert.equal(t2.observe([okR()], { poll: 2 }).length, 1, 'and the recovery still lands');
+});
+
+test('unhealthy() lists what is currently wrong, for the heartbeat summary', () => {
+  const t = createTransitionTracker();
+  t.observe([alertR('nav-backing'), okR('fee-routing'), skipR('exit-liveness')], { poll: 1 });
+  assert.deepEqual(t.unhealthy().map((u) => u.id).sort(), [
+    `exit-liveness|${V}`, `nav-backing|${V}`,
+  ]);
+});
+
+test('an alert line names the vault, the signal, and measured vs threshold', () => {
+  const line = formatLine('alert', alertR(), '2026-08-19T00:00:00.000Z');
+  assert.match(line, /2026-08-19T00:00:00\.000Z/);
+  assert.match(line, /ALERT/);
+  assert.match(line, /\[nav-backing\]/);
+  assert.match(line, /\(measured 1\.20%, threshold 0\.50%\)/);
+});


### PR DESCRIPTION
A `packages/canary` an operator points at a deployed testnet. It **stays silent until something is genuinely wrong**, emitting one line per signal *transition* — so any output is worth reading.

Turns the [DEPLOYMENT §6](docs/DEPLOYMENT.md) signal table from prose into a running service. Full operator guide: **[docs/CANARY.md](docs/CANARY.md)**.

```bash
RPC_URL=… OPERATOR_REGISTRY_ADDRESS=… STATE_PATH=./data/indexer-state.json npm run start:canary
```

## The six signals

Each is a pure function over an injected chain reader, so every test injects a plain object and none needs an RPC.

| Signal | Measures | Alerts when |
|---|---|---|
| `oracle-freshness` | per asset, `freshSources - quorum` | margin `<= 0` — one more source failure freezes NAV and exits |
| `nav-backing` | `navWad` vs a recompute from the vault's own getters; plus token balances vs internal accounting | composition diverges > 0.5%, or the vault holds less than it accounts for |
| `share-conservation` | indexer projection vs a chain read **pinned to the snapshot height** | any difference |
| `exit-liveness` | static-called `requestExit` **as a real member** | a non-gate revert (the H-1 sentinel) |
| `module-events` | `ModuleCallFailed` + `SliceEscrowed` | any occurrence in the window |
| `fee-routing` | USDC from a vault straight to a registered operator address | no same-block `ExitSettled`/`PendingCancelled` behind it |

## Design decisions worth reviewing

**The exit sentinel is the one that could ship green and be worthless.** `requestExit` reverts `InsufficientShares` unless the caller holds shares, so probing from an arbitrary address would revert with a gate error forever while exits were bricked. The probe therefore uses a real holder from the indexer's share book, and reverts are classified three ways: gate → OK, `StaleOracle` → DEGRADED (attributed to the oracle signal), **everything else including empty returndata → ALERT**. Empty returndata is the actual H-1 signature, so there is deliberately no "couldn't classify, assume healthy" branch. Three tests pin exactly this.

**`skipped`/DEGRADED is a first-class status.** A check that cannot run has not passed, so it never collapses into OK — no eligible member to probe with, no projection for the vault, or a tripped breaker all surface as their own transition rather than silence.

**Two thresholds were nearly mis-set, and both decide whether this gets muted:**
- Oracle margin alerts at `<= 0`, not `<= 1`. A vault on the protocol floor (3 sources, quorum 2) sits at margin 1 when *perfectly healthy* — it takes two failures to trip. Paging there would page forever.
- Fee routing uses the narrow check the threat model names, not an inverse allowlist. The allowlist version fires on every exit payout to a member the indexer hasn't projected yet; and EE-9 explicitly permits an operator to hold and exit a member position, so a same-block settlement excuses the transfer.

**One root cause, one page.** A tripped breaker makes `navWad()` and `requestExit` revert too; both attribute it to the oracle signal and go DEGRADED instead of adding two more alerts.

**Height pinning.** Share conservation reads the chain at the snapshot's own `lastBlock`, so the indexer's confirmation lag cannot false-alarm. On a pruned node it falls back to head, marks itself unpinned, and asks for two consecutive observations — alive rather than silently dead.

**Scan gaps are reported.** If downtime pushes the backlog past `MAX_LOG_SPAN_BLOCKS`, the unscanned range is named explicitly. A silent coverage hole is the exact failure this package exists to prevent.

## Read-only, enforced not asserted

A viem **public** client only — `eth_call`, `eth_getLogs`, `eth_blockNumber`, `eth_getBlockByNumber`. No wallet client, no account, no key, no `PRIVATE_KEY` read, and no ABI fragment for a non-`view` function (`requestExit` exists solely to build `eth_call` calldata). It reads the indexer snapshot and never writes it; transition state has its own path.

Tests assert the reader exposes no send/sign surface, that every declared function fragment is `view`, and that the indexer snapshot is byte-identical after a sweep.

## Tests

**195 backend tests pass** (81 pre-existing + 114 new), all with mocked clients — **no live RPC in CI**. Healthy and alerting fixtures for every signal.

The drift guard is load-bearing rather than bookkeeping: `test/abis.test.mjs` recomputes every embedded selector with viem and cross-checks the watched events, views, and gate errors against the **compiled** `VaultCore` ABI. A stale gate selector would file a live fault as a benign gate and silence the H-1 sentinel.

## Wiring

`npm run test:backend`, the CI `node --check` entrypoint line, and `docker-compose.yml` as a third service on the shared volume (`depends_on: indexer`, its own `CANARY_STATE_PATH`). `.env.example`, `docs/RUNTIME.md` (topology, wiring order, env table, non-custodial guarantees), and `docs/DEPLOYMENT.md` §6 updated.

No existing behaviour changed — the only edits outside `packages/canary/` and the docs are additive script/service/env entries.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
