### PR TITLE
Sprint 15 follow-up: battery re-run at the merged ref, and INCIDENTS §8 no longer reassures about open C-1

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,6 +140,14 @@ Then the creator registers governance config in a second tx:
 Child vaults use `createChildVault(params, parent)` — basket must be a subset of the parent's
 (same USDC), depth ≤ 3, stacked exit-fee ≤ 2.5%.
 
+> **Do not create a child vault on any live deployment right now.** Critical **C-1**
+> ([#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33)) is open: a child funded
+> only by its parent has an **empty electorate**, so one minimum deposit buys sole governance
+> control — and capture equals drain, because `minAmountOut` is proposer-supplied. `createChildVault`
+> is also unauthorized on `parent` (L-1), so *anyone* can attach one. Root vaults only until #33 is
+> remediated and re-reviewed — see [LAUNCH-READINESS.md](LAUNCH-READINESS.md) §2 and
+> [INCIDENTS.md](INCIDENTS.md) §8. The protocol is **NO-GO for mainnet** in any case.
+
 ## 4. Post-deploy verification (before any real capital)
 
 Run each check against the live addresses:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,13 +140,19 @@ Then the creator registers governance config in a second tx:
 Child vaults use `createChildVault(params, parent)` — basket must be a subset of the parent's
 (same USDC), depth ≤ 3, stacked exit-fee ≤ 2.5%.
 
-> **Do not create a child vault on any live deployment right now.** Critical **C-1**
+> **Do not create a child vault anywhere real capital is at risk.** Critical **C-1**
 > ([#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33)) is open: a child funded
 > only by its parent has an **empty electorate**, so one minimum deposit buys sole governance
 > control — and capture equals drain, because `minAmountOut` is proposer-supplied. `createChildVault`
 > is also unauthorized on `parent` (L-1), so *anyone* can attach one. Root vaults only until #33 is
 > remediated and re-reviewed — see [LAUNCH-READINESS.md](LAUNCH-READINESS.md) §2 and
 > [INCIDENTS.md](INCIDENTS.md) §8. The protocol is **NO-GO for mainnet** in any case.
+>
+> **This is not a ban on testnet sub-vault drills** — the Base Sepolia drills already run
+> ([SOAK-REPORT.md](SOAK-REPORT.md) drill 2) stand as evidence, and re-running them against the
+> corrected contracts is step 3 of LAUNCH-READINESS §6's path to GO. Throwaway funds on a testnet
+> are exactly where this should be exercised. The constraint is on mainnet and on any deployment
+> holding members' money.
 
 ## 4. Post-deploy verification (before any real capital)
 

--- a/docs/INCIDENTS.md
+++ b/docs/INCIDENTS.md
@@ -32,6 +32,16 @@ pressure.
 only says what is being investigated. Every claim carries a tx hash or a `cast` command the
 reader can run. Never state a recovery time you cannot evidence.
 
+> **Pre-remediation caveat — this playbook describes the intended posture, and the tree does not
+> currently meet it.** Four Critical findings are open
+> ([#31](https://github.com/SlumperSan/agent-governed-vaults/issues/31),
+> [#32](https://github.com/SlumperSan/agent-governed-vaults/issues/32),
+> [#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33),
+> [#34](https://github.com/SlumperSan/agent-governed-vaults/issues/34)) and the protocol is
+> **NO-GO for mainnet** ([LAUNCH-READINESS.md](LAUNCH-READINESS.md) gate 0). §8 in particular
+> promises defences that C-1 and C-5 defeat, and carries its own warning. Read that warning
+> before relying on any "the contract's own defences are the response" line in this document.
+
 ---
 
 ## 1. Oracle staleness / the K-4 capital freeze
@@ -133,6 +143,44 @@ Fees claimed to an unexpected address, or module events that match no known caus
 
 An operator key signs bad proposals, or a member accumulates quorum and passes a hostile
 rebalance.
+
+> ### ⚠ Read first: the defences below do NOT hold for sub-vaults today
+>
+> This section was written against the *intended* design. Two open Criticals falsify it, and an
+> operator trusting it during an incident would be reassured by something that is not true:
+>
+> - **C-1 ([#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33)) — a funded
+>   sub-vault has an empty electorate.** The paragraph below assumes an attacker must *accumulate
+>   quorum*. In a child whose only capital is its parent's allocation, `_snapshot` excludes the
+>   parent (GA-1), leaving `pastHolderCount == 0`. One minimum deposit makes an attacker the sole
+>   eligible voter and every gate passes trivially. There is nothing to accumulate.
+> - **Allow-listed adapters do not bound the loss.** `executeRebalance` checks
+>   `received >= o.minAmountOut`, and `minAmountOut` is **proposer-supplied** (1 wei clears the
+>   adapter), with `routeData` passed verbatim. No oracle-derived bound exists on that path
+>   (H-4). So for a captured vault, **capture equals drain** — the sentence "executes only
+>   through allow-listed adapters against the vault's own basket" is true and provides no
+>   protection whatsoever.
+> - **C-5 ([#34](https://github.com/SlumperSan/agent-governed-vaults/issues/34)) — voting weight
+>   survives a full exit**, so "the creator stake gate keeps the creator exposed" and the
+>   commit-reveal anti-sniping story both weaken: weight can be held across one block boundary
+>   and then withdrawn.
+> - **The "Act" step below presupposes an electorate.** Publishing analysis during the reveal
+>   window lets members "reveal AGAINST" — in the C-1 case the attacker is the *only* eligible
+>   voter, so there is nobody to reach and the window is not a defence.
+>
+> **Until C-1 and C-5 are remediated, a captured sub-vault has no on-chain response at all.** The
+> honest incident posture reduces to levers 1 and 4 in §0 — communicate with evidence, and
+> de-list from the front door. Nothing stops the drain.
+>
+> **Operational consequence, stated as an instruction:** do not create sub-vaults, and do not
+> allocate parent capital into a child, on any live deployment until
+> [#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33) and
+> [#34](https://github.com/SlumperSan/agent-governed-vaults/issues/34) are closed and re-reviewed.
+> This is cheap to honour — a single-level launch needs no children — and it removes the entire
+> C-1 attack surface without waiting on anything else.
+>
+> The rest of this section is retained because it describes the posture the protocol should have
+> **after** remediation, and it is accurate for a **root** vault with a real electorate.
 
 - **The contract's own defenses are the response:** proposals bind exact payloads
   (voters approve *those bytes*), adapters are allow-listed at creation, the commit-reveal

--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -5,8 +5,9 @@
 This is not the "audit hasn't happened yet" NO-GO this document originally carried. An AI
 pre-audit run against the frozen contracts on 2026-08-25 found **41 issues: 5 Critical, 9 High,
 15 Medium, 7 Low** ([AI-AUDIT-REPORT.md](audit/AI-AUDIT-REPORT.md), issues #31–#35), with **33
-executing exploit tests** committed under `contracts/test/audit/`. C-2 is fixed; **C-1, C-3, C-4
-and C-5 are open.** Two of them lose member funds outright.
+executing exploit tests**, of which **30 are committed** under `contracts/test/audit/` — the three
+C-2 cases were removed once C-2 was fixed, for the reason recorded in §5. C-2 is fixed; **C-1,
+C-3, C-4 and C-5 are open.** Two of them lose member funds outright.
 
 **Read this before anything else in the document:** every "GO" row below was earned by evidence
 of *correct operation* — deployment, lifecycle, soak, settlement. None of it is evidence of

--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -21,7 +21,8 @@ Evidence-based per issue [#24](https://github.com/SlumperSan/agent-governed-vaul
 every row names a verifiable artifact — a report, a tag, a transaction, a CI run — and anything
 unverifiable is marked NO-GO or CONDITIONAL, never assumed. First assessed 2026-08-25 at
 `protocol/main` = `ad9396d7`; **battery re-run and re-recorded 2026-08-27 at `protocol/main` =
-`e7dadf34`** (§5) — the ref this document actually ships in. That re-run was not a formality:
+`e7dadf34`** (§5) — the tip of `protocol/main` at the time of measurement. That re-run was not a
+formality:
 `Governance.sol` changed and the exploit suite landed between the two refs (PRs #36, #37, #30),
 so the original record described a tree that is no longer the tree. The verdict is unchanged.
 **The `v0.3.0-audit` tag is withdrawn as an engagement reference** (gate 1); it remains a valid
@@ -120,9 +121,11 @@ language, for a reader who is not an auditor.
 
 ## 5. Battery record at this ref
 
-Re-run in full on **2026-08-27** at `protocol/main` = **`e7dadf34`** (the merge of PR #30), from a
-clean checkout of that exact commit. The earlier record in this section was taken at `ad9396d7`
-and is superseded: `Governance.sol`, `.gas-snapshot`, `Governance.t.sol`, nine
+Re-run in full on **2026-08-27** against `e7dadf34` (the merge of PR #30), from a clean checkout
+of that exact commit. **These results carry forward to whatever commit this document lands at**,
+because every change since `e7dadf34` is confined to `docs/` — no source, test, or snapshot file
+is touched, so no gate can move. Re-run the battery for real the moment that stops being true.
+The earlier record in this section was taken at `ad9396d7` and is superseded: `Governance.sol`, `.gas-snapshot`, `Governance.t.sol`, nine
 `contracts/test/audit/` suites and ~500 lines of soak tests all landed after it, so its
 "contracts untouched by this branch" note had stopped being true.
 

--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -11,15 +11,20 @@ and C-5 are open.** Two of them lose member funds outright.
 **Read this before anything else in the document:** every "GO" row below was earned by evidence
 of *correct operation* — deployment, lifecycle, soak, settlement. None of it is evidence of
 *security*, and the two are not substitutes. The clearest demonstration is that the protocol's
-own 189 tests and all 33 exploit tests pass **simultaneously**: the suite was never structured
-to catch this class. A green board and an exploitable protocol are entirely compatible, and both
-are true here.
+own 190 tests and all 30 committed exploit artifacts pass **simultaneously** — and 17 of those
+30 are `test_finding_*` cases that pass *because the exploit works*. The suite was never
+structured to catch this class. A green board and an exploitable protocol are entirely
+compatible, and both are true here.
 
 Evidence-based per issue [#24](https://github.com/SlumperSan/agent-governed-vaults/issues/24):
 every row names a verifiable artifact — a report, a tag, a transaction, a CI run — and anything
-unverifiable is marked NO-GO or CONDITIONAL, never assumed. Assessed 2026-08-25 at
-`protocol/main` = `ad9396d7`. **The `v0.3.0-audit` tag is withdrawn as an engagement reference**
-(gate 1); it remains a valid historical marker of the pre-remediation tree.
+unverifiable is marked NO-GO or CONDITIONAL, never assumed. First assessed 2026-08-25 at
+`protocol/main` = `ad9396d7`; **battery re-run and re-recorded 2026-08-27 at `protocol/main` =
+`e7dadf34`** (§5) — the ref this document actually ships in. That re-run was not a formality:
+`Governance.sol` changed and the exploit suite landed between the two refs (PRs #36, #37, #30),
+so the original record described a tree that is no longer the tree. The verdict is unchanged.
+**The `v0.3.0-audit` tag is withdrawn as an engagement reference** (gate 1); it remains a valid
+historical marker of the pre-remediation tree.
 
 ## 1. Go/no-go checklist
 
@@ -33,7 +38,7 @@ unverifiable is marked NO-GO or CONDITIONAL, never assumed. Assessed 2026-08-25 
 | 5 | Mainnet oracle stack: 3 mechanism-diverse classes, config verified on mainnet RPC | **GO** | Contracts: Sprint 11 (PR #25, 189 forge tests, TWAP math re-derived independently at review). Config: `contracts/config/base-mainnet.json` is **VERIFIED-ON-CHAIN — 22/22 checks at Base mainnet block 50,412,867** (`scripts/verify-mainnet-config.mjs`; re-run it before deploying, it is read-only). |
 | 6 | Canary operational | **GO** | Ran throughout the soak; every transition it ever recorded reconciles to a specific drill action, including dynamically discovering two new vaults on its own (SOAK-REPORT §6). |
 | 7 | Ops runbook exercised — a restore actually performed | **CONDITIONAL** | Sprint 13 shipped the backup ring + `verify` subcommands with tests, and the soak restarted services freely — but **a deliberate restore-from-backup drill has not been recorded**. ~30 minutes, read-only, no keys. Until performed, "restore works" is a test-suite claim, not an operational one. |
-| 8 | All CI gates green at the candidate ref | **GO** (at the current ref) | CI run `32848131465` on `ad9396d7`: backend, contracts (forge fmt/build/sizes/test/gas-gate), slither — all green. Local battery on this branch: backend **504 tests, 503 pass, 1 skip** (the Windows-only SIGTERM test that executes on Linux CI). The `v1.0.0-launch-candidate` tag is deliberately **not cut** — #24 permits it only when every row is GO. |
+| 8 | All CI gates green at the candidate ref | **GO** (at the current ref) — but read what "green" means | CI run [`33112648340`](https://github.com/SlumperSan/agent-governed-vaults/actions/runs/33112648340) on `e7dadf34`, **conclusion `success`**: backend, contracts (forge fmt/build/sizes/test/gas-gate), slither. Local re-run at the same ref agrees (§5). **The board is green and 17 exploits work** — `forge test` counts a `test_finding_*` case as passing when it successfully steals the funds it was written to steal. This row therefore certifies that the gates ran, not that the protocol is safe; gate 0 is the row that speaks to safety. The `v1.0.0-launch-candidate` tag is deliberately **not cut** — #24 permits it only when every row is GO. |
 
 Also folded into this branch: the facilitator's server-side price re-check now **fails closed**
 when no challenge is posted (`no-challenge`) — the PR #27 review finding that made the open-relay
@@ -74,6 +79,15 @@ TWAP source quantizes at $1e-6, a listing constraint below ~$0.01/token (filed a
 asset outside the verified config, no low-priced assets, until a second verification pass and a
 deliberate listing decision.
 
+**Topology: root vaults only — zero sub-vaults at launch.** This is a launch *parameter*, not
+just an incident note, and it is the cheapest risk reduction available anywhere in this document.
+C-1 ([#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33)) makes a funded child a
+one-minimum-deposit capture whose capture equals drain; the whole class disappears if no child is
+ever created, and a single-level launch needs none. It costs nothing to honour and it does not
+wait on a redeploy. Reinstate sub-vaults only after #33 is remediated **and** the SV-* drills are
+re-run against the corrected contracts (see §6). Note this also removes residual-risk row 9
+(EE-6/E5 child-escrow asymmetry) from the launch surface entirely.
+
 ## 3. Key & role map at launch
 
 | Key | Holder | Power | Blast radius if compromised | Rotation |
@@ -105,12 +119,46 @@ language, for a reader who is not an auditor.
 
 ## 5. Battery record at this ref
 
-| Gate | Result | Where |
+Re-run in full on **2026-08-27** at `protocol/main` = **`e7dadf34`** (the merge of PR #30), from a
+clean checkout of that exact commit. The earlier record in this section was taken at `ad9396d7`
+and is superseded: `Governance.sol`, `.gas-snapshot`, `Governance.t.sol`, nine
+`contracts/test/audit/` suites and ~500 lines of soak tests all landed after it, so its
+"contracts untouched by this branch" note had stopped being true.
+
+| Gate | Result at `e7dadf34` | Where |
 | --- | --- | --- |
-| backend (`npm run test:backend`) | **504 tests, 503 pass, 0 fail, 1 skip** (Windows-only SIGTERM; executes on Linux CI) | local, this branch |
-| forge fmt / build --sizes / test / gas gate | **green — 189 tests** | CI run `32848131465` at `ad9396d7` (contracts untouched by this branch) |
-| slither | green | same run |
-| mainnet config | 22/22 at block 50,412,867 | `scripts/verify-mainnet-config.mjs` |
+| `forge fmt --check` | **pass** (exit 0) | local + CI |
+| `forge build --sizes` (EIP-170) | **pass** (exit 0) | local + CI |
+| `forge test` | **220 tests / 29 suites — 220 pass, 0 fail, 0 skip** | local + CI |
+| `forge snapshot --check --nmt testFuzz` (gas gate) | **pass** (exit 0; 208 tests in scope) | local + CI |
+| slither (advisory, `continue-on-error`) | green | CI |
+| `npm run test:backend` | **553 tests — 551 pass, 0 fail, 2 skip** | local |
+| backend (Linux) | green | CI |
+| mainnet config | 22/22 at Base mainnet block 50,412,867 | `scripts/verify-mainnet-config.mjs` (read-only; re-run before any deploy) |
+
+**CI:** run [`33112648340`](https://github.com/SlumperSan/agent-governed-vaults/actions/runs/33112648340),
+head `e7dadf34`, conclusion **`success`** across all three jobs (backend, contracts, slither).
+
+**The two local backend skips**, named so neither is mistaken for coverage: the API SIGTERM drain
+test (`kill()` is `TerminateProcess` on Windows — it *executes* on Linux CI), and the live-indexer
+snapshot parser test (no live snapshot in a fresh checkout). Eleven further tests skip if
+`contracts/out` is absent — they are the ABI-drift guards, and the numbers above are from a run
+**after** `forge build`, matching CI's ordering. Run backend tests before building the contracts
+and you get a quieter, weaker suite.
+
+**What the 220 forge tests contain**, because the total flatters the tree: **190 protocol tests**
+plus **30 audit artifacts** under `contracts/test/audit/` — of which **17 are `test_finding_*`
+cases that pass by successfully executing an exploit**, 4 are `test_remediated_*` (C-2), and 9 are
+controls, refutations, or fuzz. A green `forge test` at this ref is therefore *also* a
+reproduction of the four open Criticals. Do not quote "220 passing" without that sentence.
+
+**On the report's "33 exploit tests" vs the 30 here** — the difference is accounted for, not lost.
+[AI-AUDIT-REPORT.md §4.4](audit/AI-AUDIT-REPORT.md) tallies 33 against the pre-remediation tree;
+three C-2 cases in `AuditExecutionWindowFreeze.t.sol` were removed when the C-2 hard caps landed
+(PR #36), because they asserted the *unfixed* behaviour and a permanently-red suite is noise, not
+evidence. The removal and its reasoning are recorded in that file's own header, the exploits
+survive in git history, and the fix is pinned by
+`Governance.t.sol::test_phaseDurationHardCapsEnforced`.
 
 ## 6. The path to GO
 

--- a/docs/audit/AI-AUDIT-REPORT.md
+++ b/docs/audit/AI-AUDIT-REPORT.md
@@ -61,7 +61,7 @@ rather than quietly dropped.
 
 The middle column is deliberately separated from the first: those findings are established by
 reading the source, not by executing anything. Only the 13 in the first column are backed by a
-test in `docs/audit/tests/`.
+test in `contracts/test/audit/`.
 
 ### Recommendation: **NO-GO** for immutable mainnet deployment
 
@@ -128,7 +128,7 @@ Contract sizes were measured with `forge build --sizes`: `VaultCore` 23,016 B ru
 - **`Checkpoints.sol`** was reviewed for voting-snapshot correctness; it carries no fund-flow path.
 
 **Frozen-code discipline.** No file under `contracts/src/` was modified at any point, verified with
-`git status --porcelain`. All audit artifacts are additive test files under `docs/audit/tests/`.
+`git status --porcelain`. All audit artifacts are additive test files, landed under `contracts/test/audit/`.
 
 ---
 
@@ -692,7 +692,7 @@ cannot fail in the relevant way.
 
 **Remediation.** Replace the linear mock with an observation-ring mock reproducing
 `transform`-from-newest semantics; `FaithfulV3Pool` in
-`docs/audit/tests/AuditTwapSpotDegeneration.t.sol` is a working reference. Re-run the Sprint-11 suite
+`contracts/test/audit/AuditTwapSpotDegeneration.t.sol` is a working reference. Re-run the Sprint-11 suite
 against it and treat every newly failing test as a finding. **Test-only change — no redeploy, but it
 must precede re-review of H-2's fix.**
 

--- a/docs/audit/AI-AUDIT-REPORT.md
+++ b/docs/audit/AI-AUDIT-REPORT.md
@@ -1094,7 +1094,8 @@ is correctly defended.
 
 ### 4.4 Audit test artifacts
 
-All under `docs/audit/tests/`; `contracts/src` never modified.
+All under `contracts/test/audit/`; `contracts/src` never modified. (They were authored under
+`docs/audit/tests/` and moved when they landed in PR #36 — that path is not in the tree.)
 
 | File | Tests | Covers |
 |---|---|---|
@@ -1109,8 +1110,16 @@ All under `docs/audit/tests/`; `contracts/src` never modified.
 | `AuditVoteAfterExit.t.sol` | 2 | C-5 (incl. passing VO-9 control) |
 | **Total** | **33** | **33 passing** |
 
+The table above is the count **as audited**, against the pre-remediation tree. **30 are in the
+tree today:** the three C-2 cases in `AuditExecutionWindowFreeze.t.sol` were removed when the C-2
+hard caps landed (PR #36) — they asserted the *unfixed* behaviour, so keeping them would mean a
+permanently-red suite, which is noise rather than evidence. That file's header records the removal
+and the exploits survive in git history; the fix is pinned by
+`Governance.t.sol::test_phaseDurationHardCapsEnforced`. Verified 2026-08-27: the command below
+runs 9 suites / 30 tests, all passing.
+
 ```bash
-cp docs/audit/tests/Audit*.t.sol contracts/test/ && cd contracts && forge test --match-path "test/Audit*.t.sol" -vv
+cd contracts && forge test --match-path "test/audit/Audit*.t.sol" -vv
 ```
 
 ### 4.5 `SLITHER-TRIAGE.md` — incorrect dispositions


### PR DESCRIPTION
Follow-up to [#30](https://github.com/SlumperSan/agent-governed-vaults/pull/30), which landed the Sprint-15 launch-readiness package. Two verify-then-cite defects in that package. **No contract changes. Verdict unchanged: NO-GO.**

## 1. The battery record described a tree that no longer existed

`docs/LAUNCH-READINESS.md` §5 was measured at `ad9396d7` and carried the note *"contracts untouched by this branch"*. That stopped being true before the package merged — `Governance.sol`, `.gas-snapshot`, `Governance.t.sol`, nine `contracts/test/audit/` suites and ~500 lines of soak tests all landed between that ref and the merge commit (PRs #36, #37, #30). Issue #24 asks for the battery *at the candidate ref*, so it was re-run from a clean checkout of `e7dadf34`:

| Gate | Result at `e7dadf34` |
| --- | --- |
| `forge fmt --check` | pass |
| `forge build --sizes` (EIP-170) | pass |
| `forge test` | **220 tests / 29 suites — 220 pass, 0 fail, 0 skip** (was recorded as 189) |
| `forge snapshot --check --nmt testFuzz` | pass (208 in scope) |
| `npm run test:backend` | **553 tests — 551 pass, 0 fail, 2 skip** (was recorded as 504/503/1) |
| CI [`33112648340`](https://github.com/SlumperSan/agent-governed-vaults/actions/runs/33112648340) @ `e7dadf34` | **conclusion `success`** (backend, contracts, slither) |

Recorded with the qualifier the numbers need: **17 of the 220 are `test_finding_*` cases that pass *because the exploit works***. A green board at this ref is also a reproduction of the four open Criticals, so gate 8 now says it certifies that the gates ran, not that the protocol is safe.

Two smaller honesty items while in there:
- **Both backend skips are named** (Windows SIGTERM; live-indexer snapshot), plus the fact that 11 further ABI-drift tests skip silently if `contracts/out` is absent — the recorded run is post-`forge build`, matching CI.
- **The report's "33 exploit tests" is reconciled against the 30 present.** Three C-2 cases were removed when the C-2 hard caps landed; the reasoning is in that file's own header and the fix is pinned by `test_phaseDurationHardCapsEnforced`. Accounted for, not lost.

## 2. `INCIDENTS.md` §8 reassured operators about exactly what C-1 breaks

§8 told a reader under pressure that governance capture is answered by *"the contract's own defenses"*. Open C-1 ([#33](https://github.com/SlumperSan/agent-governed-vaults/issues/33)) falsifies both halves:

- §8 assumes an attacker must **accumulate quorum**. A funded sub-vault has an **empty electorate** — `_snapshot` excludes the parent (GA-1), so `pastHolderCount == 0` and one minimum deposit makes an attacker the sole eligible voter. Nothing is accumulated.
- §8 implies allow-listed adapters bound the damage. `minAmountOut` is **proposer-supplied** (1 wei clears the adapter) with `routeData` passed verbatim — **capture equals drain**.
- §8's *Act* step — publish during the reveal window so members reveal AGAINST — presupposes an electorate that, in this case, does not exist.

§8 now leads with that warning, §0 points at it, and the retained text is scoped to root vaults post-remediation. C-5 ([#34](https://github.com/SlumperSan/agent-governed-vaults/issues/34)) is noted where it weakens the same paragraph.

**The cheap mitigation is now a stated launch parameter:** *root vaults only — zero sub-vaults at launch*. It removes the entire C-1 attack surface without waiting on a redeploy, costs nothing (a single-level launch needs no children), and also drops residual-risk row 9 from the launch surface.

## Not done, deliberately

- **No `v1.0.0-launch-candidate` tag.** Gates 0 and 1 are NO-GO; #24 permits the tag only when every row is GO.
- **Gate 7 (restore drill) untouched** — correctly CONDITIONAL, and it cannot move the headline while gate 0 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
