### PR TITLE
Sprint 13: production-operable off-chain stack (logging, durability, hardening, ops-check, graceful shutdown)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,19 @@ CONFIRMATIONS=5                          # lag behind head for reorg safety
 BATCH_BLOCKS=2000                        # max blocks per getLogs batch
 POLL_INTERVAL_MS=12000                   # ~one Base block
 
+# ── Durability + operations (docs/RUNTIME.md §8) ──
+# One pair of knobs for BOTH state files (indexer snapshot + canary state): compose feeds every
+# service one .env, and two spellings of the same policy is a trap.
+SNAPSHOT_BACKUPS=3                       # rotating copies kept as state.json.1 .. .N; 0 disables
+SNAPSHOT_BACKUP_INTERVAL_MS=300000       # minimum spacing between backups. NOT per write: the
+                                         # indexer snapshots every batch, so per-write rotation
+                                         # would leave a 36-second backup horizon.
+# HEARTBEAT_DIR=                         # where each service writes <service>.heartbeat.json
+                                         # (default: alongside STATE_PATH; compose sets /data)
+LOG_FORMAT=json                          # json | pretty. Unset = pretty iff stdout is a TTY,
+                                         # so a shell is readable and a container emits JSON.
+LOG_LEVEL=info                           # debug | info | warn | error
+
 # ── Canary (docs/CANARY.md) ──
 # Read-only post-launch monitor. No key, no wallet, never sends a transaction. Silent while
 # healthy; one line per signal transition. Reuses RPC_URL / CHAIN_ID / CHAIN_NAME / CONFIRMATIONS
@@ -47,3 +60,17 @@ PORT=8402
 RELOAD_MS=5000                           # how often the API re-reads the snapshot
 CORS=1                                   # 1 to allow the browser live mode (apps/web ?api=)
 STATE_PATH=./data/indexer-state.json     # shared snapshot (compose overrides to /data/...)
+
+# ── API hardening (free routes only; the paid routes are self-limiting — x402 IS the limiter) ──
+RATE_LIMIT_PER_SEC=5                     # sustained rate per IP on /health, /.well-known/x402,
+                                         # /metrics. 0 disables the limiter entirely.
+RATE_LIMIT_BURST=60                      # burst each IP may take at once
+RATE_LIMIT_MAX_IPS=10000                 # cap on tracked IPs; an unbounded map IS the DoS
+# TRUST_PROXY=1                          # ONLY behind a reverse proxy that OVERWRITES
+                                         # x-forwarded-for. The header is client-spoofable, so
+                                         # enabling it without such a proxy lets one attacker mint
+                                         # a fresh rate-limit bucket per request. Leave it off
+                                         # when the API is reached directly.
+MAX_URL_BYTES=2048                       # longer request-target → 414
+MAX_BODY_BYTES=8192                      # larger request body → 413 (this is a GET-only read API)
+MAX_HEADER_BYTES=16384                   # Node's header cap; a payment envelope is ~1KB of base64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,15 @@ jobs:
       # Without this the viem-backed tests skip themselves and the suite silently
       # reports 80/81 forever. Install first so the full 81 actually run.
       - run: npm ci
+      # ops-check is a cron job and a compose healthcheck, so its exit CODE is the contract.
+      # Assert it with no heartbeats present: it must fail (1), not crash (2) and not pass.
+      - name: ops-check fails on absent heartbeats
+        run: |
+          set +e
+          node packages/oplog/src/ops-check.mjs --dir=./no-such-dir
+          code=$?
+          set -e
+          test "$code" = "1" || { echo "expected exit 1, got $code"; exit 1; }
       # abis.test.mjs cross-checks the indexer's embedded event fragments against
       # compiled artifacts, and skips itself when contracts/out is absent — so the
       # drift guard only bites if this job has built the contracts.
@@ -89,4 +98,4 @@ jobs:
       # by hand against a live chain. Parse them so a syntax error can't reach a
       # 6-hour smoke run or a production boot.
       - name: Syntax-check entrypoints and operational scripts
-        run: node --check scripts/smoke-test.mjs && node --check apps/api/src/serve.mjs && node --check packages/indexer/src/index-runner.mjs && node --check packages/canary/src/canary-runner.mjs
+        run: node --check scripts/smoke-test.mjs && node --check apps/api/src/serve.mjs && node --check packages/indexer/src/index-runner.mjs && node --check packages/canary/src/canary-runner.mjs && node --check packages/oplog/src/ops-check.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@
 #   docker run --env-file .env vault-runtime npm run start:indexer
 #   docker run --env-file .env -p 8402:8402 vault-runtime npm run start:api
 #   docker run --env-file .env vault-runtime npm run start:canary
+#
+# Two operational commands ship in the same image and need no env at all:
+#   docker run -v vault-state:/data vault-runtime node packages/oplog/src/ops-check.mjs --dir=/data
+#   docker run -v vault-state:/data vault-runtime node packages/indexer/src/index-runner.mjs verify /data/indexer-state.json
 FROM node:24-slim
 
 WORKDIR /app

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -5,11 +5,21 @@ Read layer over indexed vault state, gated by x402 (V2) payment.
 - `src/x402.mjs` — payment gate: 402 challenge (`PAYMENT-REQUIRED`), client authorization via
   `PAYMENT-SIGNATURE` (base64 EIP-3009 `transferWithAuthorization` envelope), settlement through
   an injected facilitator, `PAYMENT-RESPONSE` receipt echo. Server holds no keys, moves no funds.
-- `src/server.mjs` — Node-http routes: `/health` (free), `/vaults/:addr` and
-  `/operators/leaderboard` (paid).
+- `src/server.mjs` — Node-http routes: `/health`, `/.well-known/x402` and `/metrics` (free);
+  `/vaults`, `/vaults/:addr`, `/vaults/:addr/members/:m` and `/operators/leaderboard` (paid).
+  Also the request caps (method, URL length, body size) applied before any handler work.
+- `src/ratelimit.mjs` — per-IP token bucket on the FREE routes only. The paid routes are
+  self-limiting: **x402 IS the rate limiter**, since every metered read costs the caller USDC.
+- `src/metrics.mjs` — the plain-text counters behind `/metrics`, including
+  `vault_indexer_snapshot_age_seconds`, which is the indexer-lag signal. The API holds no RPC
+  client by design, so it reports snapshot age rather than a blocks-behind figure it cannot know.
 
 Settlement is USDC on Base via EIP-3009 executed by the facilitator (never this server), per the
 x402 V2 scheme (see docs/RESEARCH-SPRINT1.md).
 
+Operating it — log format, rate limits, metrics, backups, restore, the incident table — is
+[docs/RUNTIME.md §8](../../docs/RUNTIME.md#8-operations).
+
 Run tests: `npm run test:backend` (from repo root). No live chain or facilitator needed —
-the facilitator is injected and stubbed in tests.
+the facilitator is injected and stubbed in tests. `test/signals.test.mjs` spawns the real
+entrypoint and sends it a real SIGTERM; it skips on Windows, where a child cannot be signalled.

--- a/apps/api/src/metrics.mjs
+++ b/apps/api/src/metrics.mjs
@@ -1,0 +1,99 @@
+// @ts-check
+/**
+ * Plain-text counters for `/metrics`.
+ *
+ * Prometheus text exposition format, hand-written in ~20 lines, because that format is a
+ * `name value` line per metric and adding a client library to a repo whose only runtime dependency
+ * is viem would be an absurd trade. It is equally readable with `curl` when there is no Prometheus
+ * — which, during an incident, is the case that matters.
+ *
+ * Counters are monotonic and pushed at you (`inc`). Gauges are pulled: registered as functions and
+ * evaluated at scrape time, so a value like snapshot age is computed when asked rather than by a
+ * timer that could itself be the thing that died.
+ *
+ * ON "INDEXER LAG": the API deliberately has no RPC client — it serves the snapshot and nothing
+ * else — so it cannot know the chain head and MUST NOT claim a blocks-behind figure. What it can
+ * measure exactly is how long ago the indexer last wrote the snapshot, which is the number that
+ * actually tells you the indexer stopped. The metric is named for what it measures:
+ * `vault_indexer_snapshot_age_seconds`.
+ */
+
+/** Metric metadata. A metric absent from here still renders; it just has no HELP line. */
+const HELP = {
+  vault_api_requests_total: ['counter', 'HTTP requests received'],
+  vault_api_payment_required_total: ['counter', '402 responses issued (unpaid or invalid payment)'],
+  vault_api_settlements_total: ['counter', 'payments verified and settled by the facilitator'],
+  vault_api_rate_limited_total: ['counter', '429 responses issued to free routes'],
+  vault_api_rejected_total: ['counter', 'requests refused on size/URL/method limits'],
+  vault_api_errors_total: ['counter', 'unhandled errors turned into a 500'],
+  vault_api_snapshot_reload_failures_total: ['counter', 'snapshot reloads that failed and left stale state serving'],
+  vault_api_uptime_seconds: ['gauge', 'seconds since this process started serving'],
+  vault_indexer_last_block: ['gauge', 'last block in the snapshot the API is serving'],
+  vault_indexer_snapshot_age_seconds: ['gauge', 'seconds since the indexer last wrote the snapshot — the lag signal'],
+  vault_api_rate_limit_buckets: ['gauge', 'per-IP token buckets currently tracked'],
+  vault_api_seen_nonces: ['gauge', 'payment nonces held for local replay defence'],
+};
+
+export function createMetrics() {
+  /** @type {Map<string, number>} */
+  const counters = new Map();
+  /** @type {Map<string, () => number>} */
+  const gauges = new Map();
+
+  const api = {
+    /** Bump a counter. Unknown names are allowed — a metric should never be the thing that throws. */
+    inc(name, by = 1) {
+      counters.set(name, (counters.get(name) ?? 0) + by);
+      return api;
+    },
+    /** Register a pull-at-scrape-time gauge. */
+    gauge(name, fn) {
+      gauges.set(name, fn);
+      return api;
+    },
+    get(name) {
+      if (counters.has(name)) return counters.get(name);
+      const g = gauges.get(name);
+      return g ? safe(g) : undefined;
+    },
+    /** Every metric as a plain object — used by tests and by the shutdown summary line. */
+    snapshot() {
+      const out = {};
+      for (const [k, v] of counters) out[k] = v;
+      for (const [k, fn] of gauges) out[k] = safe(fn);
+      return out;
+    },
+    /** Prometheus text exposition format. */
+    render() {
+      const all = api.snapshot();
+      const lines = [];
+      for (const name of Object.keys(all).sort()) {
+        const meta = HELP[name];
+        if (meta) {
+          lines.push(`# HELP ${name} ${meta[1]}`);
+          lines.push(`# TYPE ${name} ${meta[0]}`);
+        }
+        lines.push(`${name} ${all[name]}`);
+      }
+      return `${lines.join('\n')}\n`;
+    },
+  };
+
+  // Counters that must read 0 rather than be absent before their first event: a missing series and
+  // a zero series look identical in a graph, and only one of them is good news.
+  for (const n of ['vault_api_requests_total', 'vault_api_payment_required_total', 'vault_api_settlements_total',
+    'vault_api_rate_limited_total', 'vault_api_rejected_total', 'vault_api_errors_total',
+    'vault_api_snapshot_reload_failures_total']) counters.set(n, 0);
+
+  return api;
+}
+
+/** A gauge that throws must not take the whole scrape down with it. */
+function safe(fn) {
+  try {
+    const v = Number(fn());
+    return Number.isFinite(v) ? v : 0;
+  } catch {
+    return 0;
+  }
+}

--- a/apps/api/src/ratelimit.mjs
+++ b/apps/api/src/ratelimit.mjs
@@ -1,0 +1,109 @@
+// @ts-check
+/**
+ * Per-IP token bucket for the FREE routes.
+ *
+ * WHY ONLY THE FREE ROUTES: the paid routes are self-limiting — **x402 IS the rate limiter**.
+ * Every metered read costs the caller real USDC through a facilitator settlement, so flooding
+ * `/vaults` is not a denial-of-service, it is a purchase. The only requests an attacker gets for
+ * nothing are the free ones, and those are what this bounds. (An unpaid request to a metered route
+ * returns 402 without a facilitator call, a state read or a disk touch — building the challenge is
+ * a JSON.stringify — so it is not a lever worth pulling either.)
+ *
+ * A token bucket rather than a fixed window because bursts are the normal shape of legitimate
+ * traffic here: an agent bootstrapping reads `/.well-known/x402` then `/health`, and a monitoring
+ * system scrapes `/metrics` on a tick. `capacity` is the burst it may take at once; `refillPerSec`
+ * is the sustained rate it settles into.
+ *
+ * Memory is bounded: an unbounded per-IP map IS the denial-of-service. See `prune`.
+ */
+
+/**
+ * @param {Object} [p]
+ * @param {number} [p.capacity]       burst size, in requests
+ * @param {number} [p.refillPerSec]   sustained requests per second
+ * @param {number} [p.maxKeys]        hard cap on tracked IPs
+ * @param {() => number} [p.now]
+ */
+export function createRateLimiter({ capacity = 60, refillPerSec = 1, maxKeys = 10_000, now = () => Date.now() } = {}) {
+  if (!(capacity > 0)) throw new Error('ratelimit: capacity must be > 0');
+  if (!(refillPerSec > 0)) throw new Error('ratelimit: refillPerSec must be > 0');
+  /** @type {Map<string, {tokens:number, at:number}>} key → bucket. Insertion order doubles as LRU. */
+  const buckets = new Map();
+  let evicted = 0;
+
+  const levelAt = (b, t) => Math.min(capacity, b.tokens + (Math.max(0, t - b.at) / 1000) * refillPerSec);
+
+  /**
+   * Keep the table bounded.
+   *
+   * A bucket that has fully refilled carries NO information — it is indistinguishable from an IP
+   * we have never seen — so those go first and dropping them changes no decision. Only if the
+   * table is still over the cap (every tracked IP is actively throttled) do we drop the
+   * least-recently-used, which does hand that IP a fresh burst. That is the deliberate trade:
+   * remembering an attacker perfectly is not worth letting them choose our heap size.
+   */
+  function prune(t) {
+    if (buckets.size <= maxKeys) return;
+    for (const [k, b] of buckets) {
+      if (levelAt(b, t) >= capacity) buckets.delete(k);
+    }
+    while (buckets.size > maxKeys) {
+      const lru = buckets.keys().next().value;
+      buckets.delete(lru);
+      evicted += 1;
+    }
+  }
+
+  return {
+    get size() { return buckets.size; },
+    get evictions() { return evicted; },
+    /**
+     * Spend one token for `key`.
+     * @returns {{allowed:boolean, limit:number, remaining:number, retryAfterSec:number}}
+     */
+    take(key, cost = 1) {
+      const t = now();
+      const existing = buckets.get(key);
+      const b = existing ?? { tokens: capacity, at: t };
+      if (existing) buckets.delete(key);   // re-insert below so Map order stays LRU-ordered
+      b.tokens = levelAt(b, t);
+      b.at = t;
+
+      const allowed = b.tokens >= cost;
+      if (allowed) b.tokens -= cost;
+      buckets.set(key, b);
+      prune(t);
+
+      return {
+        allowed,
+        limit: capacity,
+        remaining: Math.max(0, Math.floor(b.tokens)),
+        retryAfterSec: allowed ? 0 : Math.max(1, Math.ceil((cost - b.tokens) / refillPerSec)),
+      };
+    },
+    reset() { buckets.clear(); },
+  };
+}
+
+/**
+ * The key to bucket by.
+ *
+ * `x-forwarded-for` is CLIENT-SPOOFABLE: anyone can send it, so trusting it by default would let a
+ * single attacker mint a fresh bucket per request and defeat the limiter entirely. It is honoured
+ * only when the operator sets TRUST_PROXY, which is a promise that a reverse proxy in front of
+ * this process overwrites the header. Without a proxy, `remoteAddress` is the truth; behind one,
+ * it is the proxy for every request and every client would share one bucket — hence the knob.
+ *
+ * @param {{socket?:{remoteAddress?:string}, headers?:Record<string,any>}} req
+ * @param {{trustProxy?:boolean}} [opts]
+ */
+export function clientIp(req, { trustProxy = false } = {}) {
+  if (trustProxy) {
+    const xff = req?.headers?.['x-forwarded-for'];
+    if (xff) {
+      const first = String(Array.isArray(xff) ? xff[0] : xff).split(',')[0].trim();
+      if (first) return first;
+    }
+  }
+  return req?.socket?.remoteAddress || 'unknown';
+}

--- a/apps/api/src/serve.mjs
+++ b/apps/api/src/serve.mjs
@@ -15,14 +15,24 @@
  *   PRICE_AMOUNT (10000 = $0.01)  PRICE_NETWORK (base)
  *   FACILITATOR (stub | http)   FACILITATOR_URL (required when FACILITATOR=http)
  *   CORS (1 to enable — needed for the browser live mode)
+ *   RATE_LIMIT_BURST (60)  RATE_LIMIT_PER_SEC (5, 0 disables)  RATE_LIMIT_MAX_IPS (10000)
+ *   TRUST_PROXY (1 iff a reverse proxy in front of this process sets x-forwarded-for)
+ *   MAX_URL_BYTES (2048)  MAX_BODY_BYTES (8192)  MAX_HEADER_BYTES (16384)
+ *   HEARTBEAT_DIR (dirname of STATE_PATH)  LOG_FORMAT (json|pretty)  LOG_LEVEL (info)
  *
  * Run: `PRICE_ASSET=… PRICE_PAYTO=… node apps/api/src/serve.mjs`
  */
 
 import { fileURLToPath } from 'node:url';
-import { createApi } from './server.mjs';
+import { stat } from 'node:fs/promises';
+import { createApi, DEFAULT_LIMITS } from './server.mjs';
 import { createHttpFacilitator, createStubFacilitator } from './facilitator.mjs';
+import { createRateLimiter } from './ratelimit.mjs';
+import { createMetrics } from './metrics.mjs';
 import { loadSnapshot } from '../../../packages/indexer/src/store.mjs';
+import { loggerFromEnv } from '../../../packages/oplog/src/logger.mjs';
+import { createHeartbeat, defaultHeartbeatDir } from '../../../packages/oplog/src/heartbeat.mjs';
+import { createShutdown } from '../../../packages/oplog/src/shutdown.mjs';
 
 /**
  * Parse + validate the API config from a raw env object. Pure and testable.
@@ -42,11 +52,19 @@ export function resolveApiConfig(env) {
     throw new Error('api: FACILITATOR=http requires FACILITATOR_URL');
 
   const num = (k, d) => (env[k] != null && env[k] !== '' ? Number(env[k]) : d);
+  const flag = (k) => env[k] === '1' || env[k] === 'true';
+
+  const refillPerSec = num('RATE_LIMIT_PER_SEC', 5);
+  const capacity = num('RATE_LIMIT_BURST', 60);
+  if (!Number.isFinite(refillPerSec) || refillPerSec < 0) throw new Error(`api: RATE_LIMIT_PER_SEC must be >= 0, got '${env.RATE_LIMIT_PER_SEC}'`);
+  if (!Number.isFinite(capacity) || capacity <= 0) throw new Error(`api: RATE_LIMIT_BURST must be > 0, got '${env.RATE_LIMIT_BURST}'`);
+
+  const statePath = env.STATE_PATH || './data/indexer-state.json';
   return {
-    statePath: env.STATE_PATH || './data/indexer-state.json',
+    statePath,
     port: num('PORT', 8402),
     reloadMs: num('RELOAD_MS', 5000),
-    cors: env.CORS === '1' || env.CORS === 'true',
+    cors: flag('CORS'),
     price: {
       asset: env.PRICE_ASSET,
       amount: env.PRICE_AMOUNT || '10000',
@@ -55,6 +73,18 @@ export function resolveApiConfig(env) {
     },
     facilitatorKind: facilitator,
     facilitatorUrl: env.FACILITATOR_URL,
+    // RATE_LIMIT_PER_SEC=0 turns the limiter off entirely — for a private deployment where the
+    // only client is your own front end and an accidental 429 is worse than an unbounded scrape.
+    rateLimit: { enabled: refillPerSec > 0, capacity, refillPerSec, maxKeys: num('RATE_LIMIT_MAX_IPS', 10_000) },
+    // Off by default and it must stay that way: x-forwarded-for is client-spoofable, so trusting
+    // it without a proxy that overwrites it lets one attacker mint a fresh bucket per request.
+    trustProxy: flag('TRUST_PROXY'),
+    limits: {
+      maxUrlLength: num('MAX_URL_BYTES', DEFAULT_LIMITS.maxUrlLength),
+      maxBodyBytes: num('MAX_BODY_BYTES', DEFAULT_LIMITS.maxBodyBytes),
+      maxHeaderBytes: num('MAX_HEADER_BYTES', DEFAULT_LIMITS.maxHeaderBytes),
+    },
+    heartbeatDir: defaultHeartbeatDir({ ...env, STATE_PATH: statePath }),
   };
 }
 
@@ -69,44 +99,100 @@ export function facilitatorFromConfig(cfg, { fetchImpl } = {}) {
  * Build the API server from config. Loads the initial snapshot and exposes a `reload()` that
  * refreshes state IN PLACE (so createApi's closure stays valid) — fault-tolerant: a malformed or
  * version-mismatched snapshot is logged and the previous good state is kept serving.
+ *
+ * `reload()` also drives the two operational signals the API is uniquely placed to report: the
+ * snapshot's age (the indexer-lag metric — see metrics.mjs on why age, not blocks-behind) and the
+ * API's own heartbeat, which is written on a SUCCESSFUL reload so a process that is up but has
+ * lost its snapshot does not look healthy to ops-check.
+ *
  * @param {ReturnType<typeof resolveApiConfig>} cfg
- * @param {{facilitator?:object, log?:(m:string)=>void}} [opts]
+ * @param {{facilitator?:object, log?:any, now?:() => number}} [opts]
  */
-export async function buildApiServer(cfg, { facilitator, log = console.log } = {}) {
+export async function buildApiServer(cfg, { facilitator, log = loggerFromEnv('api'), now = () => Date.now() } = {}) {
   const state = await loadSnapshot(cfg.statePath);
   const fac = facilitator ?? facilitatorFromConfig(cfg);
-  const api = createApi({ state, facilitator: fac, price: cfg.price, cors: cfg.cors });
+  const metrics = createMetrics();
+  const rateLimit = cfg.rateLimit?.enabled
+    ? createRateLimiter({ capacity: cfg.rateLimit.capacity, refillPerSec: cfg.rateLimit.refillPerSec, maxKeys: cfg.rateLimit.maxKeys, now })
+    : null;
+
+  const startedAt = now();
+  let snapshotMtimeMs = await mtimeOrNull(cfg.statePath);
+  metrics.gauge('vault_api_uptime_seconds', () => Math.round((now() - startedAt) / 1000));
+  metrics.gauge('vault_indexer_snapshot_age_seconds', () => (snapshotMtimeMs == null ? -1 : Math.round((now() - snapshotMtimeMs) / 1000)));
+
+  const heartbeat = createHeartbeat({
+    dir: cfg.heartbeatDir, service: 'api',
+    // Three reload cycles of silence is a dead API, with room for one slow disk read.
+    staleAfterMs: Math.max(30_000, cfg.reloadMs * 3),
+    onError: (err) => log.warn?.('heartbeat.failed', { error: String(err?.message ?? err) }),
+  });
+
+  const api = createApi({
+    state, facilitator: fac, price: cfg.price, cors: cfg.cors,
+    rateLimit, metrics, limits: cfg.limits, trustProxy: cfg.trustProxy, log,
+  });
 
   async function reload() {
     try {
       const fresh = await loadSnapshot(cfg.statePath);
       // Replace the Map/scalar fields on the SAME object the API closes over.
       Object.assign(state, fresh);
+      snapshotMtimeMs = await mtimeOrNull(cfg.statePath);
+      await heartbeat.beat({ lastBlock: state.lastBlock, vaults: state.vaults.size });
       return true;
     } catch (err) {
-      log(`api: snapshot reload failed, keeping stale state at block ${state.lastBlock}: ${err?.message ?? err}`);
+      metrics.inc('vault_api_snapshot_reload_failures_total');
+      log.warn?.('snapshot.reload_failed', { path: cfg.statePath, lastBlock: state.lastBlock, error: String(err?.message ?? err) });
       return false;
     }
   }
 
-  return { api, state, reload };
+  return { api, state, reload, metrics, rateLimit, heartbeat, log };
+}
+
+async function mtimeOrNull(path) {
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return null;
+  }
 }
 
 // ── entrypoint ──
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 if (isMain) {
+  const log = loggerFromEnv('api');
   const cfg = resolveApiConfig(process.env);
-  buildApiServer(cfg).then(({ api, state, reload }) => {
+  buildApiServer(cfg, { log }).then(async ({ api, state, reload, metrics, heartbeat }) => {
     if (cfg.facilitatorKind === 'stub') {
-      console.warn('⚠ api: FACILITATOR=stub — payments are ACCEPTED WITHOUT on-chain settlement (dev only). Set FACILITATOR=http + FACILITATOR_URL for production.');
+      log.warn('facilitator.stub', { msg: 'payments are ACCEPTED WITHOUT on-chain settlement (dev only). Set FACILITATOR=http + FACILITATOR_URL for production.' });
     }
     const timer = setInterval(reload, cfg.reloadMs);
     if (typeof timer.unref === 'function') timer.unref();
+    await heartbeat.beat({ lastBlock: state.lastBlock, vaults: state.vaults.size }, { force: true });
+
+    // SIGTERM: stop reloading, stop accepting, let in-flight responses finish, then close.
+    // `closeIdleConnections` is what makes this bounded — keep-alive sockets with no request in
+    // flight would otherwise hold the server open for their full timeout.
+    createShutdown({ log })
+      .onShutdown('api.stop-reload', () => clearInterval(timer))
+      .onShutdown('api.drain', () => new Promise((resolve) => {
+        api.server.close(() => resolve(undefined));
+        api.server.closeIdleConnections?.();
+      }))
+      .onShutdown('api.final-metrics', () => log.info('metrics.final', metrics.snapshot()))
+      .install();
+
     api.server.listen(cfg.port, () => {
-      console.log(`api: listening on :${cfg.port} — snapshot ${cfg.statePath} (block ${state.lastBlock}), reload ${cfg.reloadMs}ms, facilitator ${cfg.facilitatorKind}${cfg.cors ? ', cors on' : ''}`);
+      log.info('listening', {
+        port: cfg.port, snapshot: cfg.statePath, lastBlock: state.lastBlock, reloadMs: cfg.reloadMs,
+        facilitator: cfg.facilitatorKind, cors: cfg.cors, trustProxy: cfg.trustProxy,
+        rateLimit: cfg.rateLimit.enabled ? `${cfg.rateLimit.refillPerSec}/s burst ${cfg.rateLimit.capacity}` : 'off',
+      });
     });
   }).catch((err) => {
-    console.error(err?.message ?? err);
+    log.error('startup.failed', { error: String(err?.message ?? err) });
     process.exit(1);
   });
 }

--- a/apps/api/src/server.mjs
+++ b/apps/api/src/server.mjs
@@ -1,17 +1,42 @@
 // @ts-check
 /**
  * Metered read API over indexed vault state. Read routes are gated by the x402 payment gate;
- * a health route is free. Uses only Node built-ins (http) — no framework dependency.
+ * a small set of routes is free. Uses only Node built-ins (http) — no framework dependency.
  *
  * Routes (all GET):
- *   /health                     free
- *   /vaults/:addr               paid — vault view (shares, members, capacity, sub-vault links)
- *   /operators/leaderboard      paid — all-vaults-included operator leaderboard (SF-4)
+ *   /health                     free   — liveness + the block being served
+ *   /.well-known/x402           free   — discovery document (pricing + route map)
+ *   /metrics                    free   — plain-text counters (see metrics.mjs)
+ *   /vaults                     paid   — every indexed vault
+ *   /vaults/:addr               paid   — vault view (shares, members, capacity, sub-vault links)
+ *   /vaults/:addr/members/:m    paid   — one member's position
+ *   /operators/leaderboard      paid   — all-vaults-included operator leaderboard (SF-4)
+ *
+ * HARDENING. The free routes get a per-IP token bucket; the paid ones do not, because
+ * **x402 IS the rate limiter** for them — every metered read costs the caller real USDC through a
+ * facilitator settlement, so flooding them is a purchase, not a denial-of-service. Method, URL
+ * length and request-body size are capped before any work happens. See ratelimit.mjs.
  */
 
 import { createServer } from 'node:http';
 import { gate, HEADERS } from './x402.mjs';
+import { createMetrics } from './metrics.mjs';
+import { clientIp } from './ratelimit.mjs';
 import { leaderboard, vaultView, memberPosition, listVaults } from '../../../packages/indexer/src/projections.mjs';
+
+/** Routes served without payment — and therefore the routes the rate limiter guards. */
+export const FREE_ROUTES = ['/health', '/.well-known/x402', '/metrics'];
+
+/**
+ * Caps applied before any handler work. Deliberately small: this is a GET-only read API, so a
+ * request body is already a sign of something wrong, and no legitimate URL here needs 2KB.
+ */
+export const DEFAULT_LIMITS = {
+  maxUrlLength: 2048,
+  maxBodyBytes: 8192,
+  /** Node's own header cap. The payment-signature envelope is ~1KB of base64, so 16KB is ample. */
+  maxHeaderBytes: 16384,
+};
 
 /** JSON with bigint support (as decimal strings). */
 function jsonStringify(obj) {
@@ -24,43 +49,91 @@ function jsonStringify(obj) {
  * @param {import('./x402.mjs').Facilitator} deps.facilitator
  * @param {import('./x402.mjs').PriceSpec} deps.price
  * @param {() => number} [deps.now]
- * @param {boolean} [deps.cors]  emit permissive CORS headers + answer preflight (browser live mode)
+ * @param {boolean} [deps.cors]        emit permissive CORS headers + answer preflight (browser live mode)
+ * @param {{take:Function, size?:number}} [deps.rateLimit]
+ *        per-IP bucket for the free routes; omitted = no limiting (the default, so existing
+ *        in-process callers and tests are unchanged)
+ * @param {ReturnType<typeof createMetrics>} [deps.metrics]
+ * @param {typeof DEFAULT_LIMITS} [deps.limits]
+ * @param {boolean} [deps.trustProxy]  honour x-forwarded-for (only true behind a proxy that sets it)
+ * @param {{debug?:Function, info?:Function, warn?:Function, error?:Function}} [deps.log]
  */
-export function createApi({ state, facilitator, price, now = () => Date.now(), cors = false }) {
+export function createApi({ state, facilitator, price, now = () => Date.now(), cors = false, rateLimit = null, metrics = createMetrics(), limits = DEFAULT_LIMITS, trustProxy = false, log = {} }) {
   const seenNonces = new Set();
+  const lim = { ...DEFAULT_LIMITS, ...limits };
 
-  /** @returns {Promise<{status:number, headers:Record<string,string>, body:string}>} */
-  async function handle(method, url, headers) {
-    if (method !== 'GET')
-      return { status: 405, headers: {}, body: jsonStringify({ error: 'method not allowed' }) };
+  metrics.gauge('vault_indexer_last_block', () => state.lastBlock);
+  metrics.gauge('vault_api_seen_nonces', () => seenNonces.size);
+  if (rateLimit) metrics.gauge('vault_api_rate_limit_buckets', () => rateLimit.size ?? 0);
+
+  const json = (status, headers, body) => ({ status, headers, body: jsonStringify(body) });
+
+  /**
+   * @param {string} method
+   * @param {string} url
+   * @param {Record<string,any>} headers
+   * @param {{ip?:string}} [ctx]  request context; positional-compatible with the 3-arg callers
+   * @returns {Promise<{status:number, headers:Record<string,string>, body:string}>}
+   */
+  async function handle(method, url, headers, ctx = {}) {
+    metrics.inc('vault_api_requests_total');
+
+    if (method !== 'GET') {
+      metrics.inc('vault_api_rejected_total');
+      return json(405, {}, { error: 'method not allowed' });
+    }
+    if (url.length > lim.maxUrlLength) {
+      metrics.inc('vault_api_rejected_total');
+      return json(414, {}, { error: 'uri too long', limit: lim.maxUrlLength });
+    }
 
     const path = url.split('?')[0];
+
+    // Free routes are cheap and unpriced, which makes them the only thing worth flooding. Bucket
+    // them per IP. The metered routes below are NOT bucketed: see the module header.
+    if (rateLimit && FREE_ROUTES.includes(path)) {
+      const verdict = rateLimit.take(ctx.ip || 'unknown');
+      if (!verdict.allowed) {
+        metrics.inc('vault_api_rate_limited_total');
+        log.warn?.('http.rate_limited', { path, ip: ctx.ip, retryAfterSec: verdict.retryAfterSec });
+        return json(429, {
+          'retry-after': String(verdict.retryAfterSec),
+          'x-ratelimit-limit': String(verdict.limit),
+          'x-ratelimit-remaining': '0',
+        }, { error: 'rate limit exceeded', retryAfterSec: verdict.retryAfterSec });
+      }
+    }
+
     if (path === '/health')
-      return { status: 200, headers: {}, body: jsonStringify({ ok: true, lastBlock: state.lastBlock }) };
+      return json(200, {}, { ok: true, lastBlock: state.lastBlock });
+
+    // Free but rate-limited: an operator scraping this must not be starved of it by a stranger,
+    // and a stranger must not find it the cheapest way to load the process.
+    if (path === '/metrics')
+      return { status: 200, headers: { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' }, body: metrics.render() };
 
     // Free discovery document — agents bootstrap from here (pricing, routes, spec pointer).
     if (path === '/.well-known/x402')
-      return {
-        status: 200,
-        headers: {},
-        body: jsonStringify({
-          x402Version: 2,
-          price: { asset: price.asset, amount: price.amount, payTo: price.payTo, network: price.network },
-          routes: {
-            free: ['/health', '/.well-known/x402'],
-            metered: ['/vaults', '/vaults/{address}', '/vaults/{address}/members/{member}', '/operators/leaderboard'],
-          },
-          openapi: 'docs/api/openapi.yaml',
-          llms: '/llms.txt',
-        }),
-      };
+      return json(200, {}, {
+        x402Version: 2,
+        price: { asset: price.asset, amount: price.amount, payTo: price.payTo, network: price.network },
+        routes: {
+          free: FREE_ROUTES,
+          metered: ['/vaults', '/vaults/{address}', '/vaults/{address}/members/{member}', '/operators/leaderboard'],
+        },
+        openapi: 'docs/api/openapi.yaml',
+        llms: '/llms.txt',
+      });
 
     // Everything else is metered.
     const lc = {};
     for (const [k, v] of Object.entries(headers)) lc[k.toLowerCase()] = v;
     const verdict = await gate({ headers: lc, price, facilitator, nowMs: now(), seenNonces });
-    if (verdict.status === 402)
+    if (verdict.status === 402) {
+      metrics.inc('vault_api_payment_required_total');
       return { status: 402, headers: verdict.headers, body: jsonStringify(verdict.body) };
+    }
+    metrics.inc('vault_api_settlements_total');
 
     // Paid — resolve the resource.
     const paidHeaders = verdict.headers;
@@ -97,7 +170,7 @@ export function createApi({ state, facilitator, price, now = () => Date.now(), c
       }
     : {};
 
-  const server = createServer((req, res) => {
+  const server = createServer({ maxHeaderSize: lim.maxHeaderBytes }, (req, res) => {
     if (cors && req.method === 'OPTIONS') {
       res.writeHead(204, {
         ...corsHeaders,
@@ -108,16 +181,40 @@ export function createApi({ state, facilitator, price, now = () => Date.now(), c
       res.end();
       return;
     }
-    handle(req.method ?? 'GET', req.url ?? '/', req.headers)
+
+    // Body cap, both ways a body can arrive: a declared content-length is refused outright, and an
+    // undeclared (chunked) one is cut off at the same ceiling. A GET-only read API has no use for
+    // a request body at all, so this only fires on something malformed or hostile.
+    const declared = Number(req.headers['content-length'] ?? 0);
+    if (Number.isFinite(declared) && declared > lim.maxBodyBytes) {
+      metrics.inc('vault_api_rejected_total');
+      res.writeHead(413, { 'content-type': 'application/json', ...corsHeaders });
+      res.end(jsonStringify({ error: 'payload too large', limit: lim.maxBodyBytes }));
+      return;
+    }
+    let received = 0;
+    req.on('data', (chunk) => {
+      received += chunk.length;
+      if (received > lim.maxBodyBytes) {
+        metrics.inc('vault_api_rejected_total');
+        req.destroy();
+      }
+    });
+
+    handle(req.method ?? 'GET', req.url ?? '/', req.headers, { ip: clientIp(req, { trustProxy }) })
       .then(({ status, headers, body }) => {
+        if (res.writableEnded) return;
         res.writeHead(status, { 'content-type': 'application/json', ...corsHeaders, ...headers });
         res.end(body);
       })
       .catch((err) => {
+        metrics.inc('vault_api_errors_total');
+        log.error?.('http.error', { url: req.url, error: String(err?.message ?? err) });
+        if (res.writableEnded) return;
         res.writeHead(500, { 'content-type': 'application/json', ...corsHeaders });
         res.end(jsonStringify({ error: 'internal', detail: String(err?.message ?? err) }));
       });
   });
 
-  return { server, handle, HEADERS };
+  return { server, handle, metrics, HEADERS };
 }

--- a/apps/api/test/metrics.test.mjs
+++ b/apps/api/test/metrics.test.mjs
@@ -1,0 +1,247 @@
+// @ts-check
+/**
+ * `/metrics` and the request caps. The counters exist to answer "is it up, is it being paid, and
+ * how far behind is the indexer" from a terminal during an incident, so the tests check the wire
+ * format an operator actually reads, not just the internal numbers.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp } from 'node:fs/promises';
+import { createMetrics } from '../src/metrics.mjs';
+import { createApi, DEFAULT_LIMITS } from '../src/server.mjs';
+import { createStubFacilitator } from '../src/facilitator.mjs';
+import { resolveApiConfig, buildApiServer } from '../src/serve.mjs';
+import { applyAll } from '../../../packages/indexer/src/projections.mjs';
+import { saveSnapshot } from '../../../packages/indexer/src/store.mjs';
+import { buildChallenge } from '../src/x402.mjs';
+
+const USDC = '0x' + 'c'.repeat(40);
+const PAYTO = '0x' + '9'.repeat(40);
+const V = '0x' + '1'.repeat(40);
+const PRICE = { asset: USDC, amount: '10000', payTo: PAYTO, network: 'base' };
+const BASE_ENV = { PRICE_ASSET: USDC, PRICE_PAYTO: PAYTO };
+
+const api = (extra = {}) => createApi({ state: applyAll([]), facilitator: createStubFacilitator(), price: PRICE, ...extra });
+
+/** Speak HTTP down a bare socket — `fetch` will not send the malformed shapes we need to refuse. */
+function rawRequest(port, text) {
+  return new Promise((resolve, reject) => {
+    const sock = connect(port, '127.0.0.1', () => sock.write(text));
+    let buf = '';
+    sock.setTimeout(3000, () => { sock.destroy(); resolve(buf); });
+    sock.on('data', (d) => { buf += d.toString('utf8'); });
+    sock.on('close', () => resolve(buf));
+    sock.on('error', () => resolve(buf));
+    sock.on('timeout', () => reject(new Error('timeout')));
+  });
+}
+
+/** A signature header the stub facilitator accepts. */
+function paidHeader(nonce = '0x' + '7'.repeat(64)) {
+  const c = buildChallenge(PRICE, { nowMs: Date.now() });
+  const env = {
+    x402Version: 2, network: PRICE.network, signature: '0xdead',
+    authorization: { asset: c.asset, to: c.payTo, value: c.amount, nonce, validBefore: Math.floor(Date.now() / 1000) + 600 },
+  };
+  return { 'payment-signature': Buffer.from(JSON.stringify(env), 'utf8').toString('base64') };
+}
+
+// ── the counter store ──
+
+test('counters start at zero rather than absent — a missing series and a zero series look alike', () => {
+  const text = createMetrics().render();
+  assert.match(text, /^vault_api_requests_total 0$/m);
+  assert.match(text, /^vault_api_settlements_total 0$/m);
+});
+
+test('render emits HELP and TYPE for known metrics, in the prometheus text format', () => {
+  const m = createMetrics();
+  m.inc('vault_api_requests_total', 3);
+  const text = m.render();
+  assert.match(text, /# HELP vault_api_requests_total HTTP requests received/);
+  assert.match(text, /# TYPE vault_api_requests_total counter/);
+  assert.match(text, /^vault_api_requests_total 3$/m);
+  assert.ok(text.endsWith('\n'), 'the exposition format requires a trailing newline');
+});
+
+test('gauges are pulled at scrape time, not pushed by a timer that could itself have died', () => {
+  const m = createMetrics();
+  let v = 1;
+  m.gauge('vault_indexer_last_block', () => v);
+  assert.equal(m.get('vault_indexer_last_block'), 1);
+  v = 99;
+  assert.match(m.render(), /^vault_indexer_last_block 99$/m);
+});
+
+test('a gauge that throws degrades to 0 instead of taking the whole scrape down', () => {
+  const m = createMetrics();
+  m.gauge('vault_indexer_last_block', () => { throw new Error('state gone'); });
+  m.gauge('weird_nan', () => NaN);
+  assert.match(m.render(), /^vault_indexer_last_block 0$/m);
+  assert.match(m.render(), /^weird_nan 0$/m);
+});
+
+// ── the route ──
+
+test('/metrics is free, plain text, and reflects the requests it has served', async () => {
+  const a = api();
+  await a.handle('GET', '/health', {});
+  await a.handle('GET', '/vaults', {});            // unpaid → 402
+  const res = await a.handle('GET', '/metrics', {});
+  assert.equal(res.status, 200);
+  assert.match(res.headers['content-type'], /^text\/plain/);
+  assert.match(res.body, /^vault_api_requests_total 3$/m);
+  assert.match(res.body, /^vault_api_payment_required_total 1$/m);
+  assert.match(res.body, /^vault_api_settlements_total 0$/m);
+});
+
+test('a settled payment increments settlements, not payment-required', async () => {
+  const a = api();
+  const res = await a.handle('GET', '/vaults', paidHeader());
+  assert.equal(res.status, 200);
+  assert.match((await a.handle('GET', '/metrics', {})).body, /^vault_api_settlements_total 1$/m);
+  assert.match((await a.handle('GET', '/metrics', {})).body, /^vault_api_payment_required_total 0$/m);
+});
+
+test('/metrics is advertised as free in the discovery document', async () => {
+  const doc = JSON.parse((await api().handle('GET', '/.well-known/x402', {})).body);
+  assert.ok(doc.routes.free.includes('/metrics'), 'the discovery doc must not lie to agents');
+  assert.ok(doc.routes.free.includes('/health'));
+});
+
+test('the snapshot block being served is exposed as a gauge', async () => {
+  const state = applyAll([{ name: 'VaultCreated', vault: V, blockNumber: 77, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } }]);
+  const a = createApi({ state, facilitator: createStubFacilitator(), price: PRICE });
+  assert.match((await a.handle('GET', '/metrics', {})).body, /^vault_indexer_last_block 77$/m);
+});
+
+// ── request caps ──
+
+test('an over-long URL is refused before any handler work', async () => {
+  const a = api();
+  const long = `/vaults/${'a'.repeat(DEFAULT_LIMITS.maxUrlLength)}`;
+  const res = await a.handle('GET', long, {});
+  assert.equal(res.status, 414);
+  assert.equal(JSON.parse(res.body).limit, DEFAULT_LIMITS.maxUrlLength);
+  assert.match((await a.handle('GET', '/metrics', {})).body, /^vault_api_rejected_total 1$/m);
+});
+
+test('the URL cap is configurable and a normal URL is unaffected', async () => {
+  const a = api({ limits: { maxUrlLength: 20 } });
+  assert.equal((await a.handle('GET', '/health', {})).status, 200);
+  assert.equal((await a.handle('GET', `/vaults/${'b'.repeat(40)}`, {})).status, 414);
+});
+
+test('a non-GET request is refused and counted as a rejection', async () => {
+  const a = api();
+  assert.equal((await a.handle('POST', '/health', {})).status, 405);
+  assert.match((await a.handle('GET', '/metrics', {})).body, /^vault_api_rejected_total 1$/m);
+});
+
+test('a declared over-size body is refused with 413 before the method is even considered', async () => {
+  const a = api({ limits: { maxBodyBytes: 64 } });
+  a.server.listen(0);
+  await once(a.server, 'listening');
+  const port = a.server.address().port;
+  try {
+    // POST, so `fetch` will actually carry a body. The cap fires in the connection handler, ahead
+    // of the 405 the method check would otherwise produce — the payload never reaches the handler.
+    const res = await fetch(`http://127.0.0.1:${port}/health`, { method: 'POST', body: 'x'.repeat(500) });
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).limit, 64);
+
+    // And on a GET, which fetch refuses to give a body — raw socket, declared content-length.
+    const raw = await rawRequest(port, `GET /health HTTP/1.1\r\nHost: t\r\nContent-Length: 5000\r\nConnection: close\r\n\r\n${'y'.repeat(5000)}`);
+    assert.match(raw, /^HTTP\/1\.1 413/);
+  } finally {
+    a.server.close();
+    await once(a.server, 'close');
+  }
+});
+
+test('an UNDECLARED (chunked) over-size body is cut off at the same ceiling', async () => {
+  const a = api({ limits: { maxBodyBytes: 64 } });
+  a.server.listen(0);
+  await once(a.server, 'listening');
+  const port = a.server.address().port;
+  try {
+    const chunk = 'z'.repeat(1000);
+    const raw = await rawRequest(port, `POST /health HTTP/1.1\r\nHost: t\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n${(3e8).toString(16)}\r\n${chunk}`);
+    // Either a refusal or a dropped connection is acceptable; silently buffering 300MB is not.
+    assert.ok(raw === '' || /^HTTP\/1\.1 4\d\d/.test(raw), `unexpected response: ${raw.slice(0, 40)}`);
+    assert.ok(a.metrics.get('vault_api_rejected_total') >= 1, 'the refusal is counted');
+  } finally {
+    a.server.close();
+    await once(a.server, 'close');
+  }
+});
+
+test('the server still answers normal traffic with the caps in place', async () => {
+  const a = api({ limits: { maxBodyBytes: 64, maxUrlLength: 100 } });
+  a.server.listen(0);
+  await once(a.server, 'listening');
+  const port = a.server.address().port;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).ok, true);
+    const met = await fetch(`http://127.0.0.1:${port}/metrics`);
+    assert.match(met.headers.get('content-type') ?? '', /text\/plain/);
+    assert.match(await met.text(), /vault_api_requests_total/);
+  } finally {
+    a.server.close();
+    await once(a.server, 'close');
+  }
+});
+
+// ── indexer lag, end to end ──
+
+test('snapshot age is the lag signal, and it is named for what it measures', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'metrics-'));
+  const path = join(dir, 'indexer-state.json');
+  try {
+    await saveSnapshot(path, applyAll([{ name: 'VaultCreated', vault: V, blockNumber: 5, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } }]));
+    let clock = Date.now();
+    const cfg = resolveApiConfig({ ...BASE_ENV, STATE_PATH: path, HEARTBEAT_DIR: dir });
+    const { api: built, metrics } = await buildApiServer(cfg, { log: {}, now: () => clock });
+
+    assert.ok(metrics.get('vault_indexer_snapshot_age_seconds') < 5, 'a just-written snapshot is fresh');
+    clock += 600_000;                       // ten minutes later, with no new snapshot
+    assert.ok(metrics.get('vault_indexer_snapshot_age_seconds') >= 600, 'age grows when the indexer stops');
+    assert.equal(metrics.get('vault_api_uptime_seconds'), 600);
+
+    const text = (await built.handle('GET', '/metrics', {})).body;
+    assert.match(text, /^vault_indexer_snapshot_age_seconds 60\d$/m);
+    assert.match(text, /^vault_indexer_last_block 5$/m);
+    // The API has no RPC client by design, so it must never claim a blocks-behind figure.
+    assert.doesNotMatch(text, /lag_blocks|blocks_behind/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a failed snapshot reload is counted, and the stale block keeps being reported honestly', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'metrics-'));
+  const path = join(dir, 'indexer-state.json');
+  try {
+    await saveSnapshot(path, applyAll([{ name: 'VaultCreated', vault: V, blockNumber: 5, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } }]));
+    const cfg = resolveApiConfig({ ...BASE_ENV, STATE_PATH: path, HEARTBEAT_DIR: dir });
+    const { reload, metrics } = await buildApiServer(cfg, { log: {} });
+    assert.equal(await reload(), true);
+    assert.equal(metrics.get('vault_api_snapshot_reload_failures_total'), 0);
+
+    await rm(path, { force: true });
+    await saveSnapshot(path, applyAll([]));
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(path, '{ torn', 'utf8');
+    assert.equal(await reload(), false);
+    assert.equal(metrics.get('vault_api_snapshot_reload_failures_total'), 1);
+    assert.equal(metrics.get('vault_indexer_last_block'), 5, 'still serving the last good block');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/api/test/ratelimit.test.mjs
+++ b/apps/api/test/ratelimit.test.mjs
@@ -1,0 +1,153 @@
+// @ts-check
+/**
+ * The free-route token bucket. The paid routes are deliberately NOT limited — x402 is their rate
+ * limiter — and one of the tests below pins that so nobody "fixes" it later.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createRateLimiter, clientIp } from '../src/ratelimit.mjs';
+import { createApi, FREE_ROUTES } from '../src/server.mjs';
+import { createStubFacilitator } from '../src/facilitator.mjs';
+import { applyAll } from '../../../packages/indexer/src/projections.mjs';
+
+const USDC = '0x' + 'c'.repeat(40);
+const PAYTO = '0x' + '9'.repeat(40);
+const PRICE = { asset: USDC, amount: '10000', payTo: PAYTO, network: 'base' };
+
+test('a burst up to capacity is allowed, and the next request is not', () => {
+  const rl = createRateLimiter({ capacity: 3, refillPerSec: 1, now: () => 0 });
+  assert.deepEqual([1, 2, 3].map(() => rl.take('a').allowed), [true, true, true]);
+  const over = rl.take('a');
+  assert.equal(over.allowed, false);
+  assert.equal(over.remaining, 0);
+  assert.equal(over.limit, 3);
+  assert.ok(over.retryAfterSec >= 1, 'a 429 always tells the caller a usable wait');
+});
+
+test('tokens refill at the configured rate, capped at capacity', () => {
+  let t = 0;
+  const rl = createRateLimiter({ capacity: 5, refillPerSec: 2, now: () => t });
+  for (let i = 0; i < 5; i += 1) rl.take('a');
+  assert.equal(rl.take('a').allowed, false);
+  t = 1000;                                   // +1s at 2/s = 2 tokens
+  assert.equal(rl.take('a').allowed, true);
+  assert.equal(rl.take('a').allowed, true);
+  assert.equal(rl.take('a').allowed, false);
+  t = 60_000;                                 // a long idle must not bank 120 tokens
+  for (let i = 0; i < 5; i += 1) assert.equal(rl.take('a').allowed, true, `refill ${i}`);
+  assert.equal(rl.take('a').allowed, false, 'capped at capacity');
+});
+
+test('buckets are per key: one noisy IP cannot throttle another', () => {
+  const rl = createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => 0 });
+  assert.equal(rl.take('1.1.1.1').allowed, true);
+  assert.equal(rl.take('1.1.1.1').allowed, false);
+  assert.equal(rl.take('2.2.2.2').allowed, true);
+});
+
+test('memory is bounded: an unbounded per-IP map would itself be the denial-of-service', () => {
+  let t = 0;
+  const rl = createRateLimiter({ capacity: 2, refillPerSec: 1, maxKeys: 10, now: () => t });
+  for (let i = 0; i < 5000; i += 1) rl.take(`ip-${i}`);
+  assert.ok(rl.size <= 11, `bounded, got ${rl.size}`);
+  t = 60_000;
+  rl.take('fresh');
+  assert.ok(rl.size <= 11);
+});
+
+test('eviction drops fully-refilled buckets first: a throttled key survives the churn', () => {
+  // A refilled bucket is indistinguishable from an IP never seen, so dropping it changes no
+  // decision. A depleted one still carries a verdict, and must outlive the harmless entries.
+  let t = 0;
+  const rl = createRateLimiter({ capacity: 10, refillPerSec: 1, maxKeys: 6, now: () => t });
+  for (let i = 0; i < 10; i += 1) rl.take('victim');        // fully depleted
+  for (const k of ['a', 'b', 'c', 'd', 'e']) rl.take(k);    // one token each
+
+  t = 2000;                                                 // a–e are full again; victim has 2
+  for (let i = 0; i < 3; i += 1) rl.take(`flood-${i}`);     // push over maxKeys → prune
+  assert.ok(rl.size <= 6, `bounded, got ${rl.size}`);
+
+  // victim kept its deficit: 2 tokens at t=2000, +1 by t=3000 → 3 allowed, then throttled.
+  t = 3000;
+  assert.deepEqual([1, 2, 3].map(() => rl.take('victim').allowed), [true, true, true]);
+  assert.equal(rl.take('victim').allowed, false, 'not silently reset to a full burst');
+});
+
+test('under sustained table pressure eviction falls back to LRU — a known, bounded trade', () => {
+  // When EVERY tracked IP is actively throttled there is no harmless entry to drop, so the
+  // least-recently-used goes and that IP gets a fresh burst. Remembering an attacker perfectly is
+  // not worth letting them choose our heap size. Pinned here so the trade stays deliberate.
+  const rl = createRateLimiter({ capacity: 1, refillPerSec: 0.001, maxKeys: 5, now: () => 0 });
+  rl.take('attacker');
+  assert.equal(rl.take('attacker').allowed, false);
+  for (let i = 0; i < 100; i += 1) rl.take(`noise-${i}`);
+  assert.equal(rl.take('attacker').allowed, true, 'evicted and reset — the documented trade-off');
+  assert.ok(rl.evictions > 0, 'and it is counted, not silent');
+});
+
+test('a bad configuration is refused loudly rather than silently allowing everything', () => {
+  assert.throws(() => createRateLimiter({ capacity: 0 }), /capacity must be/);
+  assert.throws(() => createRateLimiter({ refillPerSec: 0 }), /refillPerSec must be/);
+});
+
+test('clientIp ignores x-forwarded-for unless TRUST_PROXY says a proxy sets it', () => {
+  const req = { socket: { remoteAddress: '10.0.0.1' }, headers: { 'x-forwarded-for': '9.9.9.9, 10.0.0.2' } };
+  assert.equal(clientIp(req), '10.0.0.1', 'spoofable header ignored by default');
+  assert.equal(clientIp(req, { trustProxy: true }), '9.9.9.9', 'left-most entry is the client');
+  assert.equal(clientIp({ socket: {}, headers: {} }), 'unknown');
+  assert.equal(clientIp({ socket: { remoteAddress: '10.0.0.1' }, headers: {} }, { trustProxy: true }), '10.0.0.1', 'trusted but absent → socket');
+});
+
+// ── wiring: which routes the limiter actually guards ──
+
+function api({ rateLimit }) {
+  return createApi({ state: applyAll([]), facilitator: createStubFacilitator(), price: PRICE, rateLimit });
+}
+
+test('free routes are limited, and the 429 carries retry-after', async () => {
+  const a = api({ rateLimit: createRateLimiter({ capacity: 2, refillPerSec: 1, now: () => 0 }) });
+  assert.equal((await a.handle('GET', '/health', {}, { ip: 'x' })).status, 200);
+  assert.equal((await a.handle('GET', '/health', {}, { ip: 'x' })).status, 200);
+  const res = await a.handle('GET', '/health', {}, { ip: 'x' });
+  assert.equal(res.status, 429);
+  assert.ok(Number(res.headers['retry-after']) >= 1);
+  assert.equal(res.headers['x-ratelimit-remaining'], '0');
+  assert.equal(JSON.parse(res.body).error, 'rate limit exceeded');
+});
+
+test('every advertised free route is covered by the limiter', async () => {
+  for (const route of FREE_ROUTES) {
+    const a = api({ rateLimit: createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => 0 }) });
+    assert.notEqual((await a.handle('GET', route, {}, { ip: 'x' })).status, 429);
+    assert.equal((await a.handle('GET', route, {}, { ip: 'x' })).status, 429, `${route} is limited`);
+  }
+});
+
+test('PAID routes are NOT rate limited — x402 is their limiter, and that is deliberate', async () => {
+  const a = api({ rateLimit: createRateLimiter({ capacity: 1, refillPerSec: 1, now: () => 0 }) });
+  for (let i = 0; i < 25; i += 1) {
+    const res = await a.handle('GET', '/vaults', {}, { ip: 'x' });
+    assert.equal(res.status, 402, 'unpaid metered reads keep answering 402, never 429');
+  }
+});
+
+test('the limiter is off by default, so existing in-process callers are unchanged', async () => {
+  const a = api({ rateLimit: null });
+  for (let i = 0; i < 50; i += 1) assert.equal((await a.handle('GET', '/health', {})).status, 200);
+});
+
+test('limiting keys on the real socket address end to end', async () => {
+  const a = api({ rateLimit: createRateLimiter({ capacity: 2, refillPerSec: 1, now: () => 0 }) });
+  a.server.listen(0);
+  await once(a.server, 'listening');
+  const port = a.server.address().port;
+  try {
+    const codes = [];
+    for (let i = 0; i < 4; i += 1) codes.push((await fetch(`http://127.0.0.1:${port}/health`)).status);
+    assert.deepEqual(codes, [200, 200, 429, 429]);
+  } finally {
+    a.server.close();
+    await once(a.server, 'close');
+  }
+});

--- a/apps/api/test/serve.test.mjs
+++ b/apps/api/test/serve.test.mjs
@@ -8,13 +8,14 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { rm, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { rm, writeFile, mkdtemp } from 'node:fs/promises';
 import { resolveApiConfig, facilitatorFromConfig, buildApiServer } from '../src/serve.mjs';
 import { createApi } from '../src/server.mjs';
 import { createStubFacilitator } from '../src/facilitator.mjs';
 import { applyAll } from '../../../packages/indexer/src/projections.mjs';
 import { saveSnapshot } from '../../../packages/indexer/src/store.mjs';
+import { readHeartbeatFile } from '../../../packages/oplog/src/heartbeat.mjs';
 
 const USDC = '0x' + 'c'.repeat(40);
 const PAYTO = '0x' + '9'.repeat(40);
@@ -110,5 +111,62 @@ test('no CORS headers by default (existing behavior preserved)', async () => {
   } finally {
     server.close();
     await once(server, 'close');
+  }
+});
+
+// ── hardening config (Sprint 13) ──
+
+test('rate-limit config: defaults, and RATE_LIMIT_PER_SEC=0 turns the limiter off', () => {
+  assert.deepEqual(resolveApiConfig(BASE_ENV).rateLimit, { enabled: true, capacity: 60, refillPerSec: 5, maxKeys: 10_000 });
+  assert.equal(resolveApiConfig({ ...BASE_ENV, RATE_LIMIT_PER_SEC: '0' }).rateLimit.enabled, false);
+  const tuned = resolveApiConfig({ ...BASE_ENV, RATE_LIMIT_PER_SEC: '1', RATE_LIMIT_BURST: '10', RATE_LIMIT_MAX_IPS: '50' }).rateLimit;
+  assert.deepEqual(tuned, { enabled: true, capacity: 10, refillPerSec: 1, maxKeys: 50 });
+});
+
+test('rate-limit config rejects nonsense instead of silently disabling the limiter', () => {
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, RATE_LIMIT_PER_SEC: '-1' }), /RATE_LIMIT_PER_SEC must be >= 0/);
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, RATE_LIMIT_BURST: '0' }), /RATE_LIMIT_BURST must be > 0/);
+  assert.throws(() => resolveApiConfig({ ...BASE_ENV, RATE_LIMIT_BURST: 'lots' }), /RATE_LIMIT_BURST must be > 0/);
+});
+
+test('TRUST_PROXY is OFF unless explicitly set — x-forwarded-for is client-spoofable', () => {
+  assert.equal(resolveApiConfig(BASE_ENV).trustProxy, false);
+  assert.equal(resolveApiConfig({ ...BASE_ENV, TRUST_PROXY: '1' }).trustProxy, true);
+  assert.equal(resolveApiConfig({ ...BASE_ENV, TRUST_PROXY: 'true' }).trustProxy, true);
+  assert.equal(resolveApiConfig({ ...BASE_ENV, TRUST_PROXY: 'yes-please' }).trustProxy, false);
+});
+
+test('request caps default sensibly and are overridable', () => {
+  assert.deepEqual(resolveApiConfig(BASE_ENV).limits, { maxUrlLength: 2048, maxBodyBytes: 8192, maxHeaderBytes: 16384 });
+  const l = resolveApiConfig({ ...BASE_ENV, MAX_URL_BYTES: '512', MAX_BODY_BYTES: '1024', MAX_HEADER_BYTES: '4096' }).limits;
+  assert.deepEqual(l, { maxUrlLength: 512, maxBodyBytes: 1024, maxHeaderBytes: 4096 });
+});
+
+test('heartbeatDir defaults alongside the snapshot, and HEARTBEAT_DIR overrides it', () => {
+  assert.equal(resolveApiConfig({ ...BASE_ENV, STATE_PATH: '/data/indexer-state.json' }).heartbeatDir, dirname('/data/indexer-state.json'));
+  assert.equal(resolveApiConfig({ ...BASE_ENV, HEARTBEAT_DIR: '/hb' }).heartbeatDir, '/hb');
+});
+
+test('buildApiServer beats the API heartbeat only on a SUCCESSFUL reload', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'serve-hb-'));
+  const path = join(dir, 'indexer-state.json');
+  try {
+    const V = '0x' + '1'.repeat(40);
+    await saveSnapshot(path, applyAll([{ name: 'VaultCreated', vault: V, blockNumber: 5, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } }]));
+    const cfg = resolveApiConfig({ ...BASE_ENV, STATE_PATH: path, HEARTBEAT_DIR: dir });
+    const { reload, heartbeat } = await buildApiServer(cfg, { log: {} });
+
+    assert.equal(await reload(), true);
+    const first = await readHeartbeatFile(heartbeat.path);
+    assert.equal(first.service, 'api');
+    assert.equal(first.detail.lastBlock, 5);
+
+    // A process that is up but has lost its snapshot must NOT keep looking healthy to ops-check.
+    await writeFile(path, '{ torn', 'utf8');
+    assert.equal(await reload(), false);
+    const second = await readHeartbeatFile(heartbeat.path);
+    assert.equal(second.ts, first.ts, 'heartbeat not refreshed by a failed reload');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
 });

--- a/apps/api/test/signals.test.mjs
+++ b/apps/api/test/signals.test.mjs
@@ -1,0 +1,108 @@
+// @ts-check
+/**
+ * The one thing unit tests cannot reach: a REAL SIGTERM delivered to the REAL entrypoint.
+ *
+ * shutdown.test.mjs proves the hook machinery with a fake process emitter, and serve.test.mjs
+ * proves the pieces the hooks call. What is left unverified is the wiring in between — that
+ * `install()` on the actual `process` runs the actual hooks, that the listener drains rather than
+ * hanging, and that the process exits 0 rather than being killed by the grace-period timer.
+ *
+ * SKIPPED ON WINDOWS, where `child.kill('SIGTERM')` is TerminateProcess: the handler cannot run, so
+ * the test would assert a platform artifact rather than our behaviour. CI is ubuntu-latest and
+ * production is a Linux container, which is where the signal is real and this runs.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { rm, mkdtemp } from 'node:fs/promises';
+import { applyAll } from '../../../packages/indexer/src/projections.mjs';
+import { saveSnapshot } from '../../../packages/indexer/src/store.mjs';
+
+const skipOnWindows = process.platform === 'win32'
+  ? 'SIGTERM is not deliverable to a child on Windows (kill() is TerminateProcess)'
+  : false;
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SERVE = join(HERE, '..', 'src', 'serve.mjs');
+const V = '0x' + '1'.repeat(40);
+const USDC = '0x' + 'c'.repeat(40);
+
+/** Free-ish port: high and unlikely to collide with the other tests in this suite. */
+const PORT = 8500 + (process.pid % 300);
+
+function waitFor(child, predicate, timeoutMs = 15_000) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const timer = setTimeout(() => reject(new Error(`timeout waiting; saw:\n${buf}`)), timeoutMs);
+    const onData = (d) => {
+      buf += d.toString('utf8');
+      if (predicate(buf)) {
+        clearTimeout(timer);
+        resolve(buf);
+      }
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+  });
+}
+
+test('SIGTERM to the real API entrypoint drains and exits 0', { skip: skipOnWindows }, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'api-signal-'));
+  const statePath = join(dir, 'indexer-state.json');
+  await saveSnapshot(statePath, applyAll([
+    { name: 'VaultCreated', vault: V, blockNumber: 5, logIndex: 0, args: { vault: V, creator: V, usdc: USDC, capacityCapUsdc: 1n } },
+  ]));
+
+  const child = spawn(process.execPath, [SERVE], {
+    env: {
+      ...process.env,
+      PRICE_ASSET: USDC, PRICE_PAYTO: '0x' + '9'.repeat(40),
+      STATE_PATH: statePath, HEARTBEAT_DIR: dir, PORT: String(PORT),
+      LOG_FORMAT: 'json', RELOAD_MS: '1000',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const output = [];
+  child.stdout.on('data', (d) => output.push(d.toString('utf8')));
+  child.stderr.on('data', (d) => output.push(d.toString('utf8')));
+
+  try {
+    await waitFor(child, (b) => b.includes('"event":"listening"'));
+
+    // It is actually serving before we stop it — otherwise "it drained" proves nothing.
+    const res = await fetch(`http://127.0.0.1:${PORT}/health`);
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).lastBlock, 5);
+
+    const exited = new Promise((resolve) => child.on('exit', (code, signal) => resolve({ code, signal })));
+    child.kill('SIGTERM');
+    const { code, signal } = await Promise.race([
+      exited,
+      new Promise((_, rej) => setTimeout(() => rej(new Error('did not exit within 10s of SIGTERM')), 10_000)),
+    ]);
+
+    assert.equal(signal, null, 'exited on its own rather than being killed');
+    assert.equal(code, 0, 'clean exit code');
+
+    const text = output.join('');
+    assert.match(text, /"event":"shutdown\.begin"/);
+    assert.match(text, /"event":"shutdown\.complete"/);
+    assert.doesNotMatch(text, /"event":"shutdown\.timeout"/, 'the hooks finished inside the watchdog');
+    // Every hook ran, in order, and none of them failed.
+    for (const step of ['api.stop-reload', 'api.drain', 'api.final-metrics']) {
+      assert.match(text, new RegExp(`"step":"${step.replace('.', '\\.')}","ok":true`), `${step} completed`);
+    }
+    // The final metrics line is the point of the last hook: it must carry real counters.
+    assert.match(text, /"event":"metrics\.final"[\s\S]*vault_api_requests_total/);
+
+    // And the port is genuinely released, not lingering in a half-closed listener.
+    await assert.rejects(fetch(`http://127.0.0.1:${PORT}/health`));
+  } finally {
+    if (child.exitCode === null) child.kill('SIGKILL');
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,18 @@
 #
 #   cp .env.example .env   # fill in RPC_URL + deployed addresses + price
 #   docker compose up --build
+#
+# HEALTHCHECKS. Every service writes a heartbeat file into the shared volume on each successful
+# work cycle, and healthchecks itself with `ops-check` (docs/RUNTIME.md §8). Each container checks
+# only ITS OWN heartbeat on purpose: a whole-stack check inside the indexer would mark the indexer
+# unhealthy because the canary died, and Docker would restart the wrong process. Cross-service
+# coverage belongs in the cron form, which checks all three at once.
+#
+# The heartbeats mean "I am doing my job", not "my process exists" — the API beats on a successful
+# snapshot reload and the canary on a successful sweep — so a wedged process, the exact failure
+# `restart: unless-stopped` never notices on its own, goes unhealthy here.
+#
+# `node` is the only interpreter available: node:24-slim ships neither curl nor wget.
 services:
   indexer:
     build: .
@@ -10,9 +22,19 @@ services:
     env_file: .env
     environment:
       STATE_PATH: /data/indexer-state.json
+      HEARTBEAT_DIR: /data
     volumes:
       - vault-state:/data
     restart: unless-stopped
+    # SIGTERM finishes the current batch, snapshots, and exits. A cold-start catch-up can sit in
+    # one batch for a while, so give it room past the compose default of 10s.
+    stop_grace_period: 45s
+    healthcheck:
+      test: ["CMD", "node", "packages/oplog/src/ops-check.mjs", "--dir=/data", "indexer"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   api:
     build: .
@@ -20,6 +42,7 @@ services:
     env_file: .env
     environment:
       STATE_PATH: /data/indexer-state.json
+      HEARTBEAT_DIR: /data
       PORT: 8402   # pin the CONTAINER port; ${PORT} below is the host-side knob only
     ports:
       - "${PORT:-8402}:8402"
@@ -28,6 +51,13 @@ services:
     depends_on:
       - indexer
     restart: unless-stopped
+    stop_grace_period: 30s   # SIGTERM stops reloading, then drains in-flight responses
+    healthcheck:
+      test: ["CMD", "node", "packages/oplog/src/ops-check.mjs", "--dir=/data", "api"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   # Post-launch canary (docs/CANARY.md). Read-only against the chain: no key, no wallet, no
   # transaction — it only reads. It mounts the shared volume because two of its signals compare
@@ -41,11 +71,19 @@ services:
     environment:
       STATE_PATH: /data/indexer-state.json        # the indexer snapshot (read-only to this service)
       CANARY_STATE_PATH: /data/canary-state.json  # its OWN transition state — never the indexer's
+      HEARTBEAT_DIR: /data
     volumes:
       - vault-state:/data
     depends_on:
       - indexer
     restart: unless-stopped
+    stop_grace_period: 60s   # SIGTERM finishes the in-flight sweep, then flushes transitions
+    healthcheck:
+      test: ["CMD", "node", "packages/oplog/src/ops-check.mjs", "--dir=/data", "canary"]
+      interval: 60s          # a sweep is heavier and slower than an indexer poll
+      timeout: 15s
+      retries: 3
+      start_period: 90s      # the first sweep reads every vault on the chain
 
 volumes:
   vault-state:

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -5,6 +5,9 @@ live product: the **indexer**, the **API**, and the **web** front end. Everythin
 **non-custodial** — no process in this repo holds a private key or moves funds. Payment settlement
 is delegated to an external **facilitator**.
 
+**Running it is §1–§7; keeping it running is [§8 Operations](#8-operations)** — log format, backup
+and restore, rate limits, metrics, the `ops-check` script and an incident quick-table.
+
 For the tested internals behind each piece, see [ARCHITECTURE.md](ARCHITECTURE.md); for contract
 deployment, [DEPLOYMENT.md](DEPLOYMENT.md) — and for the operational Base Sepolia path that
 produces the addresses this guide consumes, [TESTNET-CHECKLIST.md](TESTNET-CHECKLIST.md)
@@ -137,8 +140,11 @@ cp .env.example .env     # fill in RPC_URL, addresses, PRICE_*, and:
 docker compose up --build
 ```
 
-`docker-compose.yml` runs `indexer` (writes `/data/indexer-state.json`) and `api` (reads it,
-publishes `:8402`) against a shared `vault-state` volume. Both `restart: unless-stopped`.
+`docker-compose.yml` runs `indexer` (writes `/data/indexer-state.json`), `api` (reads it, publishes
+`:8402`) and `canary` against a shared `vault-state` volume. All three are `restart: unless-stopped`
+and carry a **healthcheck** that reads that service's own heartbeat file (§8.2), so a process that
+is up but wedged — the failure a restart policy never notices — shows as `unhealthy` in
+`docker compose ps`. Each also has a `stop_grace_period` long enough for its shutdown hooks (§8.6).
 
 Production notes:
 - Put the API behind TLS (a reverse proxy). `CORS=1` is required if the browser front end is served
@@ -148,7 +154,11 @@ Production notes:
 - The API serves **stale-but-valid** state if a snapshot reload ever fails (corrupt/partial write),
   and logs it — it never serves a torn read (snapshots are written temp-then-rename).
 - Back up / persist the snapshot volume to avoid a full re-index on a fresh host (or set
-  `START_BLOCK` to the deploy block so a cold start skips empty history).
+  `START_BLOCK` to the deploy block so a cold start skips empty history). The rotating backup ring
+  and the restore procedure are in §8.3.
+- Set `TRUST_PROXY=1` **only** when that reverse proxy overwrites `x-forwarded-for`; otherwise the
+  per-IP rate limiter buckets every client together. See §8.4 — the header is client-spoofable, so
+  the wrong answer here is worse than either default.
 
 ---
 
@@ -170,6 +180,11 @@ Production notes:
 | `CONFIRMATIONS` | | `5` | blocks to lag behind head (reorg safety) |
 | `BATCH_BLOCKS` | | `2000` | max blocks per `getLogs` batch |
 | `POLL_INTERVAL_MS` | | `12000` | poll cadence once caught up |
+| `SNAPSHOT_BACKUPS` | | `3` | rotating backup copies kept (§8.3); `0` disables |
+| `SNAPSHOT_BACKUP_INTERVAL_MS` | | `300000` | minimum spacing between backups — not per write |
+| `HEARTBEAT_DIR` | | dirname of `STATE_PATH` | where `indexer.heartbeat.json` is written (§8.2) |
+| `LOG_FORMAT` | | TTY-dependent | `json` or `pretty` (§8.1) |
+| `LOG_LEVEL` | | `info` | `debug` \| `info` \| `warn` \| `error` |
 
 ### API (`npm run start:api`)
 
@@ -185,6 +200,15 @@ Production notes:
 | `PORT` | | `8402` | HTTP listen port |
 | `RELOAD_MS` | | `5000` | snapshot re-read cadence |
 | `CORS` | | off | `1`/`true` to enable CORS + preflight (browser live mode) |
+| `RATE_LIMIT_PER_SEC` | | `5` | per-IP sustained rate on the FREE routes; `0` disables (§8.4) |
+| `RATE_LIMIT_BURST` | | `60` | per-IP burst on the free routes |
+| `RATE_LIMIT_MAX_IPS` | | `10000` | cap on tracked IPs |
+| `TRUST_PROXY` | | off | honour `x-forwarded-for` — ONLY behind a proxy that overwrites it |
+| `MAX_URL_BYTES` | | `2048` | longer request-target → `414` |
+| `MAX_BODY_BYTES` | | `8192` | larger request body → `413` |
+| `MAX_HEADER_BYTES` | | `16384` | Node's header cap |
+| `HEARTBEAT_DIR` | | dirname of `STATE_PATH` | where `api.heartbeat.json` is written (§8.2) |
+| `LOG_FORMAT` / `LOG_LEVEL` | | | as above (§8.1) |
 
 ### Canary (`npm run start:canary`)
 
@@ -203,7 +227,10 @@ when one fires. Reuses `RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `CONFIRMATIONS`, `ST
 | `ALERT_WEBHOOK_URL` | | — | POST one JSON body per transition |
 | `NAV_DIVERGENCE_BPS` | | `50` | NAV composition bar, 50 = 0.5% |
 | `ORACLE_MIN_MARGIN` | | `0` | alert when fresh sources minus quorum <= this |
-| `HEARTBEAT_MS` | | `0` (off) | periodic "still watching" line |
+| `HEARTBEAT_MS` | | `0` (off) | periodic "still watching" line (distinct from the heartbeat FILE in §8.2) |
+| `SNAPSHOT_BACKUPS` / `SNAPSHOT_BACKUP_INTERVAL_MS` | | `3` / `300000` | backup ring for the canary state file too (§8.3) |
+| `HEARTBEAT_DIR` | | dirname of `STATE_PATH` | where `canary.heartbeat.json` is written (§8.2) |
+| `LOG_FORMAT` / `LOG_LEVEL` | | | as above (§8.1) |
 
 The `PRICE_ASSET`/`PRICE_NETWORK`/`CHAIN_ID` must agree across the API and whatever wallet/agent
 pays: the challenge binds the payment to that exact asset + network.
@@ -243,3 +270,334 @@ id returned to the client is the settlement tx hash.
 - The **web** browser signer is a dummy against a dev facilitator; real signing is the user's wallet.
 - The only key in the whole stack is the settlement key inside the facilitator (yours in §6, or the
   third party's), which is a **relayer** paying gas — it never takes custody of vault funds.
+
+---
+
+## 8. Operations
+
+Everything in §1–§7 gets the stack running. This section is about keeping it running: what the logs
+look like, how to back up and restore, what the API refuses and why, what to scrape, and what to do
+at 3am. One person should be able to run, monitor, back up, restore and restart the whole off-chain
+stack from this section alone.
+
+The shared plumbing lives in [`packages/oplog`](../packages/oplog/) — a logger, heartbeat files, an
+`ops-check` script and a shutdown helper, all dependency-free. **viem remains the only runtime
+dependency in the repo**, and none of these four modules import it.
+
+### 8.1 Log format
+
+Every service emits **one JSON object per line** with the same four fields plus event-specific ones:
+
+```json
+{"ts":"2026-08-20T14:03:22.481Z","level":"info","service":"indexer","event":"batch.indexed","from":8204001,"to":8204113,"events":3}
+```
+
+| Field | Meaning |
+|---|---|
+| `ts` | ISO-8601 UTC, millisecond precision |
+| `level` | `debug` \| `info` \| `warn` \| `error` |
+| `service` | `indexer` \| `api` \| `canary` |
+| `event` | dotted event name — the thing to grep for |
+
+`warn` and `error` go to **stderr**, everything else to **stdout**, so `2>` gives a pure problem
+feed. When stdout is a **TTY** the same records render as human lines instead:
+
+```
+14:03:22.481 INFO  indexer batch.indexed  from=8204001 to=8204113 events=3
+```
+
+That means `npm run start:indexer` in a shell is readable and the identical command under Docker
+(no TTY) emits JSON, with no flag to remember. Force either with `LOG_FORMAT=json|pretty`; raise or
+lower the floor with `LOG_LEVEL`.
+
+Events worth knowing:
+
+| Event | Service | Means |
+|---|---|---|
+| `starting` / `listening` | all | boot, with the resolved config on the line |
+| `batch.indexed` (via `indexer.progress`) | indexer | a block range was folded and snapshotted |
+| `poll.failed` / `sweep.failed` | indexer, canary | one cycle failed; it will retry |
+| `snapshot.reload_failed` | api | serving **stale-but-valid** state — see the incident table |
+| `http.rate_limited` | api | a free route returned 429 |
+| `canary.transition` | canary | a signal changed state — **the** line to page on |
+| `heartbeat.failed` | all | could not write the heartbeat file (disk?) |
+| `shutdown.begin` / `.step` / `.complete` | all | a clean stop, hook by hook |
+| `shutdown.timeout` / `.forced` | all | a stop that did **not** finish cleanly |
+
+Alert transitions are also delivered to `ALERT_WEBHOOK_URL` as structured JSON if set — the log is
+not the only path (see [CANARY.md](CANARY.md)).
+
+### 8.2 Heartbeats and `ops-check`
+
+`restart: unless-stopped` catches a process that **crashes**. It does nothing about one that is
+**wedged** — up, holding its port, indexing nothing. So each service writes
+`<HEARTBEAT_DIR>/<service>.heartbeat.json` on every successful work cycle, and `ops-check` fails
+when one goes stale.
+
+"Successful" is load-bearing. The heartbeat means *I am doing my job*, not *my process exists*:
+
+| Service | Beats when | So it goes stale if |
+|---|---|---|
+| `indexer` | boot, then after each poll cycle | it stops polling or wedges on an RPC call |
+| `api` | after each **successful** snapshot reload | it loses or cannot parse the snapshot |
+| `canary` | after each **successful** sweep | it cannot reach the chain — i.e. is not watching |
+
+Each file carries its own `staleAfterMs`, written by the service that knows its cadence (three
+missed cycles, floored). Nothing has to be kept in sync by hand.
+
+```bash
+node packages/oplog/src/ops-check.mjs --dir=./data
+```
+
+Exit **0** with one line per service when all are fresh; exit **1** listing the bad ones otherwise
+(**2** on a usage error, so a broken invocation is never mistaken for a healthy stack):
+
+```
+ops-check: 1 of 3 service(s) UNHEALTHY: canary(stale)
+FAIL canary   stale      age=612s  last beat 612s ago, limit 90s — canary is down or wedged
+ok   indexer  fresh      age=4s    pid=12 lastBlock=8204113 vaults=7
+ok   api      fresh      age=2s    pid=14 lastBlock=8204113 vaults=7
+```
+
+`missing`, `unreadable` and `future` (clock skew) are failures too, each named separately because
+each has a different fix.
+
+**Cron it** — this is the whole-stack view:
+
+```bash
+*/5 * * * * cd /srv/vaults && node packages/oplog/src/ops-check.mjs --dir=./data || mail -s 'vault stack unhealthy' you@example.com
+```
+
+**Compose already runs it**, but per-service: each container healthchecks only *its own*
+heartbeat. A whole-stack check inside the indexer container would mark the indexer unhealthy
+because the *canary* died, and Docker would restart the wrong process.
+
+```bash
+docker compose ps          # STATUS column shows healthy / unhealthy per service
+```
+
+Override every service's own budget with `--max-age-ms=N`, or pick services positionally
+(`ops-check.mjs indexer api`).
+
+### 8.3 Backups and restore
+
+Both state files — the indexer snapshot and the canary's transition state — are written
+temp-then-rename (atomic: a crash never truncates) **and** kept in a rotating backup ring
+(`SNAPSHOT_BACKUPS=3`, `SNAPSHOT_BACKUP_INTERVAL_MS=300000`):
+
+```
+data/indexer-state.json      ← live
+data/indexer-state.json.1    ← newest backup (~5 min old)
+data/indexer-state.json.2
+data/indexer-state.json.3    ← oldest, ~15 min
+```
+
+Atomicity survives a crash. The ring survives the other way state dies: **a write that succeeded
+and was wrong.** Backups are spaced by *time*, not per write — the indexer snapshots every batch,
+so a per-write ring would give a 36-second horizon, useless when corruption is noticed minutes
+later. The live file is *copied* into slot 1, never renamed, so it never blinks out of existence
+under the API's reload timer.
+
+Tune the horizon: `SNAPSHOT_BACKUPS × SNAPSHOT_BACKUP_INTERVAL_MS` is how far back you can go.
+Defaults give 15 minutes. `SNAPSHOT_BACKUPS=0` disables the ring; writes stay atomic.
+
+**Inspect before you act.** `verify` loads a state file and reports it without starting a poller
+and without an RPC — it needs no environment at all, which matters because whoever is verifying a
+snapshot after a crash has none of the six indexer variables set:
+
+```bash
+node packages/indexer/src/index-runner.mjs verify ./data/indexer-state.json
+node packages/canary/src/canary-runner.mjs  verify ./data/canary-state.json
+```
+
+```
+snapshot ./data/indexer-state.json: OK
+  cursor      lastBlock=8204113 lastLogIndex=-1 → resumes from block 8204114
+  counts      vaults=7 operators=12 proposals=3 shareBooks=7 holders=64 activeProposals=1
+  file        184213 bytes, written 2026-08-20T14:03:22.481Z (11s ago)
+  backups     3 (newest first)
+    .1  lastBlock=8202901 vaults=7 183902 bytes  2026-08-20T13:58:20.114Z
+    .2  lastBlock=8201640 vaults=7 183511 bytes  2026-08-20T13:53:19.882Z
+    .3  lastBlock=8200388 vaults=6 182004 bytes  2026-08-20T13:48:19.630Z
+```
+
+Exit 0 if usable, 1 if not. Each backup is parsed and reported with **its own** cursor and counts,
+so "restore from which one?" is answerable at a glance, and a corrupt rung is flagged individually
+rather than poisoning the rest.
+
+**Restore procedure** (indexer snapshot; the canary's is identical with its own paths):
+
+1. **Stop the writer.** Nothing else may be writing while you swap files.
+   ```bash
+   docker compose stop indexer
+   ```
+2. **Verify the candidates** and pick a rung by its printed cursor, not by its number. `.1` is
+   usually the one you want, but a clean shutdown takes a final snapshot, which can push the ring
+   along by one — so read the `lastBlock` and `vaults=` on each rung rather than assuming.
+   ```bash
+   node packages/indexer/src/index-runner.mjs verify ./data/indexer-state.json
+   ```
+3. **Keep the bad file.** It is the only evidence of what went wrong, and it is what the ring is
+   about to overwrite.
+   ```bash
+   mv ./data/indexer-state.json ./data/indexer-state.json.bad-$(date +%s)
+   ```
+4. **Put the backup in place** — copy, do not move, so the ring stays intact if step 5 fails.
+   ```bash
+   cp ./data/indexer-state.json.1 ./data/indexer-state.json
+   ```
+5. **Verify the restored file** and note the cursor it will resume from.
+   ```bash
+   node packages/indexer/src/index-runner.mjs verify ./data/indexer-state.json
+   ```
+6. **Start the writer.** It resumes from `lastBlock + 1` and re-indexes the gap; the projection is
+   a pure fold over events, so replaying the range that the backup was missing rebuilds exactly the
+   state that was lost. Catch-up is bounded by `BATCH_BLOCKS` per poll.
+   ```bash
+   docker compose start indexer
+   docker compose logs -f indexer      # watch batch.indexed reach the head
+   ```
+
+> **If every backup is bad**, delete the snapshot and set `START_BLOCK` to the **factory deploy
+> block**. The indexer rebuilds from chain history — slow, never wrong. Do **not** set a later
+> block to save time: vaults created before `START_BLOCK` are never discovered and their events go
+> unindexed forever. The indexer warns loudly when you do this on a fresh snapshot.
+
+> **Restoring the canary's state is optional.** Deleting it costs one duplicate page per signal
+> that is currently firing, and nothing else. If the alternative is a stale cursor causing an event
+> scan gap, delete it.
+
+In Docker the files live in the `vault-state` volume. Reach them with a throwaway container:
+
+```bash
+docker run --rm -v vault-state:/data vault-runtime node packages/indexer/src/index-runner.mjs verify /data/indexer-state.json
+```
+
+Back the volume up off-host as well — the ring protects against a bad write, not a dead disk:
+
+```bash
+docker run --rm -v vault-state:/data -v "$PWD":/backup alpine tar czf /backup/vault-state-$(date +%F).tar.gz -C /data .
+```
+
+### 8.4 Rate limits and request caps
+
+The API applies a **per-IP token bucket to the free routes only** — `/health`,
+`/.well-known/x402`, `/metrics`:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `RATE_LIMIT_PER_SEC` | `5` | sustained requests per second per IP; **`0` disables the limiter** |
+| `RATE_LIMIT_BURST` | `60` | burst an IP may take at once |
+| `RATE_LIMIT_MAX_IPS` | `10000` | cap on tracked IPs |
+
+Over the limit returns **429** with `retry-after` and `x-ratelimit-limit`.
+
+**The paid routes are deliberately unlimited: x402 *is* their rate limiter.** Every metered read
+costs the caller real USDC through a facilitator settlement, so flooding `/vaults` is a purchase,
+not a denial-of-service. An *unpaid* request to a metered route returns 402 without a facilitator
+call, a state read or a disk touch, so it is not a lever worth pulling either.
+
+Memory is bounded because an unbounded per-IP map would itself be the denial-of-service. Buckets
+that have fully refilled are pruned first — they carry no information — and only under sustained
+pressure does it fall back to evicting the least-recently-used, which does hand that IP a fresh
+burst. That trade is deliberate: remembering an attacker perfectly is not worth letting them choose
+the heap size.
+
+**Behind a reverse proxy, set `TRUST_PROXY=1`.** Without it every request appears to come from the
+proxy and all clients share one bucket. **Do not set it when the API is reachable directly**:
+`x-forwarded-for` is client-spoofable, so trusting it without a proxy that overwrites the header
+lets one attacker mint a fresh bucket per request and defeat the limiter entirely.
+
+Request caps, applied before any handler work:
+
+| Var | Default | Over the limit |
+|---|---|---|
+| `MAX_URL_BYTES` | `2048` | `414 URI Too Long` |
+| `MAX_BODY_BYTES` | `8192` | `413 Payload Too Large` (declared *and* chunked) |
+| `MAX_HEADER_BYTES` | `16384` | connection refused by Node |
+
+This is a GET-only read API, so a request body is already a sign of something wrong. Non-`GET`
+gets `405`.
+
+### 8.5 Metrics
+
+`GET /metrics` returns Prometheus text exposition format — free, rate-limited, and readable with
+plain `curl`, which is the case that matters during an incident.
+
+```bash
+curl -s localhost:8402/metrics
+```
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `vault_api_requests_total` | counter | requests received |
+| `vault_api_payment_required_total` | counter | 402s issued |
+| `vault_api_settlements_total` | counter | payments verified + settled |
+| `vault_api_rate_limited_total` | counter | 429s issued |
+| `vault_api_rejected_total` | counter | refused on method/size/URL limits |
+| `vault_api_errors_total` | counter | unhandled errors turned into a 500 |
+| `vault_api_snapshot_reload_failures_total` | counter | reloads that failed, leaving stale state serving |
+| `vault_api_uptime_seconds` | gauge | seconds since this process started serving |
+| `vault_indexer_last_block` | gauge | last block in the snapshot being served |
+| **`vault_indexer_snapshot_age_seconds`** | gauge | **seconds since the indexer last wrote the snapshot — the lag signal** |
+| `vault_api_rate_limit_buckets` | gauge | per-IP buckets currently tracked |
+| `vault_api_seen_nonces` | gauge | payment nonces held for local replay defence |
+
+Counters read `0` before their first event rather than being absent: a missing series and a zero
+series look identical in a graph, and only one of them is good news.
+
+**On indexer lag.** The API has **no RPC client by design** — it serves the snapshot and nothing
+else — so it cannot know the chain head and must not claim a blocks-behind figure. It reports how
+long ago the snapshot was written, which is the number that actually tells you the indexer stopped,
+and the metric is named for exactly that. Alert on it:
+
+```
+vault_indexer_snapshot_age_seconds > 5 × POLL_INTERVAL_MS/1000     # for 2 minutes
+```
+
+For true blocks-behind, compare `vault_indexer_last_block` against your own RPC's head — the
+indexer is the process that has an RPC connection, not the API.
+
+### 8.6 Restarting safely
+
+All three services handle `SIGTERM` (and `SIGINT`), running ordered hooks before exiting:
+
+| Service | On SIGTERM |
+|---|---|
+| `indexer` | finishes the **current batch**, snapshots, exits. The batch loop checks for the signal *between* batches, so a cold-start backlog does not swallow the signal. |
+| `api` | stops reloading, stops accepting, drains in-flight responses (`closeIdleConnections` bounds the wait), logs a final metrics line. |
+| `canary` | finishes the in-flight sweep, then **flushes** its transition state so the restart does not re-page every standing alert. |
+
+A hook that throws is logged and the remaining hooks still run — a failed snapshot must not block
+the API drain. A **second** signal exits immediately, and a watchdog force-exits if the hooks never
+finish, so the process cannot outlive its own shutdown.
+
+Compose sets `stop_grace_period` per service (indexer 45s, api 30s, canary 60s) so Docker waits for
+the hooks instead of `SIGKILL`ing through them.
+
+```bash
+docker compose restart indexer      # clean stop, clean resume from the snapshot
+docker compose down                 # stops all three cleanly; the volume survives
+```
+
+Look for `shutdown.complete` in the logs. `shutdown.timeout` or `shutdown.forced` means the stop
+was **not** clean — verify the snapshot before restarting.
+
+### 8.7 Incident quick-table
+
+| Symptom | Most likely | Do this |
+|---|---|---|
+| `ops-check` says a service is **stale** | crashed or wedged | `docker compose ps` / `logs --tail=100 <svc>`. Restart it: `docker compose restart <svc>`. If it goes stale again quickly, the RPC is the usual culprit — check `poll.failed`/`sweep.failed` lines. |
+| `ops-check` says **missing** | never started, or wrong `HEARTBEAT_DIR` | Confirm the service is up at all, then that `HEARTBEAT_DIR` (or `dirname(STATE_PATH)`) matches what you passed `--dir`. |
+| `ops-check` says **future** | clock skew between checker and service | Fix NTP on the host. Do not raise the threshold — a wrong clock also corrupts every `ts` in the logs. |
+| `vault_indexer_snapshot_age_seconds` climbing | indexer stopped or is stuck on the RPC | `ops-check` the indexer; check its logs for `poll.failed`. The API keeps serving the last good block, correctly and staleley — it is not the broken piece. |
+| API logs `snapshot.reload_failed` | torn, corrupt, or version-mismatched snapshot | The API is serving **stale-but-valid** state — no torn read reaches a client. `verify` the snapshot (§8.3); if it is bad, restore and restart the indexer. The API picks the fix up on its next reload with no restart. |
+| `verify` says snapshot **UNUSABLE** | bad write, or a schema change | Restore from `.1` per §8.3. Keep the bad file. |
+| Every backup is unreadable | disk or filesystem fault | Delete the snapshot, set `START_BLOCK` to the **factory deploy block**, let it rebuild from chain history. Then check the disk — this should not happen. |
+| API returning 429s to your own front end | one shared IP behind a proxy | Set `TRUST_PROXY=1` **iff** a reverse proxy overwrites `x-forwarded-for`; otherwise raise `RATE_LIMIT_BURST`. Never set `TRUST_PROXY` on a directly-reachable API (§8.4). |
+| API returning 402 to a paying agent | asset/network/amount mismatch, or a dead facilitator | `curl -s <api>/.well-known/x402` and compare against what the agent signs. Then check `FACILITATOR_URL` is reachable — a failed settlement is reported as a 402. |
+| Canary silent for a long time | healthy — silence *is* the healthy state | Confirm with `ops-check canary`, or set `HEARTBEAT_MS` for a periodic "still watching" line. |
+| Canary logs `event scan gap` | it was down longer than one `MAX_LOG_SPAN_BLOCKS` window | Those blocks were **not** scanned for module/fee events. Raise `MAX_LOG_SPAN_BLOCKS` and sweep the named range by hand before it scrolls away. |
+| Canary re-pages everything after a restart | its state file was lost or not flushed | Harmless but noisy. Check for `shutdown.timeout` on the last stop; `verify` the canary state (§8.3). |
+| Logs are prose, not JSON | stdout is a TTY | Expected. Set `LOG_FORMAT=json` to force JSON anywhere. |
+| `shutdown.timeout` in the logs | a hook wedged | Verify the state file before restarting — the clean-stop guarantee did not hold for that stop. |

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -546,6 +546,11 @@ curl -s localhost:8402/metrics
 Counters read `0` before their first event rather than being absent: a missing series and a zero
 series look identical in a graph, and only one of them is good news.
 
+> **`/metrics` is rate-limited like every other free route**, and a scraper usually shares an IP
+> with the operator debugging next to it. During an incident that is exactly when you burn the
+> bucket on `curl` and get a 429 from the endpoint you most need. Give the burst room
+> (`RATE_LIMIT_BURST`), or set `RATE_LIMIT_PER_SEC=0` on a deployment whose only clients are yours.
+
 **On indexer lag.** The API has **no RPC client by design** — it serves the snapshot and nothing
 else — so it cannot know the chain head and must not claim a blocks-behind figure. It reports how
 long ago the snapshot was written, which is the number that actually tells you the indexer stopped,
@@ -595,6 +600,7 @@ was **not** clean — verify the snapshot before restarting.
 | `verify` says snapshot **UNUSABLE** | bad write, or a schema change | Restore from `.1` per §8.3. Keep the bad file. |
 | Every backup is unreadable | disk or filesystem fault | Delete the snapshot, set `START_BLOCK` to the **factory deploy block**, let it rebuild from chain history. Then check the disk — this should not happen. |
 | API returning 429s to your own front end | one shared IP behind a proxy | Set `TRUST_PROXY=1` **iff** a reverse proxy overwrites `x-forwarded-for`; otherwise raise `RATE_LIMIT_BURST`. Never set `TRUST_PROXY` on a directly-reachable API (§8.4). |
+| `/metrics` returning 429 mid-incident | your own `curl`s share the scraper's bucket | Wait one refill, or raise `RATE_LIMIT_BURST`. `ops-check` and `verify` read files, not HTTP, so they keep working when the API will not answer you (§8.5). |
 | API returning 402 to a paying agent | asset/network/amount mismatch, or a dead facilitator | `curl -s <api>/.well-known/x402` and compare against what the agent signs. Then check `FACILITATOR_URL` is reachable — a failed settlement is reported as a 402. |
 | Canary silent for a long time | healthy — silence *is* the healthy state | Confirm with `ops-check canary`, or set `HEARTBEAT_MS` for a periodic "still watching" line. |
 | Canary logs `event scan gap` | it was down longer than one `MAX_LOG_SPAN_BLOCKS` window | Those blocks were **not** scanned for module/fee events. Raise `MAX_LOG_SPAN_BLOCKS` and sweep the named range by hand before it scrolls away. |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -31,6 +31,7 @@ paths:
                   routes: { type: object }
                   openapi: { type: string }
                   llms: { type: string }
+        '429': { $ref: '#/components/responses/RateLimited' }
   /vaults:
     get:
       summary: List all known vaults (metered) — the discovery surface for agents
@@ -72,6 +73,28 @@ paths:
                 properties:
                   ok: { type: boolean }
                   lastBlock: { type: integer }
+        '429': { $ref: '#/components/responses/RateLimited' }
+  /metrics:
+    get:
+      summary: >
+        Operational counters (free, rate-limited). Prometheus text exposition format, readable
+        with plain curl. `vault_indexer_snapshot_age_seconds` is the indexer-lag signal: the API
+        holds no RPC client by design, so it reports how long ago the snapshot was written rather
+        than claiming a blocks-behind figure it cannot know. See docs/RUNTIME.md section 8.
+      operationId: metrics
+      responses:
+        '200':
+          description: Counters
+          content:
+            text/plain:
+              schema: { type: string }
+              example: |
+                # HELP vault_api_requests_total HTTP requests received
+                # TYPE vault_api_requests_total counter
+                vault_api_requests_total 1841
+                vault_indexer_last_block 8204113
+                vault_indexer_snapshot_age_seconds 11
+        '429': { $ref: '#/components/responses/RateLimited' }
   /vaults/{address}:
     get:
       summary: Vault projection (metered)
@@ -113,6 +136,24 @@ paths:
         '402': { $ref: '#/components/responses/PaymentRequired' }
 components:
   responses:
+    RateLimited:
+      description: >
+        Per-IP token bucket exhausted on a FREE route. The metered routes are deliberately not
+        rate-limited: x402 is their rate limiter, since every metered read costs the caller USDC.
+      headers:
+        retry-after:
+          schema: { type: integer }
+          description: Seconds to wait before retrying.
+        x-ratelimit-limit:
+          schema: { type: integer }
+          description: Burst capacity, in requests.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error: { type: string }
+              retryAfterSec: { type: integer }
     PaymentRequired:
       description: >
         Payment required. The `PAYMENT-REQUIRED` header carries the JSON challenge; authorize it

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   "scripts": {
     "build:contracts": "cd contracts && forge build",
     "test:contracts": "cd contracts && forge test -vv",
-    "test:backend": "node --test packages/indexer/test/*.test.mjs packages/canary/test/*.test.mjs packages/agent-sdk/test/*.test.mjs packages/reference-agent/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs",
+    "test:backend": "node --test packages/oplog/test/*.test.mjs packages/indexer/test/*.test.mjs packages/canary/test/*.test.mjs packages/agent-sdk/test/*.test.mjs packages/reference-agent/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs",
     "start:indexer": "node packages/indexer/src/index-runner.mjs",
     "start:api": "node apps/api/src/serve.mjs",
-    "start:canary": "node packages/canary/src/canary-runner.mjs"
+    "start:canary": "node packages/canary/src/canary-runner.mjs",
+    "ops-check": "node packages/oplog/src/ops-check.mjs"
   },
   "dependencies": {
     "viem": "^2.21.0"

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -37,9 +37,12 @@
  */
 
 import { fileURLToPath } from 'node:url';
-import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
 import { loadSnapshot } from '../../indexer/src/store.mjs';
+import { createCanaryStateWriter, loadCanaryState, verifyCanaryState, formatCanaryStateReport } from './state-file.mjs';
+import { loggerFromEnv } from '../../oplog/src/logger.mjs';
+import { createHeartbeat, defaultHeartbeatDir } from '../../oplog/src/heartbeat.mjs';
+import { createShutdown } from '../../oplog/src/shutdown.mjs';
+import { resolveDurabilityOptions } from '../../oplog/src/durable.mjs';
 import { createChainReader } from './reader.mjs';
 import { createTransitionTracker } from './transitions.mjs';
 import { createConsoleSink, createWebhookSink, emitAll } from './sinks.mjs';
@@ -77,41 +80,31 @@ export function resolveCanaryConfig(env) {
     throw new Error(`canary: OPERATOR_REGISTRY_ADDRESS is not a 20-byte address: ${operatorRegistry}`);
   }
 
+  const statePath = env.STATE_PATH || './data/indexer-state.json';
+  const pollIntervalMs = num('CANARY_POLL_INTERVAL_MS', 30_000);
   return {
     rpcUrl: env.RPC_URL,
     chainId: num('CHAIN_ID', 8453),
     chainName: env.CHAIN_NAME || 'base',
-    statePath: env.STATE_PATH || './data/indexer-state.json',
+    statePath,
     canaryStatePath: env.CANARY_STATE_PATH || './data/canary-state.json',
+    ...resolveDurabilityOptions(env),
+    heartbeatDir: defaultHeartbeatDir({ ...env, STATE_PATH: statePath }),
+    // Three missed sweeps, floored at 60s. A canary sweep is many RPC round-trips, so its
+    // tolerance is looser than the indexer's on purpose.
+    heartbeatStaleMs: Math.max(60_000, pollIntervalMs * 3),
     vaults,
     operatorRegistry,
     extraOperators,
     webhookUrl: env.ALERT_WEBHOOK_URL || null,
     confirmations: num('CONFIRMATIONS', 5),
-    pollIntervalMs: num('CANARY_POLL_INTERVAL_MS', 30_000),
+    pollIntervalMs,
     navDivergenceBps: num('NAV_DIVERGENCE_BPS', 50),
     oracleMinMargin: num('ORACLE_MIN_MARGIN', 0),
     logLookbackBlocks: num('LOG_LOOKBACK_BLOCKS', 0),
     maxLogSpanBlocks: num('MAX_LOG_SPAN_BLOCKS', 2000),
     heartbeatMs: num('HEARTBEAT_MS', 0),
   };
-}
-
-/** Atomic write, same write-temp-then-rename discipline the indexer's snapshot uses. */
-async function saveCanaryState(path, obj) {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
-  await writeFile(tmp, JSON.stringify(obj), 'utf8');
-  await rename(tmp, path);
-}
-
-async function loadCanaryState(path) {
-  try {
-    return JSON.parse(await readFile(path, 'utf8'));
-  } catch (err) {
-    if (err && err.code === 'ENOENT') return { transitions: {}, lastScannedBlock: null };
-    throw err;
-  }
 }
 
 /**
@@ -219,7 +212,13 @@ export async function collectSignals({ reader, state, vaults, cfg, window }) {
  * Build a wired (but not started) canary. Returns `runOnce()` for a single sweep and `start()`
  * for the forever loop.
  */
-export async function buildCanary(cfg, { log = console.log, error = console.error, client, fetchImpl, now = () => new Date() } = {}) {
+export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('canary'), client, fetchImpl, now = () => new Date() } = {}) {
+  // The transition lines ARE the product here, so they keep their own stdout/stderr split (`2>`
+  // gives a pure alert feed). Left uninjected they now flow through the structured logger like
+  // everything else; the tests inject plain string sinks and are unaffected.
+  const line = log ?? logger.text('canary.transition');
+  const errLine = error ?? logger.text('canary.transition', 'error');
+
   const reader = createChainReader({
     client, rpcUrl: cfg.rpcUrl, chainId: cfg.chainId, chainName: cfg.chainName,
   });
@@ -229,8 +228,17 @@ export async function buildCanary(cfg, { log = console.log, error = console.erro
   let lastScannedBlock = persisted.lastScannedBlock ?? null;
   let poll = 0;
 
-  const sinks = [createConsoleSink({ log, error })];
-  if (cfg.webhookUrl) sinks.push(createWebhookSink({ url: cfg.webhookUrl, fetchImpl, onError: error }));
+  const stateWriter = createCanaryStateWriter({
+    path: cfg.canaryStatePath, backups: cfg.backups ?? 0, backupIntervalMs: cfg.backupIntervalMs ?? 0,
+  });
+  const heartbeat = createHeartbeat({
+    dir: cfg.heartbeatDir ?? './data', service: 'canary',
+    staleAfterMs: cfg.heartbeatStaleMs ?? 120_000,
+    onError: (err) => logger.warn?.('heartbeat.failed', { error: String(err?.message ?? err) }),
+  });
+
+  const sinks = [createConsoleSink({ log: line, error: errLine })];
+  if (cfg.webhookUrl) sinks.push(createWebhookSink({ url: cfg.webhookUrl, fetchImpl, onError: errLine }));
 
   /** The vault set: explicit VAULTS if given, else every vault the indexer has projected. */
   async function resolveVaults() {
@@ -243,7 +251,7 @@ export async function buildCanary(cfg, { log = console.log, error = console.erro
     try {
       return await loadSnapshot(cfg.statePath);
     } catch (err) {
-      error(`canary: could not read the indexer snapshot at ${cfg.statePath}: ${err?.message ?? err}`);
+      errLine(`canary: could not read the indexer snapshot at ${cfg.statePath}: ${err?.message ?? err}`);
       return null;
     }
   }
@@ -264,13 +272,13 @@ export async function buildCanary(cfg, { log = console.log, error = console.erro
     // prevent, and an operator who sees this line can widen MAX_LOG_SPAN_BLOCKS or sweep the gap
     // by hand before it scrolls away.
     if (windowFrom > fromBlock) {
-      error(`canary: event scan gap — blocks ${fromBlock}-${windowFrom - 1} (${windowFrom - fromBlock} blocks) were NOT scanned for ModuleCallFailed/SliceEscrowed/fee outflows. The backlog exceeded MAX_LOG_SPAN_BLOCKS=${cfg.maxLogSpanBlocks}; raise it or scan that range manually.`);
+      errLine(`canary: event scan gap — blocks ${fromBlock}-${windowFrom - 1} (${windowFrom - fromBlock} blocks) were NOT scanned for ModuleCallFailed/SliceEscrowed/fee outflows. The backlog exceeded MAX_LOG_SPAN_BLOCKS=${cfg.maxLogSpanBlocks}; raise it or scan that range manually.`);
     }
     const nowSec = await reader.chainNow();
 
     const { vaults, state } = await resolveVaults();
     if (vaults.length === 0) {
-      error(`canary: no vaults to watch — set VAULTS, or point STATE_PATH at an indexer snapshot that has seen a VaultCreated (currently ${cfg.statePath})`);
+      errLine(`canary: no vaults to watch — set VAULTS, or point STATE_PATH at an indexer snapshot that has seen a VaultCreated (currently ${cfg.statePath})`);
       return { transitions: [], results: [], vaults: [] };
     }
 
@@ -280,49 +288,113 @@ export async function buildCanary(cfg, { log = console.log, error = console.erro
     });
 
     const transitions = tracker.observe(results, { poll, timestamp: now().toISOString() });
-    await emitAll(sinks, transitions, { onError: error });
+    await emitAll(sinks, transitions, { onError: errLine });
 
     lastScannedBlock = toBlock;
-    await saveCanaryState(cfg.canaryStatePath, { transitions: tracker.snapshot(), lastScannedBlock });
+    await flush();
     return { transitions, results, vaults };
   }
 
-  async function start({ signal } = {}) {
-    log(`canary up: chain ${cfg.chainId}, read-only, polling every ${cfg.pollIntervalMs}ms. Silence means healthy.`);
-    let lastHeartbeat = 0;
+  /** Persist what the tracker knows right now. Called after every sweep, and on shutdown. */
+  async function flush() {
+    await stateWriter.save({ transitions: tracker.snapshot(), lastScannedBlock });
+    return { tracked: tracker.size, lastScannedBlock };
+  }
+
+  const ac = new AbortController();
+  /** @type {Promise<void>|null} */
+  let running = null;
+
+  async function loop(signal) {
+    let lastHeartbeatLine = 0;
     for (;;) {
-      if (signal?.aborted) return;
+      if (signal.aborted) return;
       try {
         const { vaults } = await runOnce();
-        if (cfg.heartbeatMs > 0 && Date.now() - lastHeartbeat >= cfg.heartbeatMs) {
-          lastHeartbeat = Date.now();
+        // Only a SUCCESSFUL sweep counts as watching. A canary that cannot reach the RPC is not
+        // monitoring anything and must not keep telling ops-check that it is.
+        await heartbeat.beat({ vaults: vaults.length, tracked: tracker.size, notOk: tracker.unhealthy().length, lastScannedBlock });
+        if (cfg.heartbeatMs > 0 && Date.now() - lastHeartbeatLine >= cfg.heartbeatMs) {
+          lastHeartbeatLine = Date.now();
           const bad = tracker.unhealthy();
-          log(`canary heartbeat: ${vaults.length} vault(s), ${tracker.size} signal(s) tracked, ${bad.length} not OK${bad.length ? `: ${bad.map((b) => b.id).join(', ')}` : ''}`);
+          line(`canary heartbeat: ${vaults.length} vault(s), ${tracker.size} signal(s) tracked, ${bad.length} not OK${bad.length ? `: ${bad.map((b) => b.id).join(', ')}` : ''}`);
         }
       } catch (err) {
         // A poll failure is an RPC problem, not a protocol problem. Say so and keep watching.
-        error(`canary poll error (will retry): ${err?.message ?? err}`);
+        logger.warn?.('sweep.failed', { error: String(err?.message ?? err) });
+        errLine(`canary poll error (will retry): ${err?.message ?? err}`);
       }
       await sleep(cfg.pollIntervalMs, signal);
     }
   }
 
-  return { reader, tracker, runOnce, start };
+  async function start({ signal } = {}) {
+    if (signal) {
+      if (signal.aborted) ac.abort();
+      else signal.addEventListener('abort', () => ac.abort(), { once: true });
+    }
+    logger.info?.('starting', {
+      chainId: cfg.chainId, pollIntervalMs: cfg.pollIntervalMs, statePath: cfg.statePath,
+      canaryStatePath: cfg.canaryStatePath, tracked: tracker.size, readOnly: true,
+    });
+    line(`canary up: chain ${cfg.chainId}, read-only, polling every ${cfg.pollIntervalMs}ms. Silence means healthy.`);
+    running = loop(ac.signal);
+    return running;
+  }
+
+  /**
+   * Stop cleanly: abort the sweep loop, wait for the in-flight sweep, then FLUSH the transition
+   * state. Losing that file is not fatal but costs one duplicate page per still-firing signal on
+   * the next start — precisely the noise an operator restarting a service does not need.
+   */
+  async function stop() {
+    ac.abort();
+    if (running) await running.catch(() => {});
+    const flushed = await flush();
+    logger.info?.('stopped', { ...flushed, canaryStatePath: cfg.canaryStatePath });
+    return flushed;
+  }
+
+  return { reader, tracker, runOnce, start, stop, flush, heartbeat, logger };
 }
 
 function sleep(ms, signal) {
   return new Promise((resolve) => {
-    const t = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => { clearTimeout(t); resolve(undefined); }, { once: true });
+    const t = setTimeout(finish, ms);
+    function finish() {
+      clearTimeout(t);
+      // Removed explicitly: this sleeps once per sweep against a signal that lives as long as the
+      // process, so leaving listeners attached would leak one per sweep forever.
+      signal?.removeEventListener?.('abort', finish);
+      resolve(undefined);
+    }
+    signal?.addEventListener('abort', finish, { once: true });
   });
 }
 
 // ── entrypoint ──
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 if (isMain) {
-  const cfg = resolveCanaryConfig(process.env);
-  buildCanary(cfg).then(({ start }) => start()).catch((err) => {
-    console.error(err?.message ?? err);
-    process.exit(1);
-  });
+  const argv = process.argv.slice(2);
+  // `verify` runs BEFORE config resolution, so it works with no RPC_URL and no env at all —
+  // which is the state of the shell you are in when you need it.
+  if (argv[0] === 'verify') {
+    const path = argv[1] || process.env.CANARY_STATE_PATH || './data/canary-state.json';
+    const report = await verifyCanaryState(path);
+    (report.ok ? console.log : console.error)(formatCanaryStateReport(report));
+    process.exit(report.ok ? 0 : 1);
+  } else {
+    const logger = loggerFromEnv('canary');
+    try {
+      const cfg = resolveCanaryConfig(process.env);
+      const { start, stop } = await buildCanary(cfg, { logger });
+      createShutdown({ log: logger })
+        .onShutdown('canary.flush-transitions', stop)
+        .install();
+      await start();
+    } catch (err) {
+      logger.error('startup.failed', { error: String(err?.message ?? err) });
+      process.exit(1);
+    }
+  }
 }

--- a/packages/canary/src/state-file.mjs
+++ b/packages/canary/src/state-file.mjs
@@ -1,0 +1,112 @@
+// @ts-check
+/**
+ * The canary's own transition state on disk — never the indexer's snapshot, which it opens
+ * read-only.
+ *
+ * Small file, big consequence: it is what stops a restart from re-paging every alert that was
+ * already acknowledged, and what remembers `lastScannedBlock` so the event signals do not re-scan
+ * or, worse, silently skip a range. Losing it is not fatal — the canary rebuilds by observing —
+ * but the rebuild costs one duplicate page per still-firing signal, at exactly the moment an
+ * operator is least able to absorb noise. So it gets the same durability as the snapshot: atomic
+ * write plus a time-spaced backup ring.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { createRotatingWriter, listBackups } from '../../oplog/src/durable.mjs';
+
+export const emptyCanaryState = () => ({ transitions: {}, lastScannedBlock: null });
+
+/** Atomic writer with the backup ring. `save(obj)` replaces the old inline temp-then-rename. */
+export function createCanaryStateWriter({ path, backups = 0, backupIntervalMs = 0, now }) {
+  const writer = createRotatingWriter({ path, backups, backupIntervalMs, now });
+  return { path, backups, get backupCount() { return writer.backupCount; }, save: (obj) => writer.write(obj) };
+}
+
+/** Load, treating an absent file as a first run rather than an error. */
+export async function loadCanaryState(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return emptyCanaryState();
+    throw err;
+  }
+}
+
+/** Tallies over a persisted transition map: how many signals, and which are not OK. */
+export function summariseTransitions(transitions) {
+  const entries = Object.entries(transitions ?? {});
+  const byStatus = {};
+  const notOk = [];
+  for (const [id, s] of entries) {
+    const status = s?.status ?? 'unknown';
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+    if (status !== 'ok') notOk.push({ id, status, since: s?.since ?? null });
+  }
+  return { tracked: entries.length, byStatus, notOk };
+}
+
+/**
+ * Read the canary state and report it, WITHOUT starting a sweep — no RPC, no RPC_URL required.
+ * The question after an incident is "what did it already know, and how far had it scanned?".
+ */
+export async function verifyCanaryState(path, { keep = 5 } = {}) {
+  const report = { path, ok: false, exists: false, error: null, lastScannedBlock: null, summary: null, backups: [] };
+  for (const b of await listBackups(path, keep)) {
+    const row = { ...b, ok: false, lastScannedBlock: null, tracked: null, error: null };
+    try {
+      const obj = JSON.parse(await readFile(b.path, 'utf8'));
+      row.ok = true;
+      row.lastScannedBlock = obj.lastScannedBlock ?? null;
+      row.tracked = summariseTransitions(obj.transitions).tracked;
+    } catch (err) {
+      row.error = String(err?.message ?? err);
+    }
+    report.backups.push(row);
+  }
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    report.error = err && err.code === 'ENOENT'
+      ? `no canary state at ${path} — a fresh canary would re-observe every signal (expect one page per signal already firing)`
+      : String(err?.message ?? err);
+    return report;
+  }
+  report.exists = true;
+  report.bytes = raw.length;
+  try {
+    const obj = JSON.parse(raw);
+    report.lastScannedBlock = obj.lastScannedBlock ?? null;
+    report.summary = summariseTransitions(obj.transitions);
+    report.ok = true;
+  } catch (err) {
+    report.error = String(err?.message ?? err);
+  }
+  return report;
+}
+
+/** Render a verify report for a terminal. */
+export function formatCanaryStateReport(report) {
+  const lines = [];
+  if (!report.ok) {
+    lines.push(`canary state ${report.path}: UNUSABLE — ${report.error}`);
+  } else {
+    const s = report.summary;
+    lines.push(`canary state ${report.path}: OK`);
+    lines.push(`  cursor      lastScannedBlock=${report.lastScannedBlock ?? 'null (cold start)'}`);
+    lines.push(`  signals     ${s.tracked} tracked — ${Object.entries(s.byStatus).map(([k, v]) => `${k}=${v}`).join(' ') || 'none'}`);
+    for (const n of s.notOk) lines.push(`    NOT OK    ${n.id} (${n.status} since poll ${n.since})`);
+    lines.push(`  file        ${report.bytes} bytes`);
+  }
+  if (report.backups.length === 0) {
+    lines.push('  backups     none on disk (SNAPSHOT_BACKUPS=0, or none taken yet)');
+  } else {
+    lines.push(`  backups     ${report.backups.length} (newest first)`);
+    for (const b of report.backups) {
+      lines.push(b.ok
+        ? `    .${b.n}  lastScannedBlock=${b.lastScannedBlock} tracked=${b.tracked} ${b.bytes} bytes  ${b.mtime}`
+        : `    .${b.n}  UNREADABLE — ${b.error}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/packages/canary/test/shutdown.test.mjs
+++ b/packages/canary/test/shutdown.test.mjs
@@ -1,0 +1,177 @@
+// @ts-check
+/**
+ * SIGTERM behaviour for the canary: the sweep loop stops and the transition state is FLUSHED.
+ * Driven through `stop()` with a stub reader — no signals, no RPC. The thing being protected is
+ * the operator's inbox: an unflushed restart re-pages every signal that was already firing.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, writeFile } from 'node:fs/promises';
+import { resolveCanaryConfig, buildCanary } from '../src/canary-runner.mjs';
+import { verifyCanaryState } from '../src/state-file.mjs';
+import { readHeartbeatFile } from '../../oplog/src/heartbeat.mjs';
+import { saveSnapshot } from '../../indexer/src/store.mjs';
+import { applyAll } from '../../indexer/src/projections.mjs';
+
+const A40 = (c) => '0x' + c.repeat(40);
+const VAULT = A40('a');
+const tmp = () => mkdtemp(join(tmpdir(), 'canary-shutdown-'));
+
+const ENV = (dir) => ({
+  RPC_URL: 'http://localhost:8545',
+  STATE_PATH: join(dir, 'indexer-state.json'),
+  CANARY_STATE_PATH: join(dir, 'canary-state.json'),
+  HEARTBEAT_DIR: dir,
+  CANARY_POLL_INTERVAL_MS: '20',
+});
+
+/** Seed a snapshot holding one vault, so the canary has something to watch. */
+async function seed(dir) {
+  await saveSnapshot(join(dir, 'indexer-state.json'), applyAll([
+    { name: 'VaultCreated', vault: VAULT, blockNumber: 5, logIndex: 0, args: { vault: VAULT, creator: A40('b'), usdc: A40('c'), capacityCapUsdc: 1000n } },
+  ]));
+}
+
+/**
+ * A reader whose vault config read fails, so every signal lands as `skipped` (DEGRADED). That is
+ * plenty: what these tests check is loop and persistence behaviour, not signal maths, which
+ * runner.test.mjs already covers against a full fixture.
+ */
+function stubReader(canary) {
+  canary.reader.headBlock = async () => 1000;
+  canary.reader.chainNow = async () => 1_700_000_000;
+  canary.reader.read = async () => { throw new Error('unreadable in this test'); };
+  canary.reader.tryRead = async () => null;
+  canary.reader.getLogs = async () => [];
+  canary.reader.staticCall = async () => ({ ok: false });
+}
+
+test('stop() ends the sweep loop and flushes what the tracker knows', async () => {
+  const dir = await tmp();
+  try {
+    await seed(dir);
+    const cfg = resolveCanaryConfig(ENV(dir));
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, logger: {}, client: {} });
+    stubReader(canary);
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 60));
+    const flushed = await canary.stop();
+    await running;
+
+    assert.ok(flushed.tracked > 0, 'it had observed something worth remembering');
+    assert.equal(flushed.lastScannedBlock, 995);
+
+    const report = await verifyCanaryState(cfg.canaryStatePath);
+    assert.equal(report.ok, true);
+    assert.equal(report.lastScannedBlock, 995);
+    assert.equal(report.summary.tracked, flushed.tracked);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the flushed state is what stops a restart re-paging every standing alert', async () => {
+  const dir = await tmp();
+  try {
+    await seed(dir);
+    const cfg = resolveCanaryConfig(ENV(dir));
+
+    const first = await buildCanary(cfg, { log: () => {}, error: () => {}, logger: {}, client: {} });
+    stubReader(first);
+    await first.runOnce();
+    const emitted = (await first.runOnce(), first.tracker.size);
+    await first.stop();
+    assert.ok(emitted > 0);
+
+    // A fresh process over the SAME state file: nothing has changed, so nothing is announced.
+    const out = [], err = [];
+    const second = await buildCanary(cfg, { log: (m) => out.push(m), error: (m) => err.push(m), logger: {}, client: {} });
+    stubReader(second);
+    const { transitions } = await second.runOnce();
+    await second.stop();
+    assert.deepEqual(transitions, [], 'a restart must not re-announce what was already reported');
+    assert.deepEqual(err, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('stop() before start() still writes clean state', async () => {
+  const dir = await tmp();
+  try {
+    await seed(dir);
+    const cfg = resolveCanaryConfig(ENV(dir));
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, logger: {}, client: {} });
+    await canary.stop();
+    const report = await verifyCanaryState(cfg.canaryStatePath);
+    assert.equal(report.ok, true);
+    assert.equal(report.summary.tracked, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the canary heartbeats only after a SUCCESSFUL sweep', async () => {
+  const dir = await tmp();
+  try {
+    await seed(dir);
+    const cfg = resolveCanaryConfig(ENV(dir));
+    assert.equal(cfg.heartbeatStaleMs, 60_000, 'floored: a sweep is many RPC round-trips');
+
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, logger: {}, client: {} });
+    // A reader that cannot even reach the head — the sweep throws, so nothing is being watched.
+    canary.reader.headBlock = async () => { throw new Error('RPC down'); };
+    canary.start();
+    await new Promise((r) => setTimeout(r, 60));
+    assert.equal(await readHeartbeatFile(canary.heartbeat.path), null,
+      'a canary that cannot reach the chain must not report itself as watching');
+
+    // Now let it work; the heartbeat appears and carries what it is watching.
+    stubReader(canary);
+    await new Promise((r) => setTimeout(r, 60));
+    await canary.stop();
+
+    const hb = await readHeartbeatFile(canary.heartbeat.path);
+    assert.equal(hb.service, 'canary');
+    assert.equal(hb.staleAfterMs, 60_000);
+    assert.equal(hb.detail.vaults, 1);
+    assert.equal(hb.detail.lastScannedBlock, 995);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the canary state file gets the backup ring too', async () => {
+  const dir = await tmp();
+  try {
+    await seed(dir);
+    const cfg = resolveCanaryConfig({ ...ENV(dir), SNAPSHOT_BACKUPS: '2', SNAPSHOT_BACKUP_INTERVAL_MS: '0' });
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, logger: {}, client: {} });
+    stubReader(canary);
+    await canary.runOnce();
+    await canary.runOnce();
+    await canary.stop();
+
+    const report = await verifyCanaryState(cfg.canaryStatePath);
+    assert.ok(report.backups.length >= 1, 'something to restore from');
+    assert.ok(report.backups.every((b) => b.ok));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a corrupt canary state is reported by verify rather than silently re-paging', async () => {
+  const dir = await tmp();
+  try {
+    const path = join(dir, 'canary-state.json');
+    await writeFile(path, '{"transitions": {"a": ', 'utf8');
+    const report = await verifyCanaryState(path);
+    assert.equal(report.ok, false);
+    assert.equal(report.exists, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/canary/test/state-file.test.mjs
+++ b/packages/canary/test/state-file.test.mjs
@@ -1,0 +1,106 @@
+// @ts-check
+/**
+ * The canary's own state file: durable like the snapshot, and verifiable without an RPC. Losing it
+ * costs one duplicate page per still-firing signal, so "did it survive, and what was in it" is a
+ * question worth being able to answer at 3am.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, writeFile } from 'node:fs/promises';
+import { createCanaryStateWriter, loadCanaryState, verifyCanaryState, formatCanaryStateReport, summariseTransitions, emptyCanaryState } from '../src/state-file.mjs';
+import { backupPath } from '../../oplog/src/durable.mjs';
+
+const tmp = () => mkdtemp(join(tmpdir(), 'canary-state-'));
+const STATE = (block, transitions) => ({ lastScannedBlock: block, transitions });
+
+test('write then load round-trips, and an absent file is a cold start not an error', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    assert.deepEqual(await loadCanaryState(p), emptyCanaryState());
+    await createCanaryStateWriter({ path: p, backups: 0 }).save(STATE(100, { 'nav-backing|0xabc': { status: 'alert', since: 3 } }));
+    const back = await loadCanaryState(p);
+    assert.equal(back.lastScannedBlock, 100);
+    assert.equal(back.transitions['nav-backing|0xabc'].status, 'alert');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('summariseTransitions counts by status and lists what is not OK', () => {
+  const s = summariseTransitions({
+    a: { status: 'ok', since: 1 },
+    b: { status: 'alert', since: 4 },
+    c: { status: 'skipped', since: 9 },
+  });
+  assert.equal(s.tracked, 3);
+  assert.deepEqual(s.byStatus, { ok: 1, alert: 1, skipped: 1 });
+  assert.deepEqual(s.notOk.map((n) => n.id).sort(), ['b', 'c']);
+});
+
+test('summariseTransitions survives an empty or absent transition map', () => {
+  assert.equal(summariseTransitions({}).tracked, 0);
+  assert.equal(summariseTransitions(undefined).tracked, 0);
+});
+
+test('verify reports the cursor, the tracked signals and the ones still firing', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    await createCanaryStateWriter({ path: p, backups: 0 }).save(STATE(8_000_000, {
+      'oracle-freshness|0xaaa|WETH': { status: 'alert', since: 12 },
+      'nav-backing|0xaaa': { status: 'ok', since: 1 },
+    }));
+    const r = await verifyCanaryState(p);
+    assert.equal(r.ok, true);
+    assert.equal(r.lastScannedBlock, 8_000_000);
+    assert.equal(r.summary.tracked, 2);
+    const text = formatCanaryStateReport(r);
+    assert.match(text, /lastScannedBlock=8000000/);
+    assert.match(text, /NOT OK {4}oracle-freshness\|0xaaa\|WETH \(alert since poll 12\)/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('an absent state file explains the consequence of starting without it', async () => {
+  const r = await verifyCanaryState(join(tmpdir(), `no-canary-${process.pid}.json`));
+  assert.equal(r.ok, false);
+  assert.match(r.error, /re-observe every signal/);
+  assert.match(formatCanaryStateReport(r), /UNUSABLE/);
+});
+
+test('a corrupt state file is reported, not thrown', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    await writeFile(p, '{"transitions": ', 'utf8');
+    const r = await verifyCanaryState(p);
+    assert.equal(r.ok, false);
+    assert.equal(r.exists, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the backup ring applies here too, and verify summarises each rung', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    let t = 0;
+    const w = createCanaryStateWriter({ path: p, backups: 2, backupIntervalMs: 0, now: () => (t += 1000) });
+    for (const b of [1, 2, 3, 4]) await w.save(STATE(b, { x: { status: 'ok', since: b } }));
+    const r = await verifyCanaryState(p);
+    assert.equal(r.lastScannedBlock, 4);
+    assert.deepEqual(r.backups.map((x) => [x.n, x.lastScannedBlock]), [[1, 3], [2, 2]]);
+
+    await writeFile(backupPath(p, 2), 'nope', 'utf8');
+    const r2 = await verifyCanaryState(p);
+    assert.equal(r2.backups[1].ok, false);
+    assert.match(formatCanaryStateReport(r2), /\.2 {2}UNREADABLE/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/indexer/src/daemon.mjs
+++ b/packages/indexer/src/daemon.mjs
@@ -18,8 +18,10 @@ import { loadSnapshot, saveSnapshot, resumeCursor } from './store.mjs';
  * @param {number} [cfg.confirmations]               lag behind head before indexing (reorg safety)
  * @param {number} [cfg.batchBlocks]                 max blocks per poll
  * @param {(msg:string)=>void} [cfg.log]
+ * @param {(state:any)=>Promise<any>} [cfg.save]     how a batch is persisted; defaults to a plain
+ *        atomic snapshot. index-runner injects a writer that also keeps a backup ring.
  */
-export function createIndexerDaemon({ statePath, fetchEvents, headBlock, confirmations = 5, batchBlocks = 2000, log = () => {} }) {
+export function createIndexerDaemon({ statePath, fetchEvents, headBlock, confirmations = 5, batchBlocks = 2000, log = () => {}, save = (st) => saveSnapshot(statePath, st) }) {
   let state = null;
   let running = false;
 
@@ -49,19 +51,29 @@ export function createIndexerDaemon({ statePath, fetchEvents, headBlock, confirm
       state.lastBlock = to;
       state.lastLogIndex = -1;
     }
-    await saveSnapshot(statePath, state);
+    await save(state);
     log(`indexed [${from}..${to}] — ${events.length} events, now at ${state.lastBlock}`);
     return events.length;
   }
 
-  /** Run until caught up with the chain head (drains all batches). Returns total events applied. */
-  async function catchUp() {
+  /**
+   * Run until caught up with the chain head (drains all batches). Returns total events applied.
+   *
+   * `signal` is checked BETWEEN batches, which is what makes SIGTERM honest: a cold-start backlog
+   * is minutes of `tick()` calls, and without this the process would ignore the signal for all of
+   * them and die by SIGKILL mid-fold. Since `tick()` snapshots each batch, stopping between two of
+   * them means "finished the current batch and persisted it" literally rather than aspirationally.
+   *
+   * @param {{signal?:AbortSignal}} [opts]
+   */
+  async function catchUp({ signal } = {}) {
     let total = 0;
     for (;;) {
       const n = await tick();
-      const head = await headBlock();
-      if (resumeCursor(state).fromBlock > head - confirmations) return total + n;
       total += n;
+      if (signal?.aborted) return total;
+      const head = await headBlock();
+      if (resumeCursor(state).fromBlock > head - confirmations) return total;
     }
   }
 

--- a/packages/indexer/src/index-runner.mjs
+++ b/packages/indexer/src/index-runner.mjs
@@ -13,14 +13,23 @@
  * Optional env:
  *   CHAIN_ID (8453)  CHAIN_NAME (base)  START_BLOCK (0)  STATE_PATH (./data/indexer-state.json)
  *   CONFIRMATIONS (5)  BATCH_BLOCKS (2000)  POLL_INTERVAL_MS (12000)
+ *   SNAPSHOT_BACKUPS (3)  SNAPSHOT_BACKUP_INTERVAL_MS (300000)
+ *   HEARTBEAT_DIR (dirname of STATE_PATH)  LOG_FORMAT (json|pretty)  LOG_LEVEL (info)
  *
- * Run: `RPC_URL=… FACTORY_ADDRESS=… … node packages/indexer/src/index-runner.mjs`
+ * Run:    `RPC_URL=… FACTORY_ADDRESS=… … node packages/indexer/src/index-runner.mjs`
+ * Verify: `node packages/indexer/src/index-runner.mjs verify [path]`
+ *         Reads a snapshot and reports its cursor, counts and backups. Needs NO env at all and
+ *         starts no poller — see the entrypoint at the bottom.
  */
 
 import { fileURLToPath } from 'node:url';
 import { createChainSource } from './rpc.mjs';
 import { createIndexerDaemon } from './daemon.mjs';
-import { loadSnapshot, resumeCursor } from './store.mjs';
+import { loadSnapshot, resumeCursor, createSnapshotWriter, verifySnapshot, formatSnapshotReport } from './store.mjs';
+import { loggerFromEnv } from '../../oplog/src/logger.mjs';
+import { createHeartbeat, defaultHeartbeatDir } from '../../oplog/src/heartbeat.mjs';
+import { createShutdown } from '../../oplog/src/shutdown.mjs';
+import { resolveDurabilityOptions } from '../../oplog/src/durable.mjs';
 
 /**
  * Parse + validate the indexer config from a raw env object. Pure and testable (no I/O).
@@ -43,25 +52,34 @@ export function resolveIndexerConfig(env) {
   for (const [label, a] of Object.entries(addresses)) {
     if (!isAddr(a)) throw new Error(`indexer: ${label} is not a 20-byte address: ${a}`);
   }
+  const statePath = env.STATE_PATH || './data/indexer-state.json';
+  const pollIntervalMs = num('POLL_INTERVAL_MS', 12_000);
   return {
     rpcUrl: env.RPC_URL,
     chainId: num('CHAIN_ID', 8453),
     chainName: env.CHAIN_NAME || 'base',
     addresses,
     startBlock: num('START_BLOCK', 0),
-    statePath: env.STATE_PATH || './data/indexer-state.json',
+    statePath,
     confirmations: num('CONFIRMATIONS', 5),
     batchBlocks: num('BATCH_BLOCKS', 2000),
-    pollIntervalMs: num('POLL_INTERVAL_MS', 12_000),
+    pollIntervalMs,
+    ...resolveDurabilityOptions(env),
+    heartbeatDir: defaultHeartbeatDir({ ...env, STATE_PATH: statePath }),
+    // Three missed polls, floored at 30s so a fast poll interval does not produce a hair-trigger
+    // that pages on one slow RPC round-trip.
+    heartbeatStaleMs: Math.max(30_000, pollIntervalMs * 3),
   };
 }
 
 /**
  * Build a wired (but not yet started) indexer from a resolved config. Seeds the chain source's
  * known-vault set from the resumed snapshot so VaultCore events keep indexing across restarts.
- * Returns the daemon plus a `start()` that polls forever.
+ * Returns the daemon plus a `start()` that polls forever and a `stop()` that ends it cleanly.
  */
-export async function buildIndexer(cfg, { log = console.log, client } = {}) {
+export async function buildIndexer(cfg, { log, logger = loggerFromEnv('indexer'), client } = {}) {
+  const line = log ?? logger.text('indexer.progress');
+
   // Load once to discover already-known vaults, so VaultCore events keep indexing across restarts.
   const resumed = await loadSnapshot(cfg.statePath);
   const knownVaults = [...resumed.vaults.keys()];
@@ -72,15 +90,29 @@ export async function buildIndexer(cfg, { log = console.log, client } = {}) {
     addresses: cfg.addresses, knownVaults,
   });
 
+  const writer = createSnapshotWriter({
+    path: cfg.statePath, backups: cfg.backups ?? 0, backupIntervalMs: cfg.backupIntervalMs ?? 0,
+  });
+
   const daemon = createIndexerDaemon({
     statePath: cfg.statePath,
     fetchEvents: source.fetchEvents,
     headBlock: source.headBlock,
     confirmations: cfg.confirmations,
     batchBlocks: cfg.batchBlocks,
-    log,
+    log: line,
+    save: (st) => writer.save(st),
   });
   await daemon.init(); // loads the same snapshot into the daemon's own state
+
+  const heartbeat = createHeartbeat({
+    dir: cfg.heartbeatDir ?? './data', service: 'indexer',
+    staleAfterMs: cfg.heartbeatStaleMs ?? 60_000,
+    // A cold-start catch-up ticks far faster than the poll interval; one heartbeat per second of
+    // wall clock is plenty to prove liveness and keeps the write off the hot path.
+    minIntervalMs: 1000,
+    onError: (err) => logger.warn?.('heartbeat.failed', { error: String(err?.message ?? err) }),
+  });
 
   // Fresh state (no snapshot) honors START_BLOCK; a resumed state keeps its own cursor.
   const st = daemon.getState();
@@ -90,38 +122,98 @@ export async function buildIndexer(cfg, { log = console.log, client } = {}) {
     // Vaults are discovered from VaultCreated within polled ranges; any vault created BEFORE
     // START_BLOCK will never be discovered (its VaultCore events go unindexed). Set START_BLOCK
     // to the deploy block, not later. Warn so this is never silent.
-    log(`⚠ indexer: START_BLOCK=${cfg.startBlock} on a fresh snapshot — vaults created before block ${cfg.startBlock} will NOT be discovered. Use the factory deploy block.`);
+    line(`⚠ indexer: START_BLOCK=${cfg.startBlock} on a fresh snapshot — vaults created before block ${cfg.startBlock} will NOT be discovered. Use the factory deploy block.`);
   }
 
-  async function start({ signal } = {}) {
-    log(`indexer up: chain ${cfg.chainId}, ${knownVaults.length} known vaults, resume block ${resumeCursor(daemon.getState()).fromBlock}`);
+  const ac = new AbortController();
+  /** @type {Promise<void>|null} */
+  let running = null;
+
+  async function loop(signal) {
     for (;;) {
-      if (signal?.aborted) return;
+      if (signal.aborted) return;
       try {
-        await daemon.catchUp();
+        await daemon.catchUp({ signal });
       } catch (err) {
-        log(`indexer poll error (will retry): ${err?.message ?? err}`);
+        logger.warn?.('poll.failed', { error: String(err?.message ?? err), lastBlock: daemon.getState().lastBlock });
+        line(`indexer poll error (will retry): ${err?.message ?? err}`);
       }
+      const s = daemon.getState();
+      await heartbeat.beat({ lastBlock: s.lastBlock, vaults: s.vaults.size });
       await sleep(cfg.pollIntervalMs, signal);
     }
   }
 
-  return { daemon, source, start };
+  async function start({ signal } = {}) {
+    if (signal) {
+      if (signal.aborted) ac.abort();
+      else signal.addEventListener('abort', () => ac.abort(), { once: true });
+    }
+    logger.info?.('starting', {
+      chainId: cfg.chainId, knownVaults: knownVaults.length,
+      resumeBlock: resumeCursor(daemon.getState()).fromBlock, statePath: cfg.statePath,
+      pollIntervalMs: cfg.pollIntervalMs, backups: cfg.backups ?? 0,
+    });
+    await heartbeat.beat({ lastBlock: daemon.getState().lastBlock, vaults: daemon.getState().vaults.size }, { force: true });
+    running = loop(ac.signal);
+    return running;
+  }
+
+  /**
+   * Stop cleanly: abort so the batch loop exits at the next batch boundary, wait for it, then take
+   * one final snapshot. The final write is belt-and-braces — `tick()` already persisted the batch
+   * it finished — but it costs one atomic write and removes any doubt about what is on disk.
+   */
+  async function stop() {
+    ac.abort();
+    if (running) await running.catch(() => {});
+    await writer.save(daemon.getState());
+    const s = daemon.getState();
+    logger.info?.('stopped', { lastBlock: s.lastBlock, vaults: s.vaults.size, statePath: cfg.statePath });
+    return s.lastBlock;
+  }
+
+  return { daemon, source, start, stop, heartbeat, writer, logger };
 }
 
 function sleep(ms, signal) {
   return new Promise((resolve) => {
-    const t = setTimeout(resolve, ms);
-    signal?.addEventListener('abort', () => { clearTimeout(t); resolve(undefined); }, { once: true });
+    const t = setTimeout(finish, ms);
+    function finish() {
+      clearTimeout(t);
+      // Removing the listener matters: this sleeps once per poll against a signal that lives for
+      // the whole process, so leaving them attached would leak one listener per poll forever.
+      signal?.removeEventListener?.('abort', finish);
+      resolve(undefined);
+    }
+    signal?.addEventListener('abort', finish, { once: true });
   });
 }
 
 // ── entrypoint ──
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 if (isMain) {
-  const cfg = resolveIndexerConfig(process.env);
-  buildIndexer(cfg).then(({ start }) => start()).catch((err) => {
-    console.error(err?.message ?? err);
-    process.exit(1);
-  });
+  const argv = process.argv.slice(2);
+  // `verify` runs BEFORE config resolution on purpose. Whoever is verifying a snapshot after a
+  // crash has an RPC URL and four contract addresses set exactly never; demanding them would make
+  // the tool useless at the only moment it is needed.
+  if (argv[0] === 'verify') {
+    const path = argv[1] || process.env.STATE_PATH || './data/indexer-state.json';
+    const report = await verifySnapshot(path);
+    (report.ok ? console.log : console.error)(formatSnapshotReport(report));
+    process.exit(report.ok ? 0 : 1);
+  } else {
+    const logger = loggerFromEnv('indexer');
+    try {
+      const cfg = resolveIndexerConfig(process.env);
+      const { start, stop } = await buildIndexer(cfg, { logger });
+      createShutdown({ log: logger })
+        .onShutdown('indexer.finish-batch-and-snapshot', stop)
+        .install();
+      await start();
+    } catch (err) {
+      logger.error('startup.failed', { error: String(err?.message ?? err) });
+      process.exit(1);
+    }
+  }
 }

--- a/packages/indexer/src/store.mjs
+++ b/packages/indexer/src/store.mjs
@@ -6,9 +6,10 @@
  * and replay only newer logs.
  */
 
-import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, rename, mkdir, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { emptyState } from './projections.mjs';
+import { createRotatingWriter, listBackups } from '../../oplog/src/durable.mjs';
 
 const VERSION = 1;
 
@@ -90,6 +91,22 @@ export async function saveSnapshot(path, state) {
   await rename(tmp, path);
 }
 
+/**
+ * `saveSnapshot` plus a time-spaced backup ring (oplog/durable.mjs). Atomicity survives a crash;
+ * the ring survives a write that succeeded and was wrong. Returns an object whose `save(state)`
+ * replaces `saveSnapshot` in the daemon.
+ * @param {{path:string, backups?:number, backupIntervalMs?:number, now?:() => number}} p
+ */
+export function createSnapshotWriter({ path, backups = 0, backupIntervalMs = 0, now }) {
+  const writer = createRotatingWriter({ path, backups, backupIntervalMs, now, serialize: (st) => JSON.stringify(serializeState(st)) });
+  return {
+    path,
+    backups,
+    get backupCount() { return writer.backupCount; },
+    save: (state) => writer.write(state),
+  };
+}
+
 /** Load a snapshot, or return a fresh empty state if the file is absent. */
 export async function loadSnapshot(path) {
   try {
@@ -104,4 +121,106 @@ export async function loadSnapshot(path) {
 /** The resume cursor an indexer should poll *after*. */
 export function resumeCursor(state) {
   return { fromBlock: state.lastBlock === 0 && state.lastLogIndex === -1 ? 0 : state.lastBlock + 1 };
+}
+
+/**
+ * Read a snapshot and report what is in it, WITHOUT starting a poller or touching an RPC.
+ *
+ * This is the after-the-incident question — "is this file usable, and how far behind is it?" —
+ * and answering it must not require the six env vars a running indexer needs, nor risk a process
+ * that starts indexing from a cursor you were about to reject. Backups are summarised alongside,
+ * because the next question is always "restore from which one?".
+ *
+ * @param {string} path
+ * @param {{keep?:number}} [opts]
+ */
+export async function verifySnapshot(path, { keep = 5 } = {}) {
+  const report = { path, ok: false, exists: false, bytes: null, mtime: null, version: VERSION, error: null,
+    lastBlock: null, lastLogIndex: null, counts: null, backups: [] };
+  try {
+    report.backups = await summariseBackups(path, keep);
+  } catch (err) {
+    report.backups = [];
+  }
+  let st;
+  try {
+    st = await stat(path);
+  } catch (err) {
+    report.error = err && err.code === 'ENOENT'
+      ? `no snapshot at ${path} — a fresh indexer would start from START_BLOCK`
+      : String(err?.message ?? err);
+    return report;
+  }
+  report.exists = true;
+  report.bytes = st.size;
+  report.mtime = new Date(st.mtimeMs).toISOString();
+  report.ageSec = Math.round((Date.now() - st.mtimeMs) / 1000);
+  try {
+    const state = deserializeState(JSON.parse(await readFile(path, 'utf8')));
+    report.lastBlock = state.lastBlock;
+    report.lastLogIndex = state.lastLogIndex;
+    report.resumeFrom = resumeCursor(state).fromBlock;
+    report.counts = countState(state);
+    report.ok = true;
+  } catch (err) {
+    report.error = String(err?.message ?? err);
+  }
+  return report;
+}
+
+/** The per-collection tallies an operator compares against a backup before restoring. */
+export function countState(state) {
+  let holders = 0;
+  for (const book of state.shares.values()) holders += book.size;
+  return {
+    vaults: state.vaults.size,
+    operators: state.operators.size,
+    proposals: state.proposals.size,
+    shareBooks: state.shares.size,
+    holders,
+    activeProposals: state.activeProposal.size,
+  };
+}
+
+/** Backups with their own cursor, so "which one do I roll back to" is answerable at a glance. */
+async function summariseBackups(path, keep) {
+  const out = [];
+  for (const b of await listBackups(path, keep)) {
+    const row = { ...b, ok: false, lastBlock: null, counts: null, error: null };
+    try {
+      const state = deserializeState(JSON.parse(await readFile(b.path, 'utf8')));
+      row.ok = true;
+      row.lastBlock = state.lastBlock;
+      row.counts = countState(state);
+    } catch (err) {
+      row.error = String(err?.message ?? err);
+    }
+    out.push(row);
+  }
+  return out;
+}
+
+/** Render a verify report for a terminal. Exit code comes from `report.ok`. */
+export function formatSnapshotReport(report) {
+  const lines = [];
+  if (!report.exists || !report.ok) {
+    lines.push(`snapshot ${report.path}: UNUSABLE — ${report.error}`);
+  } else {
+    const c = report.counts;
+    lines.push(`snapshot ${report.path}: OK`);
+    lines.push(`  cursor      lastBlock=${report.lastBlock} lastLogIndex=${report.lastLogIndex} → resumes from block ${report.resumeFrom}`);
+    lines.push(`  counts      vaults=${c.vaults} operators=${c.operators} proposals=${c.proposals} shareBooks=${c.shareBooks} holders=${c.holders} activeProposals=${c.activeProposals}`);
+    lines.push(`  file        ${report.bytes} bytes, written ${report.mtime} (${report.ageSec}s ago)`);
+  }
+  if (report.backups.length === 0) {
+    lines.push('  backups     none on disk (SNAPSHOT_BACKUPS=0, or none taken yet)');
+  } else {
+    lines.push(`  backups     ${report.backups.length} (newest first)`);
+    for (const b of report.backups) {
+      lines.push(b.ok
+        ? `    .${b.n}  lastBlock=${b.lastBlock} vaults=${b.counts.vaults} ${b.bytes} bytes  ${b.mtime}`
+        : `    .${b.n}  UNREADABLE — ${b.error}  (${b.bytes} bytes, ${b.mtime})`);
+    }
+  }
+  return lines.join('\n');
 }

--- a/packages/indexer/test/restore.test.mjs
+++ b/packages/indexer/test/restore.test.mjs
@@ -1,0 +1,145 @@
+// @ts-check
+/**
+ * The restore procedure from docs/RUNTIME.md §8.3, executed rather than asserted in prose.
+ *
+ * A runbook nobody has run is a hypothesis. This walks the documented steps against real files —
+ * corrupt the snapshot, verify, keep the bad file, copy the backup into place, re-verify, resume —
+ * and checks the thing that actually matters at the end: that the indexer resumes from the
+ * restored cursor and re-folds the gap into the same state that was lost.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, writeFile, copyFile, rename, readdir } from 'node:fs/promises';
+import { resolveIndexerConfig, buildIndexer } from '../src/index-runner.mjs';
+import { verifySnapshot, loadSnapshot } from '../src/store.mjs';
+import { backupPath } from '../../oplog/src/durable.mjs';
+
+const A40 = (c) => '0x' + c.repeat(40);
+const FACTORY = A40('1');
+const V = A40('e');
+const MEMBER = A40('7');
+
+const ENV = (dir) => ({
+  RPC_URL: 'http://localhost:8545',
+  FACTORY_ADDRESS: FACTORY, OPERATOR_REGISTRY_ADDRESS: A40('2'),
+  SUBVAULT_REGISTRY_ADDRESS: A40('3'), GOVERNANCE_ADDRESS: A40('4'),
+  STATE_PATH: join(dir, 'indexer-state.json'), HEARTBEAT_DIR: dir,
+  CONFIRMATIONS: '0', BATCH_BLOCKS: '10', POLL_INTERVAL_MS: '5',
+  SNAPSHOT_BACKUPS: '3', SNAPSHOT_BACKUP_INTERVAL_MS: '0',
+});
+
+/**
+ * A chain with a vault created at block 5 and a deposit at block 25. `head` is mutable so the test
+ * can index a prefix, take a backup, then let the rest of history arrive.
+ */
+function chain(headRef) {
+  const logs = [
+    { address: FACTORY, eventName: 'VaultCreated', blockNumber: 5n, logIndex: 0, args: { vault: V, creator: A40('a'), usdc: A40('b'), capacityCapUsdc: 1000n } },
+    { address: V, eventName: 'DepositActivated', blockNumber: 25n, logIndex: 0, args: { member: MEMBER, amountUsdc: 50n, sharesMinted: 50n } },
+  ];
+  // The chain source issues one getLogs per contract GROUP, so the fake must honour the address
+  // filter — otherwise every group returns the same log and the fold counts it once per group.
+  return {
+    getBlockNumber: async () => BigInt(headRef.head),
+    getLogs: async ({ address, fromBlock, toBlock }) => {
+      const want = new Set((Array.isArray(address) ? address : [address]).filter(Boolean).map((a) => String(a).toLowerCase()));
+      return logs.filter((l) => want.has(l.address.toLowerCase())
+        && Number(l.blockNumber) >= Number(fromBlock) && Number(l.blockNumber) <= Number(toBlock));
+    },
+  };
+}
+
+test('RUNTIME.md §8.3 restore: a corrupt snapshot is rolled back and the gap is re-indexed', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'restore-'));
+  const path = join(dir, 'indexer-state.json');
+  try {
+    const headRef = { head: 10 };
+    const cfg = resolveIndexerConfig(ENV(dir));
+
+    // ── Normal operation: index to block 10, twice, so a backup exists ──
+    const first = await buildIndexer(cfg, { log: () => {}, logger: {}, client: chain(headRef) });
+    await first.daemon.catchUp();
+    headRef.head = 20;
+    await first.daemon.catchUp();
+    await first.stop();
+
+    const healthy = await verifySnapshot(path);
+    assert.equal(healthy.ok, true);
+    assert.equal(healthy.lastBlock, 20);
+    assert.equal(healthy.counts.vaults, 1);
+    assert.ok(healthy.backups.length >= 1, 'the ring has something to restore from');
+    // The newest rung is whatever the live file held before the last write — stop()'s final
+    // snapshot rotated once more, so .1 is block 20 and .2 is the block-10 state.
+    const rung = healthy.backups.find((b) => b.lastBlock === 10);
+    assert.ok(rung, `expected a rung at block 10, got ${JSON.stringify(healthy.backups.map((b) => b.lastBlock))}`);
+    assert.equal(rung.ok, true);
+
+    // ── Step 0: something writes garbage over the live snapshot ──
+    await writeFile(path, '{"version":1,"lastBlock":20,"vaults":[[', 'utf8');
+
+    // ── Step 2: verify tells you it is unusable, and which rung to take ──
+    const broken = await verifySnapshot(path);
+    assert.equal(broken.ok, false);
+    assert.equal(broken.exists, true, 'the file is present; the CONTENT is bad');
+    assert.equal(broken.backups[0].ok, true, 'and the ring is readable');
+    const target = broken.backups.find((b) => b.lastBlock === 10);
+    assert.ok(target, 'a rung with an earlier cursor is available');
+
+    // ── Step 3: keep the bad file — it is the only evidence of what happened ──
+    const kept = `${path}.bad-test`;
+    await rename(path, kept);
+
+    // ── Step 4: COPY the backup into place, so the ring survives a failure here ──
+    await copyFile(backupPath(path, target.n), path);
+    assert.ok((await readdir(dir)).includes('indexer-state.json.1'), 'the ring is intact after the copy');
+
+    // ── Step 5: verify the restored file and read off the resume cursor ──
+    const restored = await verifySnapshot(path);
+    assert.equal(restored.ok, true);
+    assert.equal(restored.lastBlock, 10);
+    assert.equal(restored.resumeFrom, 11);
+
+    // ── Step 6: restart. It resumes from 11 and re-folds the range it lost ──
+    headRef.head = 30;
+    const second = await buildIndexer(cfg, { log: () => {}, logger: {}, client: chain(headRef) });
+    await second.daemon.catchUp();
+    await second.stop();
+
+    const after = await verifySnapshot(path);
+    assert.equal(after.ok, true);
+    assert.equal(after.lastBlock, 30);
+
+    // The projection is a pure fold, so replaying the gap rebuilds exactly what was lost —
+    // including the block-25 deposit that only ever existed in the destroyed snapshot's future.
+    const state = await loadSnapshot(path);
+    assert.equal(state.vaults.size, 1);
+    assert.equal(state.shares.get(V)?.get(MEMBER), 50n, 'the deposit after the backup point is back');
+    assert.ok((await readdir(dir)).includes('indexer-state.json.bad-test'), 'the evidence was kept');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the last-resort path: no usable snapshot, rebuild from START_BLOCK', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'restore-'));
+  const path = join(dir, 'indexer-state.json');
+  try {
+    const headRef = { head: 30 };
+    // No snapshot at all, START_BLOCK at the factory deploy block — the documented fallback.
+    const cfg = resolveIndexerConfig({ ...ENV(dir), START_BLOCK: '5' });
+    const warnings = [];
+    const { daemon, stop } = await buildIndexer(cfg, { log: (m) => warnings.push(m), logger: {}, client: chain(headRef) });
+    await daemon.catchUp();
+    await stop();
+
+    const state = await loadSnapshot(path);
+    assert.equal(state.vaults.size, 1, 'full history rebuilt from chain');
+    assert.equal(state.shares.get(V)?.get(MEMBER), 50n);
+    // And the warning the docs tell you to heed when you are tempted to set a LATER block.
+    assert.ok(warnings.some((w) => /vaults created before block 5 will NOT be discovered/.test(w)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/indexer/test/shutdown.test.mjs
+++ b/packages/indexer/test/shutdown.test.mjs
@@ -1,0 +1,181 @@
+// @ts-check
+/**
+ * SIGTERM behaviour for the indexer, driven through `stop()` with a fake chain client — no signals,
+ * no RPC. The promise is "finishes the current batch + snapshots", and the tests below check both
+ * halves of it, including the part that only bites on a cold-start backlog: catchUp() must notice
+ * the abort BETWEEN batches instead of grinding through a thousand of them.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp } from 'node:fs/promises';
+import { resolveIndexerConfig, buildIndexer } from '../src/index-runner.mjs';
+import { createIndexerDaemon } from '../src/daemon.mjs';
+import { verifySnapshot } from '../src/store.mjs';
+import { readHeartbeatFile } from '../../oplog/src/heartbeat.mjs';
+
+const A40 = (c) => '0x' + c.repeat(40);
+const V = A40('e');
+const tmp = () => mkdtemp(join(tmpdir(), 'idx-shutdown-'));
+
+const ENV = (dir) => ({
+  RPC_URL: 'http://localhost:8545',
+  FACTORY_ADDRESS: A40('1'), OPERATOR_REGISTRY_ADDRESS: A40('2'),
+  SUBVAULT_REGISTRY_ADDRESS: A40('3'), GOVERNANCE_ADDRESS: A40('4'),
+  STATE_PATH: join(dir, 'indexer-state.json'), HEARTBEAT_DIR: dir,
+  POLL_INTERVAL_MS: '20', CONFIRMATIONS: '0', BATCH_BLOCKS: '10',
+});
+
+/** A chain source that hands out one VaultCreated at block 5 and then nothing. */
+function fakeClient(head = 30) {
+  return {
+    getBlockNumber: async () => BigInt(head),
+    getLogs: async ({ fromBlock, toBlock }) => (Number(fromBlock) <= 5 && 5 <= Number(toBlock)
+      ? [{ address: A40('1'), eventName: 'VaultCreated', blockNumber: 5n, logIndex: 0, args: { vault: V, creator: A40('a'), usdc: A40('b'), capacityCapUsdc: 1000n } }]
+      : []),
+  };
+}
+
+test('catchUp checks the abort signal BETWEEN batches, so SIGTERM is honoured mid-backlog', async () => {
+  const dir = await tmp();
+  try {
+    // A 10 000-block backlog in 10-block batches: without the check this would run 1000 times.
+    const ac = new AbortController();
+    let ticks = 0;
+    const d = createIndexerDaemon({
+      statePath: join(dir, 's.json'),
+      headBlock: async () => 10_000,
+      confirmations: 0,
+      batchBlocks: 10,
+      fetchEvents: async () => { ticks += 1; if (ticks === 3) ac.abort(); return []; },
+    });
+    await d.init();
+    await d.catchUp({ signal: ac.signal });
+    assert.equal(ticks, 3, 'stopped at the batch boundary, not after draining the backlog');
+    // The batch it did finish is on disk — that is what makes "finished the current batch" true.
+    assert.equal((await verifySnapshot(join(dir, 's.json'))).lastBlock, 29);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('catchUp with no signal still drains to the head (existing behaviour unchanged)', async () => {
+  const dir = await tmp();
+  try {
+    let ticks = 0;
+    const d = createIndexerDaemon({
+      statePath: join(dir, 's.json'), headBlock: async () => 45, confirmations: 0, batchBlocks: 10,
+      fetchEvents: async () => { ticks += 1; return []; },
+    });
+    await d.init();
+    await d.catchUp();
+    assert.equal(ticks, 5, 'blocks 0-45 in 10-block batches');
+    assert.equal((await verifySnapshot(join(dir, 's.json'))).lastBlock, 45);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('stop() ends the poll loop and leaves a readable snapshot at the right cursor', async () => {
+  const dir = await tmp();
+  try {
+    const cfg = resolveIndexerConfig(ENV(dir));
+    const { start, stop } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    const running = start();
+    await new Promise((r) => setTimeout(r, 60));   // let it catch up and idle
+
+    const lastBlock = await stop();
+    assert.equal(lastBlock, 30);
+    await running;                                  // the loop really exited, not just aborted
+
+    const report = await verifySnapshot(cfg.statePath);
+    assert.equal(report.ok, true, 'the file a restart will resume from is intact');
+    assert.equal(report.lastBlock, 30);
+    assert.equal(report.counts.vaults, 1, 'the vault it indexed survived the shutdown');
+    assert.equal(report.resumeFrom, 31);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('stop() is safe before start() — a process killed during boot still writes clean state', async () => {
+  const dir = await tmp();
+  try {
+    const cfg = resolveIndexerConfig(ENV(dir));
+    const { stop } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    assert.equal(await stop(), 0);
+    assert.equal((await verifySnapshot(cfg.statePath)).ok, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the indexer heartbeats while polling, stamped with its own staleness budget', async () => {
+  const dir = await tmp();
+  try {
+    const cfg = resolveIndexerConfig(ENV(dir));
+    // POLL_INTERVAL_MS=20 → floored at 30s so a fast poll cannot become a hair-trigger.
+    assert.equal(cfg.heartbeatStaleMs, 30_000);
+
+    const { start, stop, heartbeat } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    start();
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Beaten at boot, before the first batch: an indexer grinding through a cold-start backlog is
+    // alive and must not be reported dead while it works.
+    const boot = await readHeartbeatFile(heartbeat.path);
+    assert.equal(boot.service, 'indexer');
+    assert.equal(boot.staleAfterMs, 30_000);
+
+    // And it keeps advancing as it polls. The 1s floor on writes is why this waits: a fast
+    // catch-up ticks far quicker than that and must not turn into a write per batch.
+    await new Promise((r) => setTimeout(r, 1100));
+    const later = await readHeartbeatFile(heartbeat.path);
+    await stop();
+    assert.ok(later.ts > boot.ts, 'the beat keeps advancing while polling');
+    assert.equal(later.detail.lastBlock, 30);
+    assert.equal(later.detail.vaults, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the poll loop does not leak an abort listener per iteration', async () => {
+  // The loop sleeps once per poll against ONE signal that lives for the whole process. Attaching
+  // a listener per sleep and never detaching would grow without bound for the lifetime of the
+  // service; Node notices past ten and warns, which is what this catches.
+  const dir = await tmp();
+  const warnings = [];
+  const onWarning = (w) => warnings.push(w);
+  process.on('warning', onWarning);
+  try {
+    const cfg = resolveIndexerConfig({ ...ENV(dir), POLL_INTERVAL_MS: '1' });
+    const { start, stop } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    start();
+    await new Promise((r) => setTimeout(r, 200));   // ~100+ sleeps on one long-lived signal
+    await stop();
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(warnings.filter((w) => /MaxListenersExceeded/.test(w.name)), []);
+  } finally {
+    process.off('warning', onWarning);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the backup ring is wired through from env to the snapshot on disk', async () => {
+  const dir = await tmp();
+  try {
+    const cfg = resolveIndexerConfig({ ...ENV(dir), SNAPSHOT_BACKUPS: '2', SNAPSHOT_BACKUP_INTERVAL_MS: '0' });
+    assert.equal(cfg.backups, 2);
+    const { daemon, stop } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    await daemon.catchUp();
+    await daemon.catchUp();
+    await stop();
+    const report = await verifySnapshot(cfg.statePath);
+    assert.ok(report.backups.length >= 1, 'a backup exists to restore from');
+    assert.ok(report.backups.every((b) => b.ok), 'and it is readable');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/indexer/test/verify.test.mjs
+++ b/packages/indexer/test/verify.test.mjs
@@ -1,0 +1,140 @@
+// @ts-check
+/**
+ * `verify`: read a snapshot and say whether it is usable, WITHOUT starting a poller or needing an
+ * RPC. Exercised here at the library level; the entrypoint wiring is covered in index-runner.test.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { applyAll } from '../src/projections.mjs';
+import { saveSnapshot, createSnapshotWriter, verifySnapshot, formatSnapshotReport, countState } from '../src/store.mjs';
+import { backupPath } from '../../oplog/src/durable.mjs';
+
+const V = '0x' + '1'.repeat(40);
+const M = '0x' + '2'.repeat(40);
+const USDC = '0x' + 'c'.repeat(40);
+const tmp = () => mkdtemp(join(tmpdir(), 'verify-'));
+
+const created = (block) => ({ name: 'VaultCreated', vault: V, blockNumber: block, logIndex: 0, args: { vault: V, creator: M, usdc: USDC, capacityCapUsdc: 1_000_000n } });
+
+test('a good snapshot reports its cursor, its resume block and its counts', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'indexer-state.json');
+  try {
+    await saveSnapshot(p, applyAll([created(4242)]));
+    const r = await verifySnapshot(p);
+    assert.equal(r.ok, true);
+    assert.equal(r.exists, true);
+    assert.equal(r.lastBlock, 4242);
+    assert.equal(r.resumeFrom, 4243, 'the block a restarted indexer would poll from');
+    assert.equal(r.counts.vaults, 1);
+    assert.ok(r.bytes > 0 && r.mtime.endsWith('Z'));
+    assert.match(formatSnapshotReport(r), /OK[\s\S]*lastBlock=4242[\s\S]*vaults=1/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('an absent snapshot is reported as unusable, and says what would happen', async () => {
+  const r = await verifySnapshot(join(tmpdir(), `no-such-${process.pid}.json`));
+  assert.equal(r.ok, false);
+  assert.equal(r.exists, false);
+  assert.match(r.error, /no snapshot at .*START_BLOCK/);
+  assert.match(formatSnapshotReport(r), /UNUSABLE/);
+});
+
+test('a corrupt snapshot is reported as unusable rather than throwing at the caller', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'indexer-state.json');
+  try {
+    await writeFile(p, '{ truncated mid-w', 'utf8');
+    const r = await verifySnapshot(p);
+    assert.equal(r.ok, false);
+    assert.equal(r.exists, true, 'the file is there — it is the CONTENT that is bad');
+    assert.ok(r.error);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a snapshot from a future schema version is refused, not half-read', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'indexer-state.json');
+  try {
+    await writeFile(p, JSON.stringify({ version: 99, lastBlock: 1, lastLogIndex: -1, vaults: [], operators: [], shares: [], proposals: [], activeProposal: [] }), 'utf8');
+    const r = await verifySnapshot(p);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unsupported snapshot version: 99/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify summarises each BACKUP with its own cursor — "restore from which one?"', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'indexer-state.json');
+  try {
+    let t = 0;
+    const w = createSnapshotWriter({ path: p, backups: 3, backupIntervalMs: 0, now: () => (t += 1000) });
+    for (const b of [10, 20, 30, 40]) await w.save(applyAll([created(b)]));
+
+    const r = await verifySnapshot(p);
+    assert.equal(r.lastBlock, 40);
+    assert.deepEqual(r.backups.map((b) => [b.n, b.lastBlock, b.ok]), [[1, 30, true], [2, 20, true], [3, 10, true]]);
+    const text = formatSnapshotReport(r);
+    assert.match(text, /backups {5}3 \(newest first\)/);
+    assert.match(text, /\.1 {2}lastBlock=30/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a corrupt BACKUP is flagged individually — the readable ones stay usable', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'indexer-state.json');
+  try {
+    const w = createSnapshotWriter({ path: p, backups: 2, backupIntervalMs: 0 });
+    await w.save(applyAll([created(10)]));
+    await w.save(applyAll([created(20)]));
+    await w.save(applyAll([created(30)]));
+    await writeFile(backupPath(p, 1), 'garbage', 'utf8');
+
+    const r = await verifySnapshot(p);
+    assert.equal(r.ok, true, 'the live snapshot is unaffected');
+    assert.equal(r.backups[0].ok, false);
+    assert.ok(r.backups[0].error);
+    assert.equal(r.backups[1].ok, true);
+    assert.equal(r.backups[1].lastBlock, 10);
+    assert.match(formatSnapshotReport(r), /\.1 {2}UNREADABLE/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('createSnapshotWriter is a drop-in for saveSnapshot: byte-identical output', async () => {
+  const dir = await tmp();
+  try {
+    const a = join(dir, 'a.json');
+    const b = join(dir, 'b.json');
+    const state = applyAll([created(7)]);
+    await saveSnapshot(a, state);
+    await createSnapshotWriter({ path: b, backups: 0 }).save(state);
+    assert.equal(await readFile(a, 'utf8'), await readFile(b, 'utf8'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('countState tallies holders across every share book', () => {
+  const state = applyAll([
+    created(1),
+    { name: 'DepositActivated', vault: V, blockNumber: 2, logIndex: 0, args: { member: M, sharesMinted: 10n } },
+    { name: 'DepositActivated', vault: V, blockNumber: 3, logIndex: 0, args: { member: '0x' + '3'.repeat(40), sharesMinted: 5n } },
+  ]);
+  const c = countState(state);
+  assert.equal(c.vaults, 1);
+  assert.equal(c.shareBooks, 1);
+  assert.equal(c.holders, 2);
+});

--- a/packages/oplog/README.md
+++ b/packages/oplog/README.md
@@ -1,0 +1,26 @@
+# `oplog` — operational plumbing for the runtime stack
+
+Four small, dependency-free modules shared by the indexer, the API and the canary. Nothing here
+knows about vaults, chains or payments; it is the layer that makes those three processes
+*operable* by one person.
+
+| Module | What it gives you |
+|---|---|
+| [`src/logger.mjs`](src/logger.mjs) | JSON-lines logging (`ts`/`level`/`service`/`event` + fields), with a pretty mode when stdout is a TTY |
+| [`src/heartbeat.mjs`](src/heartbeat.mjs) | atomic `<service>.heartbeat.json` files, each stamped with the writer's own staleness budget |
+| [`src/ops-check.mjs`](src/ops-check.mjs) | reads those files, exits nonzero listing anything stale — cron job and compose healthcheck |
+| [`src/shutdown.mjs`](src/shutdown.mjs) | ordered, once-only SIGTERM hooks with a force-exit watchdog |
+
+No `package.json`: like every other package in this repo it is imported by relative path, which
+keeps `npm ci` and the root lockfile untouched. **No runtime dependency** — viem stays the only
+one in the tree, and none of these four modules import it.
+
+Operator-facing documentation (log format, backup/restore, rate limits, metrics, the incident
+table) lives in [docs/RUNTIME.md §8](../../docs/RUNTIME.md).
+
+```bash
+node packages/oplog/src/ops-check.mjs --dir=./data       # all three services
+node packages/oplog/src/ops-check.mjs indexer            # just one (what compose runs)
+```
+
+Tested by `packages/oplog/test/*.test.mjs`, included in `npm run test:backend`.

--- a/packages/oplog/src/durable.mjs
+++ b/packages/oplog/src/durable.mjs
@@ -1,0 +1,124 @@
+// @ts-check
+/**
+ * Durable state files: atomic write (already the rule here) plus a rotating backup ring.
+ *
+ * Atomicity stops a CRASH from truncating a file. It does nothing about the other way state dies:
+ * a write that succeeds and is wrong — a bad fold, a half-migrated schema, a disk that returned
+ * success and lied. By the time anyone notices, the good state has been overwritten dozens of
+ * times. The ring keeps N older copies so the answer to "restore from what?" is not "re-index from
+ * the deploy block".
+ *
+ * Two rules the implementation exists to honour:
+ *
+ *  - **`path` never blinks out of existence.** The current file is COPIED to `.1`, never renamed
+ *    there. The API reloads the snapshot on a timer; a reader that found it missing would drop to
+ *    stale-state serving for no reason at all.
+ *  - **Backups are spaced by TIME, not by write.** The indexer snapshots every batch — every 12s
+ *    at the default poll, and far faster during a cold-start catch-up. Rotating per write would
+ *    give a 36-second backup horizon (useless: corruption is noticed minutes later) and turn
+ *    catch-up into a copy-per-batch hot loop. `backupIntervalMs` decouples the two.
+ */
+
+import { writeFile, rename, mkdir, copyFile, stat, rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/** `state.json` → `state.json.1` (1 = most recent backup). */
+export function backupPath(path, n) {
+  return `${path}.${n}`;
+}
+
+async function statOrNull(p) {
+  try {
+    return await stat(p);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * Shift the ring and copy the current file into slot 1. No-op (returns false) when backups are
+ * disabled or there is nothing to back up yet.
+ * @returns {Promise<boolean>} whether a backup was taken
+ */
+export async function rotateBackups(path, keep) {
+  if (!(keep > 0)) return false;
+  if (!(await statOrNull(path))) return false;
+  await rm(backupPath(path, keep), { force: true });        // drop the oldest
+  for (let n = keep - 1; n >= 1; n -= 1) {                  // .2 → .3, .1 → .2
+    if (await statOrNull(backupPath(path, n))) await rename(backupPath(path, n), backupPath(path, n + 1));
+  }
+  await copyFile(path, backupPath(path, 1));                // copy, never rename — see the header
+  return true;
+}
+
+/** Write-temp-then-rename, creating the directory. The repo's existing snapshot discipline. */
+export async function atomicWriteFile(path, text) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, text, 'utf8');
+  await rename(tmp, path);
+}
+
+/**
+ * What is actually on disk right now, newest first. Used by the `verify` subcommands so an
+ * operator picking a file to restore can see sizes and ages instead of guessing.
+ */
+export async function listBackups(path, keep = 5) {
+  const out = [];
+  for (let n = 1; n <= keep; n += 1) {
+    const p = backupPath(path, n);
+    const st = await statOrNull(p);
+    if (st) out.push({ n, path: p, bytes: st.size, mtimeMs: st.mtimeMs, mtime: new Date(st.mtimeMs).toISOString() });
+  }
+  return out;
+}
+
+/**
+ * An atomic writer with a time-spaced backup ring.
+ *
+ * @param {Object} p
+ * @param {string} p.path
+ * @param {number} [p.backups]            ring size; 0 disables backups entirely
+ * @param {number} [p.backupIntervalMs]   minimum wall-clock spacing between backups
+ * @param {() => number} [p.now]
+ * @param {(o:any)=>string} [p.serialize]
+ */
+export function createRotatingWriter({ path, backups = 0, backupIntervalMs = 0, now = () => Date.now(), serialize = (o) => JSON.stringify(o) }) {
+  let lastBackupAt = -Infinity;
+  let backupCount = 0;
+
+  return {
+    path,
+    get lastBackupAt() { return lastBackupAt; },
+    get backupCount() { return backupCount; },
+    /** @returns {Promise<{backedUp:boolean}>} */
+    async write(obj) {
+      const t = now();
+      let backedUp = false;
+      if (backups > 0 && t - lastBackupAt >= backupIntervalMs) {
+        // On the very first write `path` does not exist yet, so this is a no-op and lastBackupAt
+        // stays unset — the FIRST real snapshot gets captured by the next write rather than being
+        // skipped for a whole interval.
+        backedUp = await rotateBackups(path, backups);
+        if (backedUp) { lastBackupAt = t; backupCount += 1; }
+      }
+      await atomicWriteFile(path, serialize(obj));
+      return { backedUp };
+    },
+  };
+}
+
+/**
+ * Resolve the durability knobs shared by the indexer and the canary. One pair of env vars for both
+ * — compose feeds them a single .env, and two spellings of the same policy is a trap.
+ * @param {Record<string,string|undefined>} [env]
+ */
+export function resolveDurabilityOptions(env = {}) {
+  const num = (k, d) => (env[k] != null && env[k] !== '' ? Number(env[k]) : d);
+  const backups = num('SNAPSHOT_BACKUPS', 3);
+  const backupIntervalMs = num('SNAPSHOT_BACKUP_INTERVAL_MS', 300_000);
+  if (!Number.isInteger(backups) || backups < 0) throw new Error(`oplog: SNAPSHOT_BACKUPS must be a non-negative integer, got '${env.SNAPSHOT_BACKUPS}'`);
+  if (!Number.isFinite(backupIntervalMs) || backupIntervalMs < 0) throw new Error(`oplog: SNAPSHOT_BACKUP_INTERVAL_MS must be a non-negative number, got '${env.SNAPSHOT_BACKUP_INTERVAL_MS}'`);
+  return { backups, backupIntervalMs };
+}

--- a/packages/oplog/src/heartbeat.mjs
+++ b/packages/oplog/src/heartbeat.mjs
@@ -1,0 +1,93 @@
+// @ts-check
+/**
+ * Heartbeat files — how a service proves it is alive to something that is not itself.
+ *
+ * Each runtime process writes `<dir>/<service>.heartbeat.json` on every successful work cycle.
+ * `ops-check.mjs` reads them and fails when one goes stale. A crashed process stops writing; a
+ * WEDGED process — the one a `restart: unless-stopped` policy never notices — also stops writing,
+ * which is the failure this exists to catch.
+ *
+ * The writer stamps its OWN `staleAfterMs`, because only the writer knows its cadence: the API
+ * reloads every 5s, the indexer polls every 12s, the canary sweeps every 30s. The checker uses
+ * that hint, so nobody has to keep three thresholds in sync by hand.
+ *
+ * Written with the same write-temp-then-rename discipline as the snapshot: a reader must never
+ * see a torn heartbeat and conclude a healthy service is broken.
+ */
+
+import { writeFile, readFile, rename, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/** Where a service's heartbeat lives. One directory for the whole stack (the shared volume). */
+export function heartbeatPath(dir, service) {
+  return join(dir, `${service}.heartbeat.json`);
+}
+
+/**
+ * The default heartbeat directory: alongside the snapshot, so the shared volume that already
+ * carries indexer state carries the heartbeats too and no new mount is needed.
+ * @param {Record<string,string|undefined>} [env]
+ */
+export function defaultHeartbeatDir(env = {}) {
+  return env.HEARTBEAT_DIR || dirname(env.STATE_PATH || './data/indexer-state.json');
+}
+
+export async function writeHeartbeatFile(path, rec) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(rec), 'utf8');
+  await rename(tmp, path);
+}
+
+/** Read one heartbeat. Absent file → null (a service that has never started, not an error). */
+export async function readHeartbeatFile(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * A per-service heartbeat writer.
+ *
+ * `beat()` never rejects: a full disk must not take down the indexer, and the resulting silence
+ * is itself the alarm — ops-check sees the stale file either way. Failures go to `onError`.
+ *
+ * @param {Object} p
+ * @param {string} p.dir
+ * @param {string} p.service
+ * @param {number} p.staleAfterMs      how long this service's own silence is tolerable
+ * @param {number} [p.minIntervalMs]   floor between writes (a cold-start catch-up loop can tick fast)
+ * @param {() => number} [p.now]
+ * @param {number} [p.pid]
+ * @param {(path:string, rec:object)=>Promise<void>} [p.write]
+ * @param {(err:any)=>void} [p.onError]
+ */
+export function createHeartbeat({
+  dir, service, staleAfterMs, minIntervalMs = 0,
+  now = () => Date.now(), pid = process.pid,
+  write = writeHeartbeatFile, onError = () => {},
+}) {
+  const path = heartbeatPath(dir, service);
+  let lastAt = -Infinity;
+
+  return {
+    path,
+    service,
+    /** @returns {Promise<boolean>} true iff a file was written this call. */
+    async beat(detail = {}, { force = false } = {}) {
+      const ts = now();
+      if (!force && ts - lastAt < minIntervalMs) return false;
+      try {
+        await write(path, { service, ts, iso: new Date(ts).toISOString(), pid, staleAfterMs, detail });
+        lastAt = ts;
+        return true;
+      } catch (err) {
+        onError(err);
+        return false;
+      }
+    },
+  };
+}

--- a/packages/oplog/src/logger.mjs
+++ b/packages/oplog/src/logger.mjs
@@ -1,0 +1,108 @@
+// @ts-check
+/**
+ * The one logger for the runtime stack (indexer, API, canary).
+ *
+ * Two rendering modes over the SAME record, so nothing is lost by choosing one:
+ *   json    — one JSON object per line: {ts, level, service, event, ...fields}. The production
+ *             mode. Every line is greppable and machine-parseable without a log shipper.
+ *   pretty  — a human line for a terminal. Auto-selected when stdout is a TTY, so `npm run
+ *             start:indexer` in a shell stays readable and the same command under Docker (no TTY)
+ *             emits JSON. Override either way with LOG_FORMAT=json|pretty.
+ *
+ * No dependency, by design: this repo's only runtime dependency is viem and it stays that way.
+ * `warn`/`error` go to stderr and everything else to stdout, so `2>` gives a pure problem feed —
+ * the same split the canary's console sink already relies on.
+ */
+
+const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 };
+
+/** JSON.stringify replacer: bigints as decimal strings (state is full of them), Errors as objects. */
+function replacer(_k, v) {
+  if (typeof v === 'bigint') return v.toString();
+  if (v instanceof Error) return { name: v.name, message: v.message };
+  return v;
+}
+
+/** One JSON line. Never throws — a log call must not be the thing that kills a service. */
+export function formatJson(rec) {
+  try {
+    return JSON.stringify(rec, replacer);
+  } catch (err) {
+    return JSON.stringify({ ts: rec?.ts, level: rec?.level, service: rec?.service, event: rec?.event, logError: String(err?.message ?? err) });
+  }
+}
+
+function scalar(v) {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'bigint') return v.toString();
+  if (typeof v === 'object') return formatJson(v);
+  const s = String(v);
+  return /[\s"]/.test(s) ? JSON.stringify(s) : s;
+}
+
+/** `12:03:22.123 INFO  indexer batch.indexed  from=1 to=99 events=3` */
+export function formatPretty(rec) {
+  const { ts, level, service, event, ...fields } = rec;
+  const kv = Object.entries(fields).map(([k, v]) => `${k}=${scalar(v)}`).join(' ');
+  return `${String(ts).slice(11, 23)} ${String(level).toUpperCase().padEnd(5)} ${String(service).padEnd(7)} ${event}${kv ? `  ${kv}` : ''}`;
+}
+
+/**
+ * Resolve format + level from env. Pure, so the TTY probe stays at the edge.
+ * @param {Record<string,string|undefined>} [env]
+ * @param {{isTTY?:boolean}} [io]
+ */
+export function resolveLogOptions(env = {}, { isTTY = false } = {}) {
+  const fmt = String(env.LOG_FORMAT ?? '').toLowerCase();
+  const lvl = String(env.LOG_LEVEL ?? '').toLowerCase();
+  if (fmt && fmt !== 'json' && fmt !== 'pretty') throw new Error(`oplog: LOG_FORMAT must be 'json' or 'pretty', got '${fmt}'`);
+  if (lvl && !(lvl in LEVELS)) throw new Error(`oplog: LOG_LEVEL must be one of ${Object.keys(LEVELS).join('|')}, got '${lvl}'`);
+  return { pretty: fmt ? fmt === 'pretty' : Boolean(isTTY), level: lvl || 'info' };
+}
+
+/**
+ * @param {Object} [p]
+ * @param {string} [p.service]   the emitting process: 'indexer' | 'api' | 'canary'
+ * @param {string} [p.level]     minimum level to emit
+ * @param {boolean} [p.pretty]   human mode instead of JSON lines
+ * @param {Record<string,any>} [p.base]  fields merged into every record (see `child`)
+ * @param {(line:string)=>void} [p.write]       stdout sink
+ * @param {(line:string)=>void} [p.errorWrite]  stderr sink (warn + error)
+ * @param {() => Date} [p.now]
+ */
+export function createLogger({
+  service = 'app', level = 'info', pretty = false, base = {},
+  write = (l) => process.stdout.write(`${l}\n`),
+  errorWrite = (l) => process.stderr.write(`${l}\n`),
+  now = () => new Date(),
+} = {}) {
+  let threshold = LEVELS[level] ?? LEVELS.info;
+
+  function emit(lv, event, fields) {
+    if (LEVELS[lv] < threshold) return null;
+    const rec = { ts: now().toISOString(), level: lv, service, event, ...base, ...(fields || {}) };
+    (LEVELS[lv] >= LEVELS.warn ? errorWrite : write)(pretty ? formatPretty(rec) : formatJson(rec));
+    return rec;
+  }
+
+  const api = {
+    get level() { return Object.keys(LEVELS).find((k) => LEVELS[k] === threshold); },
+    get service() { return service; },
+    debug: (event, fields) => emit('debug', event, fields),
+    info: (event, fields) => emit('info', event, fields),
+    warn: (event, fields) => emit('warn', event, fields),
+    error: (event, fields) => emit('error', event, fields),
+    /** A logger carrying extra fields on every line (e.g. a vault, a request id). */
+    child: (extra) => createLogger({ service, level: api.level, pretty, base: { ...base, ...extra }, write, errorWrite, now }),
+    /** Adapter for the pre-existing `log(msg)` string callbacks (daemon, canary sinks). */
+    text: (event, lv = 'info') => (msg) => emit(lv, event, { msg: String(msg) }),
+  };
+  return api;
+}
+
+/** The stack's standard logger: env-configured, TTY-aware. */
+export function loggerFromEnv(service, env = process.env, opts = {}) {
+  const { isTTY = Boolean(process.stdout.isTTY), ...rest } = opts;
+  const { pretty, level } = resolveLogOptions(env, { isTTY });
+  return createLogger({ service, pretty, level, ...rest });
+}

--- a/packages/oplog/src/ops-check.mjs
+++ b/packages/oplog/src/ops-check.mjs
@@ -1,0 +1,141 @@
+// @ts-check
+/**
+ * ops-check — watch the watchers.
+ *
+ * Reads every service's heartbeat file and exits NONZERO listing any service whose heartbeat is
+ * missing, stale, unreadable, or dated in the future (a clock problem is also an ops problem).
+ * Exit 0 and one line per service otherwise.
+ *
+ * Two jobs, one script:
+ *   cron           `*./5 * * * *  node packages/oplog/src/ops-check.mjs || mail -s 'vault stack' …`
+ *   compose        each service healthchecks ITSELF: `ops-check.mjs indexer`
+ *
+ * Restricting the compose healthcheck to one service is deliberate. A whole-stack check inside the
+ * indexer container would mark the indexer unhealthy because the CANARY died, and Docker would
+ * restart the wrong process. The cron form, which checks all three, is where cross-service
+ * coverage belongs.
+ *
+ * `staleAfterMs` comes from each heartbeat file — the writer knows its own cadence. `--max-age-ms`
+ * overrides it for every service when you want one blunt threshold.
+ *
+ * Uses Node built-ins only: no curl, no wget (node:24-slim ships neither).
+ *
+ * Run: `node packages/oplog/src/ops-check.mjs [--dir=/data] [--max-age-ms=N] [service…]`
+ */
+
+import { fileURLToPath } from 'node:url';
+import { heartbeatPath, readHeartbeatFile, defaultHeartbeatDir } from './heartbeat.mjs';
+
+export const DEFAULT_SERVICES = ['indexer', 'api', 'canary'];
+export const DEFAULT_MAX_AGE_MS = 120_000;
+/** Tolerance for a heartbeat stamped in the future before we call it a clock problem. */
+const FUTURE_SLACK_MS = 60_000;
+
+/**
+ * Classify one service from its heartbeat record. Pure — the whole decision is here.
+ * @param {string} service
+ * @param {any} rec  parsed heartbeat, or null when the file is absent
+ * @param {{nowMs:number, defaultMaxAgeMs?:number, maxAgeMs?:number|null}} opts
+ */
+export function evaluateHeartbeat(service, rec, { nowMs, defaultMaxAgeMs = DEFAULT_MAX_AGE_MS, maxAgeMs = null }) {
+  const row = { service, ok: false, state: 'missing', ageMs: null, limitMs: null, detail: '' };
+  if (rec == null) return { ...row, detail: 'no heartbeat file — service has never started, or the directory is wrong' };
+
+  // `Number(null)` is 0, which would read as a heartbeat from 1970 — i.e. merely "stale".
+  // A heartbeat we cannot date is UNREADABLE: a different fault with a different fix.
+  const ts = rec.ts == null ? NaN : Number(rec.ts);
+  if (!Number.isFinite(ts)) return { ...row, state: 'unreadable', detail: `heartbeat has no usable ts (got ${JSON.stringify(rec.ts)})` };
+
+  // Precedence: explicit override → the writer's own hint → the blunt default.
+  const hinted = Number(rec.staleAfterMs);
+  const limitMs = maxAgeMs != null ? maxAgeMs : (Number.isFinite(hinted) && hinted > 0 ? hinted : defaultMaxAgeMs);
+  const ageMs = nowMs - ts;
+
+  if (ageMs < -FUTURE_SLACK_MS)
+    return { ...row, state: 'future', ageMs, limitMs, detail: `heartbeat is ${Math.round(-ageMs / 1000)}s in the FUTURE — check clock skew between the checker and ${service}` };
+  if (ageMs > limitMs)
+    return { ...row, state: 'stale', ageMs, limitMs, detail: `last beat ${Math.round(ageMs / 1000)}s ago, limit ${Math.round(limitMs / 1000)}s — ${service} is down or wedged` };
+
+  return { service, ok: true, state: 'fresh', ageMs, limitMs, detail: describe(rec) };
+}
+
+function describe(rec) {
+  const d = rec.detail && typeof rec.detail === 'object' ? rec.detail : {};
+  const kv = Object.entries(d).map(([k, v]) => `${k}=${typeof v === 'object' ? JSON.stringify(v) : v}`).join(' ');
+  return `pid=${rec.pid ?? '?'}${kv ? ` ${kv}` : ''}`;
+}
+
+/**
+ * Check a set of services. `read` is injected so tests need no filesystem.
+ * @param {{dir:string, services?:string[], nowMs?:number, defaultMaxAgeMs?:number, maxAgeMs?:number|null, read?:(p:string)=>Promise<any>}} p
+ */
+export async function checkServices({ dir, services = DEFAULT_SERVICES, nowMs = Date.now(), defaultMaxAgeMs = DEFAULT_MAX_AGE_MS, maxAgeMs = null, read = readHeartbeatFile }) {
+  const rows = [];
+  for (const service of services) {
+    try {
+      rows.push(evaluateHeartbeat(service, await read(heartbeatPath(dir, service)), { nowMs, defaultMaxAgeMs, maxAgeMs }));
+    } catch (err) {
+      // A corrupt or unreadable file is a failure, not a crash: the other services still get checked.
+      rows.push({ service, ok: false, state: 'unreadable', ageMs: null, limitMs: null, detail: String(err?.message ?? err) });
+    }
+  }
+  return { ok: rows.every((r) => r.ok), rows, dir, nowMs };
+}
+
+/** Render a report. Failures first — the reason you ran this is at the top. */
+export function formatReport(report) {
+  const line = (r) => `${r.ok ? 'ok  ' : 'FAIL'} ${r.service.padEnd(8)} ${r.state.padEnd(10)} ${r.ageMs == null ? 'age=-' : `age=${Math.round(r.ageMs / 1000)}s`}  ${r.detail}`;
+  const bad = report.rows.filter((r) => !r.ok);
+  const good = report.rows.filter((r) => r.ok);
+  const head = report.ok
+    ? `ops-check: ${good.length}/${report.rows.length} healthy (heartbeats in ${report.dir})`
+    : `ops-check: ${bad.length} of ${report.rows.length} service(s) UNHEALTHY: ${bad.map((r) => `${r.service}(${r.state})`).join(', ')}`;
+  return [head, ...bad.map(line), ...good.map(line)].join('\n');
+}
+
+/**
+ * Parse argv/env into check options. Pure.
+ * @param {string[]} argv  args AFTER the script path
+ * @param {Record<string,string|undefined>} [env]
+ */
+export function parseArgs(argv, env = {}) {
+  let dir = env.HEARTBEAT_DIR || defaultHeartbeatDir(env);
+  let maxAgeMs = env.HEARTBEAT_MAX_AGE_MS ? Number(env.HEARTBEAT_MAX_AGE_MS) : null;
+  const services = [];
+  for (const a of argv) {
+    if (a.startsWith('--dir=')) dir = a.slice(6);
+    else if (a.startsWith('--max-age-ms=')) maxAgeMs = Number(a.slice(13));
+    else if (a === '--help' || a === '-h') return { help: true, dir, maxAgeMs, services: DEFAULT_SERVICES };
+    else if (a.startsWith('-')) throw new Error(`ops-check: unknown flag ${a}`);
+    else services.push(a);
+  }
+  if (maxAgeMs != null && !Number.isFinite(maxAgeMs)) throw new Error('ops-check: max-age-ms must be a number');
+  const listed = services.length ? services : (env.OPS_CHECK_SERVICES ? env.OPS_CHECK_SERVICES.split(',').map((s) => s.trim()).filter(Boolean) : DEFAULT_SERVICES);
+  return { help: false, dir, maxAgeMs, services: listed };
+}
+
+const USAGE = `ops-check — exit nonzero if any service heartbeat is stale.
+
+  node packages/oplog/src/ops-check.mjs [--dir=<heartbeat dir>] [--max-age-ms=<n>] [service...]
+
+  --dir           default: HEARTBEAT_DIR, else dirname(STATE_PATH), else ./data
+  --max-age-ms    override every service's own staleAfterMs hint
+  service...      default: indexer api canary (or OPS_CHECK_SERVICES)`;
+
+// -- entrypoint --
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  try {
+    const opts = parseArgs(process.argv.slice(2), process.env);
+    if (opts.help) {
+      console.log(USAGE);
+      process.exit(0);
+    }
+    const report = await checkServices({ dir: opts.dir, services: opts.services, maxAgeMs: opts.maxAgeMs });
+    (report.ok ? console.log : console.error)(formatReport(report));
+    process.exit(report.ok ? 0 : 1);
+  } catch (err) {
+    console.error(`ops-check: ${err?.message ?? err}`);
+    process.exit(2);
+  }
+}

--- a/packages/oplog/src/shutdown.mjs
+++ b/packages/oplog/src/shutdown.mjs
@@ -1,0 +1,85 @@
+// @ts-check
+/**
+ * Graceful shutdown: run a list of named hooks on SIGTERM/SIGINT, then exit.
+ *
+ * `docker compose down`, a rolling restart and a Ctrl-C all deliver a signal and then wait a
+ * bounded time before SIGKILL. Without a handler the default action is immediate termination —
+ * the indexer loses the batch it was folding, the API cuts live responses mid-body, and the canary
+ * drops the transitions it had just detected. Each hook here closes exactly one of those gaps.
+ *
+ * Guarantees:
+ *  - hooks run ONCE, in registration order, sequentially;
+ *  - a hook that throws is logged and does not stop the ones after it (a failed snapshot must
+ *    still let the API drain);
+ *  - a SECOND signal exits immediately — the "I meant it" escape hatch, so an operator is never
+ *    stuck waiting on a hook that is itself wedged;
+ *  - a `timeoutMs` watchdog force-exits if the hooks never finish, so the process cannot outlive
+ *    its own shutdown and sit there until SIGKILL.
+ *
+ * `proc` and `exit` are injected, which is how this is tested with no real signals (see
+ * test/shutdown.test.mjs) — a fake EventEmitter stands in for `process`.
+ */
+
+/**
+ * @param {Object} [p]
+ * @param {{info?:Function, warn?:Function, error?:Function}} [p.log]
+ * @param {{on:Function}} [p.proc]
+ * @param {string[]} [p.signals]
+ * @param {number} [p.timeoutMs]
+ * @param {(code:number)=>void} [p.exit]
+ */
+export function createShutdown({
+  log = {}, proc = process, signals = ['SIGTERM', 'SIGINT'], timeoutMs = 15_000,
+  exit = (code) => process.exit(code),
+} = {}) {
+  /** @type {{name:string, fn:(reason:string)=>any}[]} */
+  const hooks = [];
+  let state = 'idle';
+  /** @type {Promise<void>|null} */
+  let running = null;
+
+  async function drain(reason) {
+    for (const h of hooks) {
+      try {
+        await h.fn(reason);
+        log.info?.('shutdown.step', { step: h.name, ok: true });
+      } catch (err) {
+        log.error?.('shutdown.step', { step: h.name, ok: false, error: String(err?.message ?? err) });
+      }
+    }
+  }
+
+  /** Begin (or, on a repeat signal, abandon) shutdown. Resolves when the hooks are done. */
+  function trigger(reason = 'manual') {
+    if (state !== 'idle') {
+      log.warn?.('shutdown.forced', { reason, state });
+      exit(1);
+      return running ?? Promise.resolve();
+    }
+    state = 'running';
+    log.info?.('shutdown.begin', { reason, hooks: hooks.length, timeoutMs });
+    const watchdog = setTimeout(() => {
+      log.error?.('shutdown.timeout', { reason, timeoutMs });
+      exit(1);
+    }, timeoutMs);
+    if (typeof watchdog.unref === 'function') watchdog.unref();
+
+    running = drain(reason).then(() => {
+      clearTimeout(watchdog);
+      state = 'done';
+      log.info?.('shutdown.complete', { reason });
+      exit(0);
+    });
+    return running;
+  }
+
+  const api = {
+    /** Register a hook. Order matters: they run in the order registered. */
+    onShutdown(name, fn) { hooks.push({ name, fn }); return api; },
+    install() { for (const s of signals) proc.on(s, () => { trigger(s); }); return api; },
+    trigger,
+    get state() { return state; },
+    get hooks() { return hooks.map((h) => h.name); },
+  };
+  return api;
+}

--- a/packages/oplog/test/durable.test.mjs
+++ b/packages/oplog/test/durable.test.mjs
@@ -1,0 +1,157 @@
+// @ts-check
+/**
+ * The backup ring. The properties that matter are all about what an operator finds on disk AFTER
+ * something went wrong: the live file always present, the ring ordered newest-first, and backups
+ * spaced by time rather than by write so the horizon is useful.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, readFile, readdir, writeFile, stat } from 'node:fs/promises';
+import { createRotatingWriter, rotateBackups, atomicWriteFile, listBackups, backupPath, resolveDurabilityOptions } from '../src/durable.mjs';
+
+const tmp = () => mkdtemp(join(tmpdir(), 'durable-'));
+const read = (p) => readFile(p, 'utf8');
+
+test('atomicWriteFile creates the directory and leaves no .tmp behind', async () => {
+  const dir = await tmp();
+  try {
+    const p = join(dir, 'deep', 'state.json');
+    await atomicWriteFile(p, '{"a":1}');
+    assert.equal(await read(p), '{"a":1}');
+    assert.deepEqual(await readdir(join(dir, 'deep')), ['state.json']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the ring keeps N copies, newest at .1, and drops the oldest', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    let t = 0;
+    const w = createRotatingWriter({ path: p, backups: 2, backupIntervalMs: 0, now: () => (t += 1000) });
+    for (const v of ['v1', 'v2', 'v3', 'v4']) await w.write({ v });
+
+    assert.equal(JSON.parse(await read(p)).v, 'v4', 'live file is the newest write');
+    assert.equal(JSON.parse(await read(backupPath(p, 1))).v, 'v3');
+    assert.equal(JSON.parse(await read(backupPath(p, 2))).v, 'v2');
+    // v1 fell off the end: keep=2 means exactly two backups exist.
+    assert.equal((await listBackups(p, 5)).length, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the live file is never absent — it is COPIED to .1, not renamed', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    await atomicWriteFile(p, '{"v":"first"}');
+    // rotateBackups is the only window in which `path` could vanish; assert it survives.
+    assert.equal(await rotateBackups(p, 3), true);
+    assert.ok(await stat(p), 'live file still present after rotation');
+    assert.equal(await read(backupPath(p, 1)), '{"v":"first"}');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('backups are spaced by TIME, not by write — 12s snapshots do not shred the horizon', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    let t = 0;
+    const w = createRotatingWriter({ path: p, backups: 3, backupIntervalMs: 300_000, now: () => t });
+    // 100 writes 12s apart = 20 minutes: at a 5-minute interval that is ~4 backups taken,
+    // not 100 rotations.
+    for (let i = 0; i < 100; i += 1) { await w.write({ i }); t += 12_000; }
+    assert.equal(w.backupCount, 4);
+    const ring = await listBackups(p, 5);
+    assert.equal(ring.length, 3, 'ring size is still N');
+    // .1 is 5 minutes old, not 12 seconds old — that is the whole point.
+    assert.equal(JSON.parse(await read(backupPath(p, 1))).i, 75);
+    assert.equal(JSON.parse(await read(p)).i, 99);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the FIRST real state is captured, not skipped for a whole interval', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    let t = 0;
+    const w = createRotatingWriter({ path: p, backups: 2, backupIntervalMs: 300_000, now: () => t });
+    await w.write({ i: 1 });                 // no file yet → nothing to back up
+    assert.equal(w.backupCount, 0);
+    t += 1000;
+    await w.write({ i: 2 });                 // still inside the interval, but nothing was ever taken
+    assert.equal(w.backupCount, 1);
+    assert.equal(JSON.parse(await read(backupPath(p, 1))).i, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('backups: 0 disables the ring entirely (writes stay atomic)', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    const w = createRotatingWriter({ path: p, backups: 0, backupIntervalMs: 0 });
+    await w.write({ i: 1 });
+    await w.write({ i: 2 });
+    assert.deepEqual(await readdir(dir), ['state.json']);
+    assert.equal(await rotateBackups(p, 0), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('rotating before any file exists is a no-op, not a crash', async () => {
+  const dir = await tmp();
+  try {
+    assert.equal(await rotateBackups(join(dir, 'never-written.json'), 3), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('a corrupt live file is still backed up — the ring is bytes, not judgement', async () => {
+  // Rotation happens BEFORE the new write, so the ring holds prior states even if the current
+  // file is garbage. That is what makes restore-from-.1 possible after a bad write.
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    await writeFile(p, '{ truncated', 'utf8');
+    const w = createRotatingWriter({ path: p, backups: 1, backupIntervalMs: 0 });
+    await w.write({ good: true });
+    assert.equal(await read(backupPath(p, 1)), '{ truncated');
+    assert.equal(JSON.parse(await read(p)).good, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('listBackups reports size and mtime, newest first, skipping gaps', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'state.json');
+  try {
+    await writeFile(backupPath(p, 1), 'aa', 'utf8');
+    await writeFile(backupPath(p, 3), 'bbbb', 'utf8');
+    const ring = await listBackups(p, 3);
+    assert.deepEqual(ring.map((b) => [b.n, b.bytes]), [[1, 2], [3, 4]]);
+    assert.ok(ring[0].mtime.endsWith('Z'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveDurabilityOptions: defaults, overrides, and rejected nonsense', () => {
+  assert.deepEqual(resolveDurabilityOptions({}), { backups: 3, backupIntervalMs: 300_000 });
+  assert.deepEqual(resolveDurabilityOptions({ SNAPSHOT_BACKUPS: '0', SNAPSHOT_BACKUP_INTERVAL_MS: '60000' }), { backups: 0, backupIntervalMs: 60_000 });
+  assert.throws(() => resolveDurabilityOptions({ SNAPSHOT_BACKUPS: '-1' }), /non-negative integer/);
+  assert.throws(() => resolveDurabilityOptions({ SNAPSHOT_BACKUPS: 'three' }), /non-negative integer/);
+  assert.throws(() => resolveDurabilityOptions({ SNAPSHOT_BACKUP_INTERVAL_MS: 'soon' }), /non-negative number/);
+});

--- a/packages/oplog/test/heartbeat.test.mjs
+++ b/packages/oplog/test/heartbeat.test.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+/**
+ * Heartbeats: written atomically, throttled, self-describing (the writer stamps its own staleness
+ * budget), and never fatal to the service that emits them.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { rm, mkdtemp, readdir } from 'node:fs/promises';
+import { createHeartbeat, heartbeatPath, readHeartbeatFile, writeHeartbeatFile, defaultHeartbeatDir } from '../src/heartbeat.mjs';
+
+const tmp = () => mkdtemp(join(tmpdir(), 'hb-'));
+
+test('heartbeatPath / defaultHeartbeatDir', () => {
+  assert.equal(heartbeatPath('/data', 'indexer'), join('/data', 'indexer.heartbeat.json'));
+  assert.equal(defaultHeartbeatDir({ HEARTBEAT_DIR: '/hb' }), '/hb');
+  assert.equal(defaultHeartbeatDir({ STATE_PATH: '/data/indexer-state.json' }), dirname('/data/indexer-state.json'));
+  assert.equal(defaultHeartbeatDir({}), dirname('./data/indexer-state.json'));
+});
+
+test('beat() writes a readable record round-trip, creating the directory', async () => {
+  const dir = join(await tmp(), 'nested');
+  try {
+    const hb = createHeartbeat({ dir, service: 'indexer', staleAfterMs: 36_000, now: () => 1_700_000_000_000, pid: 4242 });
+    assert.equal(await hb.beat({ lastBlock: 99 }), true);
+    const rec = await readHeartbeatFile(hb.path);
+    assert.equal(rec.service, 'indexer');
+    assert.equal(rec.ts, 1_700_000_000_000);
+    assert.equal(rec.pid, 4242);
+    assert.equal(rec.staleAfterMs, 36_000);
+    assert.deepEqual(rec.detail, { lastBlock: 99 });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('the write is atomic: no .tmp is left behind for a reader to trip over', async () => {
+  const dir = await tmp();
+  try {
+    await writeHeartbeatFile(heartbeatPath(dir, 'api'), { service: 'api', ts: 1 });
+    assert.deepEqual(await readdir(dir), ['api.heartbeat.json']);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('minIntervalMs throttles a fast loop, and force bypasses it', async () => {
+  const writes = [];
+  let t = 0;
+  const hb = createHeartbeat({
+    dir: '/x', service: 'indexer', staleAfterMs: 1000, minIntervalMs: 5000,
+    now: () => t, write: async (p, r) => { writes.push(r.ts); },
+  });
+  assert.equal(await hb.beat(), true);      // first always writes
+  t = 1000;
+  assert.equal(await hb.beat(), false);     // too soon
+  assert.equal(await hb.beat({}, { force: true }), true);
+  t = 9000;
+  assert.equal(await hb.beat(), true);
+  assert.deepEqual(writes, [0, 1000, 9000]);
+});
+
+test('a failing write is reported, not thrown — a full disk must not kill the indexer', async () => {
+  const seen = [];
+  const hb = createHeartbeat({
+    dir: '/x', service: 'canary', staleAfterMs: 1,
+    write: async () => { throw new Error('ENOSPC'); },
+    onError: (e) => seen.push(e.message),
+  });
+  assert.equal(await hb.beat(), false);
+  assert.deepEqual(seen, ['ENOSPC']);
+});
+
+test('a throttled beat that fails does not poison the throttle clock', async () => {
+  let fail = true;
+  let t = 0;
+  const writes = [];
+  const hb = createHeartbeat({
+    dir: '/x', service: 'api', staleAfterMs: 1, minIntervalMs: 1000, now: () => t,
+    write: async (p, r) => { if (fail) throw new Error('nope'); writes.push(r.ts); },
+    onError: () => {},
+  });
+  assert.equal(await hb.beat(), false);
+  fail = false;
+  // Still inside minIntervalMs, but the failed attempt never counted — the retry writes.
+  t = 10;
+  assert.equal(await hb.beat(), true);
+  assert.deepEqual(writes, [10]);
+});
+
+test('readHeartbeatFile: absent file is null, not an error', async () => {
+  assert.equal(await readHeartbeatFile(join(tmpdir(), 'definitely-not-here.heartbeat.json')), null);
+});

--- a/packages/oplog/test/logger.test.mjs
+++ b/packages/oplog/test/logger.test.mjs
@@ -1,0 +1,121 @@
+// @ts-check
+/**
+ * The logger's contract: one JSON object per line in production, a readable line on a TTY, the
+ * same record either way, warn/error split to stderr, and a log call that can never throw.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createLogger, formatJson, formatPretty, resolveLogOptions, loggerFromEnv } from '../src/logger.mjs';
+
+/** A logger writing into two arrays instead of the real streams. */
+function harness(opts = {}) {
+  const out = [];
+  const err = [];
+  let t = Date.UTC(2026, 7, 20, 12, 3, 22, 123);
+  const log = createLogger({
+    service: 'indexer', write: (l) => out.push(l), errorWrite: (l) => err.push(l),
+    now: () => new Date(t), ...opts,
+  });
+  return { log, out, err, advance: (ms) => { t += ms; } };
+}
+
+test('json mode emits one parseable line per call with ts/level/service/event', () => {
+  const { log, out } = harness();
+  log.info('batch.indexed', { from: 1, to: 99, events: 3 });
+  assert.equal(out.length, 1);
+  const rec = JSON.parse(out[0]);
+  assert.equal(rec.ts, '2026-08-20T12:03:22.123Z');
+  assert.equal(rec.level, 'info');
+  assert.equal(rec.service, 'indexer');
+  assert.equal(rec.event, 'batch.indexed');
+  assert.deepEqual([rec.from, rec.to, rec.events], [1, 99, 3]);
+  assert.ok(!out[0].includes('\n'), 'exactly one line');
+});
+
+test('warn and error go to stderr, info and debug to stdout', () => {
+  const { log, out, err } = harness({ level: 'debug' });
+  log.debug('d');
+  log.info('i');
+  log.warn('w');
+  log.error('e');
+  assert.deepEqual(out.map((l) => JSON.parse(l).event), ['d', 'i']);
+  assert.deepEqual(err.map((l) => JSON.parse(l).event), ['w', 'e']);
+});
+
+test('level threshold drops quieter records entirely', () => {
+  const { log, out, err } = harness({ level: 'warn' });
+  assert.equal(log.info('nope'), null);
+  log.error('yep');
+  assert.equal(out.length, 0);
+  assert.equal(err.length, 1);
+});
+
+test('bigints serialize as decimal strings (projection state is full of them)', () => {
+  const { log, out } = harness();
+  log.info('vault.seen', { totalShares: 123456789012345678901234567890n });
+  assert.equal(JSON.parse(out[0]).totalShares, '123456789012345678901234567890');
+});
+
+test('a circular field cannot take the process down — the line degrades instead', () => {
+  const { log, out } = harness();
+  const loop = { name: 'x' };
+  loop.self = loop;
+  assert.doesNotThrow(() => log.info('weird', { loop }));
+  const rec = JSON.parse(out[0]);
+  assert.equal(rec.event, 'weird');
+  assert.match(rec.logError, /circular|convert/i);
+});
+
+test('pretty mode renders a human line carrying the same fields', () => {
+  const { log, out } = harness({ pretty: true });
+  log.info('batch.indexed', { from: 1, to: 99 });
+  assert.equal(out[0], '12:03:22.123 INFO  indexer batch.indexed  from=1 to=99');
+});
+
+test('pretty mode quotes values containing whitespace so k=v stays parseable by eye', () => {
+  assert.match(formatPretty({ ts: '2026-08-20T00:00:00.000Z', level: 'warn', service: 'api', event: 'x', msg: 'two words' }), /msg="two words"/);
+});
+
+test('child() carries base fields onto every later record', () => {
+  const { log, out } = harness();
+  const vaultLog = log.child({ vault: '0xabc' });
+  vaultLog.info('signal.checked', { signal: 'nav-backing' });
+  const rec = JSON.parse(out[0]);
+  assert.equal(rec.vault, '0xabc');
+  assert.equal(rec.signal, 'nav-backing');
+  log.info('unrelated');
+  assert.equal(JSON.parse(out[1]).vault, undefined, 'parent is unaffected');
+});
+
+test('text() adapts the pre-existing log(msg) string callbacks', () => {
+  const { log, out, err } = harness();
+  log.text('indexer.progress')('indexed [1..99] — 3 events');
+  assert.equal(JSON.parse(out[0]).msg, 'indexed [1..99] — 3 events');
+  log.text('indexer.progress', 'warn')('heads up');
+  assert.equal(JSON.parse(err[0]).level, 'warn');
+});
+
+test('resolveLogOptions: TTY picks pretty, no TTY picks json, LOG_FORMAT overrides both', () => {
+  assert.deepEqual(resolveLogOptions({}, { isTTY: true }), { pretty: true, level: 'info' });
+  assert.deepEqual(resolveLogOptions({}, { isTTY: false }), { pretty: false, level: 'info' });
+  assert.equal(resolveLogOptions({ LOG_FORMAT: 'json' }, { isTTY: true }).pretty, false);
+  assert.equal(resolveLogOptions({ LOG_FORMAT: 'pretty' }, { isTTY: false }).pretty, true);
+  assert.equal(resolveLogOptions({ LOG_LEVEL: 'debug' }).level, 'debug');
+});
+
+test('resolveLogOptions rejects a typo instead of silently logging in the wrong mode', () => {
+  assert.throws(() => resolveLogOptions({ LOG_FORMAT: 'jsonl' }), /LOG_FORMAT must be/);
+  assert.throws(() => resolveLogOptions({ LOG_LEVEL: 'verbose' }), /LOG_LEVEL must be/);
+});
+
+test('loggerFromEnv wires service + env through', () => {
+  const out = [];
+  const log = loggerFromEnv('api', { LOG_FORMAT: 'json' }, { isTTY: true, write: (l) => out.push(l) });
+  log.info('listening', { port: 8402 });
+  assert.equal(JSON.parse(out[0]).service, 'api');
+});
+
+test('formatJson never throws on an unserializable record', () => {
+  const bad = { ts: 'x', level: 'info', service: 's', event: 'e', fn: () => {} };
+  assert.doesNotThrow(() => formatJson(bad));
+});

--- a/packages/oplog/test/ops-check.test.mjs
+++ b/packages/oplog/test/ops-check.test.mjs
@@ -1,0 +1,135 @@
+// @ts-check
+/**
+ * ops-check: the thing that notices a service stopped noticing. The interesting cases are all the
+ * ways a heartbeat can be untrustworthy — absent, stale, torn, or from a machine whose clock is wrong.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rm, mkdtemp, writeFile } from 'node:fs/promises';
+import { evaluateHeartbeat, checkServices, formatReport, parseArgs, DEFAULT_SERVICES, DEFAULT_MAX_AGE_MS } from '../src/ops-check.mjs';
+import { createHeartbeat } from '../src/heartbeat.mjs';
+
+const NOW = 1_700_000_000_000;
+const beat = (ts, staleAfterMs) => ({ service: 's', ts, pid: 7, staleAfterMs, detail: { lastBlock: 5 } });
+
+test('a recent heartbeat inside its own budget is fresh', () => {
+  const r = evaluateHeartbeat('indexer', beat(NOW - 10_000, 36_000), { nowMs: NOW });
+  assert.equal(r.ok, true);
+  assert.equal(r.state, 'fresh');
+  assert.equal(r.limitMs, 36_000);
+  assert.match(r.detail, /pid=7 lastBlock=5/);
+});
+
+test('the writer’s own staleAfterMs wins over the blunt default', () => {
+  // 60s old: stale against a 30s budget even though the 120s default would call it fine.
+  const r = evaluateHeartbeat('canary', beat(NOW - 60_000, 30_000), { nowMs: NOW });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'stale');
+  assert.match(r.detail, /limit 30s/);
+});
+
+test('--max-age-ms overrides the writer’s hint in both directions', () => {
+  assert.equal(evaluateHeartbeat('api', beat(NOW - 60_000, 30_000), { nowMs: NOW, maxAgeMs: 90_000 }).ok, true);
+  assert.equal(evaluateHeartbeat('api', beat(NOW - 60_000, 300_000), { nowMs: NOW, maxAgeMs: 10_000 }).ok, false);
+});
+
+test('a heartbeat with no usable hint falls back to the default budget', () => {
+  assert.equal(evaluateHeartbeat('api', beat(NOW - 10_000, undefined), { nowMs: NOW }).limitMs, DEFAULT_MAX_AGE_MS);
+  assert.equal(evaluateHeartbeat('api', beat(NOW - 10_000, 0), { nowMs: NOW }).limitMs, DEFAULT_MAX_AGE_MS);
+});
+
+test('a missing file is a failure, and says why an operator might see it', () => {
+  const r = evaluateHeartbeat('canary', null, { nowMs: NOW });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'missing');
+  assert.match(r.detail, /never started|directory/);
+});
+
+test('a heartbeat with no usable ts is unreadable, not silently fresh', () => {
+  for (const ts of [undefined, null, 'yesterday', NaN]) {
+    const r = evaluateHeartbeat('api', { service: 'api', ts }, { nowMs: NOW });
+    assert.equal(r.ok, false, `ts=${String(ts)}`);
+    assert.equal(r.state, 'unreadable');
+  }
+});
+
+test('a heartbeat from the future is flagged as clock skew, not accepted', () => {
+  const r = evaluateHeartbeat('indexer', beat(NOW + 600_000, 36_000), { nowMs: NOW });
+  assert.equal(r.ok, false);
+  assert.equal(r.state, 'future');
+  assert.match(r.detail, /clock skew/);
+  // A few seconds of skew is normal and must not page anyone.
+  assert.equal(evaluateHeartbeat('indexer', beat(NOW + 5_000, 36_000), { nowMs: NOW }).ok, true);
+});
+
+test('checkServices is red if ANY service is red, and keeps checking past a corrupt file', async () => {
+  const report = await checkServices({
+    dir: '/data', nowMs: NOW,
+    read: async (p) => {
+      if (p.includes('indexer')) return beat(NOW - 1000, 36_000);
+      if (p.includes('api')) throw new Error('EACCES');
+      return null; // canary
+    },
+  });
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.rows.map((r) => [r.service, r.state]), [
+    ['indexer', 'fresh'], ['api', 'unreadable'], ['canary', 'missing'],
+  ]);
+});
+
+test('checkServices is green only when every service is fresh', async () => {
+  const report = await checkServices({ dir: '/data', nowMs: NOW, read: async () => beat(NOW - 1000, 36_000) });
+  assert.equal(report.ok, true);
+  assert.equal(report.rows.length, DEFAULT_SERVICES.length);
+});
+
+test('the report leads with the failures', () => {
+  const report = { ok: false, dir: '/data', nowMs: NOW, rows: [
+    { service: 'indexer', ok: true, state: 'fresh', ageMs: 1000, limitMs: 36_000, detail: 'pid=1' },
+    { service: 'canary', ok: false, state: 'stale', ageMs: 600_000, limitMs: 90_000, detail: 'down or wedged' },
+  ] };
+  const lines = formatReport(report).split('\n');
+  assert.match(lines[0], /1 of 2 service\(s\) UNHEALTHY: canary\(stale\)/);
+  assert.match(lines[1], /^FAIL canary/);
+  assert.match(lines[2], /^ok {2}\s*indexer/);
+});
+
+test('a healthy report names the directory it looked in (the usual misconfiguration)', () => {
+  const head = formatReport({ ok: true, dir: '/data', nowMs: NOW, rows: [{ service: 'api', ok: true, state: 'fresh', ageMs: 0, limitMs: 1, detail: '' }] }).split('\n')[0];
+  assert.match(head, /1\/1 healthy \(heartbeats in \/data\)/);
+});
+
+test('parseArgs: flags, positional services, env fallbacks', () => {
+  assert.deepEqual(parseArgs([], {}), { help: false, dir: parseArgs([], {}).dir, maxAgeMs: null, services: DEFAULT_SERVICES });
+  assert.deepEqual(parseArgs(['--dir=/data', 'indexer'], {}).services, ['indexer']);
+  assert.equal(parseArgs(['--dir=/data'], {}).dir, '/data');
+  assert.equal(parseArgs(['--max-age-ms=5000'], {}).maxAgeMs, 5000);
+  assert.equal(parseArgs([], { HEARTBEAT_DIR: '/hb' }).dir, '/hb');
+  assert.equal(parseArgs([], { HEARTBEAT_MAX_AGE_MS: '77' }).maxAgeMs, 77);
+  assert.deepEqual(parseArgs([], { OPS_CHECK_SERVICES: 'api, canary' }).services, ['api', 'canary']);
+  assert.equal(parseArgs(['--help'], {}).help, true);
+});
+
+test('parseArgs rejects a typo rather than checking the wrong thing', () => {
+  assert.throws(() => parseArgs(['--durr=/data'], {}), /unknown flag/);
+  assert.throws(() => parseArgs(['--max-age-ms=soon'], {}), /must be a number/);
+});
+
+test('end to end on a real directory: a live beat passes, a hand-written stale one fails', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'opscheck-'));
+  try {
+    await createHeartbeat({ dir, service: 'indexer', staleAfterMs: 36_000 }).beat({ lastBlock: 12 });
+    await writeFile(join(dir, 'api.heartbeat.json'), JSON.stringify({ service: 'api', ts: Date.now() - 600_000, staleAfterMs: 15_000 }), 'utf8');
+    const report = await checkServices({ dir, services: ['indexer', 'api'] });
+    assert.equal(report.ok, false);
+    assert.equal(report.rows[0].state, 'fresh');
+    assert.equal(report.rows[1].state, 'stale');
+
+    // Only the indexer: a per-service healthcheck must not fail on a sibling's outage.
+    assert.equal((await checkServices({ dir, services: ['indexer'] })).ok, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/oplog/test/shutdown.test.mjs
+++ b/packages/oplog/test/shutdown.test.mjs
@@ -1,0 +1,101 @@
+// @ts-check
+/**
+ * Graceful shutdown, driven by a FAKE process emitter — real signals in a test runner are a way to
+ * kill the runner. What matters: hooks run once, in order, a thrower does not block the rest, a
+ * repeat signal exits immediately, and the watchdog fires when a hook wedges.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createShutdown } from '../src/shutdown.mjs';
+
+/** Stand-in for `process`: `.on(sig)` registers, `.emit(sig)` delivers. */
+function fakeProc() {
+  const ee = new EventEmitter();
+  return { on: (s, fn) => ee.on(s, fn), emit: (s) => ee.emit(s), ee };
+}
+
+function recorder() {
+  const lines = [];
+  const at = (lv) => (event, fields) => lines.push({ lv, event, ...fields });
+  return { log: { info: at('info'), warn: at('warn'), error: at('error') }, lines };
+}
+
+test('SIGTERM runs every hook in registration order, then exits 0', async () => {
+  const proc = fakeProc();
+  const codes = [];
+  const order = [];
+  const sd = createShutdown({ proc, exit: (c) => codes.push(c) })
+    .onShutdown('indexer.finish-batch', () => { order.push('batch'); })
+    .onShutdown('indexer.snapshot', () => { order.push('snapshot'); })
+    .install();
+
+  proc.emit('SIGTERM');
+  await sd.trigger('await');           // second call returns the in-flight promise
+  assert.deepEqual(order, ['batch', 'snapshot']);
+  assert.equal(sd.state, 'done');
+  assert.ok(codes.includes(0));
+});
+
+test('hooks are awaited: an async hook completes before exit', async () => {
+  const done = [];
+  const codes = [];
+  const sd = createShutdown({ proc: fakeProc(), exit: (c) => codes.push(c) })
+    .onShutdown('slow', async () => { await new Promise((r) => setTimeout(r, 5)); done.push('slow'); })
+    .onShutdown('after', () => { done.push('after'); });
+  await sd.trigger('SIGTERM');
+  assert.deepEqual(done, ['slow', 'after']);
+  assert.deepEqual(codes, [0]);
+});
+
+test('a hook that throws is logged and the later hooks still run', async () => {
+  const { log, lines } = recorder();
+  const ran = [];
+  const sd = createShutdown({ proc: fakeProc(), log, exit: () => {} })
+    .onShutdown('snapshot', () => { throw new Error('disk full'); })
+    .onShutdown('drain', () => { ran.push('drain'); });
+  await sd.trigger('SIGTERM');
+  assert.deepEqual(ran, ['drain'], 'a failed snapshot must not block the API drain');
+  const bad = lines.find((l) => l.event === 'shutdown.step' && l.ok === false);
+  assert.equal(bad.step, 'snapshot');
+  assert.match(bad.error, /disk full/);
+  assert.ok(lines.some((l) => l.event === 'shutdown.complete'));
+});
+
+test('hooks run exactly once even if the signal arrives twice', async () => {
+  const proc = fakeProc();
+  let runs = 0;
+  const codes = [];
+  const sd = createShutdown({ proc, exit: (c) => codes.push(c) })
+    .onShutdown('once', async () => { runs += 1; await new Promise((r) => setTimeout(r, 5)); })
+    .install();
+  proc.emit('SIGTERM');
+  proc.emit('SIGTERM');   // the "I meant it" second signal
+  await sd.trigger('drain');
+  assert.equal(runs, 1);
+  assert.ok(codes.includes(1), 'the repeat signal force-exits nonzero');
+});
+
+test('the watchdog force-exits when a hook never finishes', async () => {
+  const codes = [];
+  const { log, lines } = recorder();
+  const sd = createShutdown({ proc: fakeProc(), log, timeoutMs: 5, exit: (c) => codes.push(c) })
+    .onShutdown('wedged', () => new Promise(() => {}));
+  sd.trigger('SIGTERM');
+  await new Promise((r) => setTimeout(r, 30));
+  assert.deepEqual(codes, [1]);
+  assert.ok(lines.some((l) => l.event === 'shutdown.timeout'));
+  assert.equal(sd.state, 'running', 'still wedged — the watchdog exits, it does not pretend to finish');
+});
+
+test('install() subscribes to every configured signal', async () => {
+  const proc = fakeProc();
+  const fired = [];
+  const sd = createShutdown({ proc, signals: ['SIGTERM', 'SIGINT', 'SIGHUP'], exit: () => {} })
+    .onShutdown('note', (reason) => { fired.push(reason); })
+    .install();
+  proc.emit('SIGHUP');
+  await sd.trigger('drain');
+  assert.deepEqual(fired, ['SIGHUP'], 'the hook is told which signal caused it');
+  assert.deepEqual(sd.hooks, ['note']);
+});


### PR DESCRIPTION
Makes the off-chain stack (indexer, API, canary) operable by one person: run it, watch it, back it up, restore it, restart it safely. Zero-custody posture unchanged, contracts untouched, and **viem is still the only runtime dependency** — the new `packages/oplog` imports nothing.

## What landed

**1. Structured logging** — `packages/oplog/src/logger.mjs` (~100 lines, no dependency). One record, two renderings: JSON lines (`ts`/`level`/`service`/`event` + fields) for production, a human line when stdout is a TTY, `LOG_FORMAT` to force either. So `npm run start:indexer` in a shell is readable and the identical command under Docker emits JSON, with no flag to remember. `warn`/`error` to stderr so `2>` is a pure problem feed — the split the canary's console sink already relied on. Bigint-safe (the projection is full of them) and non-throwing: a circular field degrades the line rather than killing the service. Adopted by all three runners.

**2. Snapshot durability** — a rotating backup ring (`SNAPSHOT_BACKUPS=3`, `SNAPSHOT_BACKUP_INTERVAL_MS=300000`) on both state files, plus `verify` subcommands.

Two decisions worth reviewing:
- The live file is **copied** into `.1`, never renamed there. The API reloads it on a timer; a reader that found it missing would drop to stale-state serving for nothing.
- Backups are spaced by **time, not by write**. The indexer snapshots every batch — 12s at the default poll, far faster during cold-start catch-up — so a per-write ring would give a 36-second backup horizon (useless: corruption is noticed minutes later) and turn catch-up into a copy-per-batch hot loop.

`verify` runs **before** config resolution in both entrypoints, deliberately: whoever is verifying a snapshot after a crash has `RPC_URL` and four contract addresses set exactly never. It reports cursor, counts, and each backup's **own** cursor, so "restore from which rung?" is answerable at a glance.

**3. API hardening** — per-IP token bucket on the free routes; request/URL/header caps; `/metrics`.

The paid routes are **deliberately unlimited: x402 IS their rate limiter.** Every metered read costs the caller real USDC through a facilitator settlement, so flooding `/vaults` is a purchase, not a denial-of-service; an unpaid request returns 402 without a facilitator call, a state read or a disk touch. A test pins the metered routes as unlimited so nobody "fixes" it later.

`x-forwarded-for` is honoured only under `TRUST_PROXY`, off by default: it is client-spoofable, so trusting it without a proxy that overwrites it lets one attacker mint a fresh bucket per request. Both directions are documented, because RUNTIME.md tells operators to run behind a proxy where the opposite failure applies.

**On indexer lag**: the API has no RPC client by design and must not claim a blocks-behind figure it cannot know. It reports `vault_indexer_snapshot_age_seconds` — snapshot age, named for what it measures, which is the number that actually tells you the indexer stopped. A test asserts no `lag_blocks`/`blocks_behind` series ever appears.

**4. Watch the watchers** — each service writes `<service>.heartbeat.json`; `ops-check` exits nonzero listing anything stale. The heartbeat means *I am doing my job*, not *my process exists*: the API beats on a **successful** snapshot reload, the canary on a **successful** sweep, so a process that is up but has lost its snapshot or cannot reach the RPC goes stale rather than reporting itself healthy. Each file carries its own `staleAfterMs`, written by the service that knows its cadence, so no threshold is kept in sync by hand.

Compose healthchecks all three, each checking **only its own** heartbeat: a whole-stack check inside the indexer container would mark the indexer unhealthy because the canary died, and Docker would restart the wrong process. Cross-service coverage is the cron form. `node` is the only interpreter used — `node:24-slim` ships neither curl nor wget.

**5. Graceful shutdown** — `catchUp()` gained an optional signal, checked **between batches**. This is what makes SIGTERM honest for the indexer: a cold-start backlog is minutes of `tick()` calls, and without it the process ignored the signal for all of them and died by SIGKILL mid-fold. Since `tick()` already snapshots each batch, stopping between two of them makes "finishes the current batch and persists it" literal. The API drains (`closeIdleConnections` bounds the wait); the canary flushes its transition state, which is what stops a restart re-paging every standing alert. `stop_grace_period` is set per service so Docker waits for the hooks.

**6. `docs/RUNTIME.md` §8 Operations** — log format and the events worth grepping, heartbeats and `ops-check` (cron + compose forms), the backup ring with a step-by-step restore, rate limits and caps, the metrics table, safe restart, and a 14-row incident quick-table keyed by symptom.

## Bugs found and fixed on the way

- **`Number(null) === 0`**, so a heartbeat with `ts: null` classified as merely *stale* (a 1970 timestamp) instead of *unreadable* — a different fault with a different fix. Caught by a test.
- **Abort-listener leak** in both `sleep()` helpers: one listener attached per iteration, never removed. Invisible against the short-lived signals they previously saw; against a process-lifetime signal it is one listener per poll, forever. A test now runs ~100 sleeps on one signal and fails on `MaxListenersExceededWarning`.
- **A doc error caught by executing the runbook**: a clean shutdown takes a final snapshot, which can push the ring along by one, so "restore from `.1`" was not reliably true. The step now says to pick a rung by its printed cursor — which is why `verify` prints one per rung.
- **`/metrics` 429s against your own debugging curls** (found while smoke-testing §8). Correct per spec, but it bites at the worst moment; now documented with both fixes.

## Testing

`443 passing, 1 skipped` (was 328). node:test only, no external dependency, no network. `package-lock.json` untouched, so the backend job's `npm ci` stays clean — `packages/oplog` deliberately has **no** `package.json`, matching every other package here.

Two tests are worth a reviewer's attention:

- **`packages/indexer/test/restore.test.mjs`** executes the RUNTIME.md §8.3 restore procedure rather than asserting it in prose — a runbook nobody has run is a hypothesis. It corrupts a snapshot, verifies, keeps the bad file, copies a rung into place, re-verifies, restarts, and checks the indexer re-folds the gap into exactly the state that was lost, including a deposit that existed only in the destroyed snapshot's future.
- **`apps/api/test/signals.test.mjs`** spawns the real entrypoint and sends it a real SIGTERM — the one path unit tests cannot reach. **It skips on Windows** (`kill()` is `TerminateProcess`, so the handler cannot run and the test would assert a platform artifact), which means **this PR's CI run is its first real execution.** Its assertions were validated locally against real entrypoint output driven in-process, but the child-process exit path and the post-close `assert.rejects(fetch(...))` have not executed anywhere yet. If the backend job goes red, look there first.

CI also gains a check on `ops-check`'s **exit code** against a nonexistent directory — it is a cron job and a healthcheck, so the code is the contract: it must fail (1), not crash (2) and not pass. Verified locally in that exact shape.

## Verified by hand against a live API

429 with `retry-after` on a free route; ten unlimited 402s on a paid one; the metrics scrape; `ops-check` reporting one stale service out of three; `verify`'s backup listing; and the full SIGTERM hook sequence ending in `shutdown.complete` and exit 0 — all matching the samples in §8.

## Not done

`forge` and `docker` are unavailable in this shell, so the contract suite and `docker compose config` were not re-run locally. `contracts/` is untouched by this branch (verified against `protocol/main`), and CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
