### PR TITLE
docs: Obsidian knowledge vault (graph-linked project brain, 48 notes)

### DIFF
--- a/docs/vault/HOME.md
+++ b/docs/vault/HOME.md
@@ -1,0 +1,48 @@
+# Agent-Governed Vaults — Knowledge Vault (HOME)
+
+> Obsidian-style knowledge graph for this protocol. This is the **map of content (MOC)** — the hub
+> of the graph. Every note links to related notes with `[[wikilinks]]` (filename without `.md`).
+> Read this first to orient; follow links to drill in. Kept current as work lands.
+
+**Repo:** `github.com/SlumperSan/agent-governed-vaults` (private) · **base:** `protocol/main`
+**One-liner:** permissionless USDC index vaults, governed by AI agents via commit-reveal weighted
+vote, x402-metered off-chain access. **Launch verdict:** NO-GO (external audit pending; C-6 open).
+
+## Conventions (for consistency across the graph)
+
+- Filenames: `kebab-case.md`; the note title is a matching `# Title` H1.
+- Link by filename stem: `[[vaultcore]]`, `[[c6-oracle-byzantine]]`. Unresolved links are fine — they
+  mark notes worth writing.
+- Each note starts with a one-line **definition**, then **why it matters**, then detail, then a
+  **Links** section. Keep notes atomic (one concept) and cross-linked, not monolithic.
+- Status tags in prose: **FIXED**, **OPEN**, **DEFERRED**, **ACCEPTED**, **DORMANT-AT-LAUNCH**.
+
+## Clusters
+
+### Architecture — [[architecture-overview]]
+- [[nav-and-shares]] · [[governance-commit-reveal]] · [[two-mode-exits]] · [[sub-vaults]] ·
+  [[oracle-layer]] · [[fees-and-carry]] · [[x402-metering]] · [[off-chain-stack]]
+
+### Contracts — [[contracts-index]]
+- [[vaultcore]] · [[governance]] · [[oracleaggregator]] · [[chainlinkoracle]] · [[vaultfactory]] ·
+  [[vaultdeployer]] · [[subvaultregistry]] · [[feeengine]] · [[operatorregistry]] ·
+  [[execution-adapters]] · [[oracle-sources]] · [[safetransferlib]]
+
+### Security — [[security-index]]
+- Criticals: [[c1-empty-electorate]] · [[c2-unbounded-governance]] · [[c3-oracle-brick]] ·
+  [[c4-depressed-price-theft]] · [[c5-vote-after-exit]] · [[c6-oracle-byzantine]]
+- [[highs]] · [[mediums-and-lows]] · [[threat-model-commitments]] · [[slither-triage]] ·
+  [[launch-readiness-gates]] · [[audit-reverification]]
+
+### Decisions & Principles — [[decisions-index]]
+- [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[build-vs-buy]] · [[auto-merge]] ·
+  [[delegatecall-split-rejected]] · [[continuous-autonomous-mode]]
+
+### State & Roadmap — [[current-state]]
+- [[remediation-history]] · [[open-items]] · [[prs-and-issues]] · [[go-to-market-plan]]
+
+## Graph note
+
+This vault is engineered as a graph: contracts link to the findings that live in them, findings link
+to the decisions that resolved them, decisions link to the principles behind them. Start anywhere and
+traverse. See [[current-state]] for "what is true right now".

--- a/docs/vault/architecture-overview.md
+++ b/docs/vault/architecture-overview.md
@@ -1,0 +1,73 @@
+# Architecture Overview
+
+**Definition.** The map of the agent-governed-vaults system: permissionless USDC index vaults
+in which AI agents pool capital, govern rebalances by stake-weighted commit-reveal vote, and pay
+for off-chain analytics via x402 — every subsystem and how the boxes connect.
+
+**Why it matters.** This is the entry point for the ARCHITECTURE cluster. Read it first, then
+drill into the atomic notes it links. Source of truth: `docs/ARCHITECTURE.md` (Sprint 1 artifact
+1.1) and `docs/THREAT-MODEL.md`.
+
+## The shape of the system
+
+```
+   VaultFactory → VaultDeployer          permissionless deploy; deployer holds NO authority (PX-4)
+        │ creates
+   Governance ⇄ VaultCore ⇄ OracleAggregator (or ChainlinkOracle)
+   commit-reveal   shares/NAV/deposits    multi-source median + staleness breaker
+        │          redemptions/capacity
+        ▼               │        │
+   SubVaultRegistry  IExecutionAdapter  OperatorRegistry
+   (DORMANT-AT-LAUNCH)  venue-agnostic   (member,operator) HWM, leaderboard
+```
+
+Each module is its own contract; **interfaces cross module boundaries, storage never does**.
+[[vaultcore]] holds immutable references to every peer, set at construction. Sprint 1 made
+VaultCore concrete; the other boxes were interfaces-with-stubs that filled in across Sprints 2–5.
+
+## Naming convention — TWO `C-n` namespaces (do not conflate)
+
+The repo overloads `C-n`. Always qualify which:
+
+- **commitment C-n** — architecture design commitments from `docs/ARCHITECTURE.md`:
+  commitment C-1 = *not ERC-4626* ([[nav-and-shares]]), commitment C-2 = *chain/venue-agnostic*,
+  commitment C-3 = *OperatorRegistry immutable reference* ([[fees-and-carry]]), commitment C-4 =
+  *two-mode settlement* ([[two-mode-exits]]).
+- **audit C-n** — critical findings from the AI pre-audit: audit C-1 = *empty electorate*
+  ([[c1-empty-electorate]], the reason [[sub-vaults]] are disabled), … audit C-6 = *oracle
+  Byzantine bound* ([[c6-oracle-byzantine]], the reason for the [[chainlink-direct-pivot]]).
+
+`K-n` is a third, separate series: brief-contradictions that were resolved or **ACCEPTED**
+(e.g. K-2 near-immutability, K-4 no-escape-breaker). Do not read K-n as a critical.
+
+## Cross-cutting invariants
+
+- **Only `block.timestamp`** as a clock; no `block.number` arithmetic (commitment C-2).
+- No hardcoded token/router/oracle addresses — all injected at construction or via timelocked
+  config. USDC referenced as `IERC20 immutable`, 6 decimals read once at construction; internal
+  math is WAD (1e18). See [[nav-and-shares]].
+- **No upgrades.** No proxies, no delegatecall, no upgradeable contracts. Iteration happens by
+  deploying new versions through the factory; migration is voluntary per vault. See
+  [[delegatecall-split-rejected]].
+- **Oracle staleness freezes everything including exits** (K-4, **ACCEPTED**) — see
+  [[oracle-layer]] and [[two-mode-exits]].
+- **x402 never appears in the contract layer** — see [[x402-metering]].
+
+## The ARCHITECTURE cluster
+
+- [[nav-and-shares]] — share/NAV accounting, deposit, observation window, not-4626
+- [[governance-commit-reveal]] — proposals, commit-reveal, quorum, delegation, timelock
+- [[two-mode-exits]] — instant vs forward-priced redemption, in-kind payout, exit fee
+- [[sub-vaults]] — parent/child mandate (DORMANT-AT-LAUNCH)
+- [[oracle-layer]] — multi-source median, circuit breaker, the Chainlink pivot
+- [[fees-and-carry]] — 10% perf fee, cross-vault HWM carryforward, operator registry
+- [[x402-metering]] — off-chain metered read API, zero contract coupling
+- [[off-chain-stack]] — indexer, agent SDK, API, canary, web
+
+## Links
+
+- Contracts: [[vaultcore]] · [[governance]] · [[oracleaggregator]] · [[chainlinkoracle]] ·
+  [[vaultfactory]] · [[vaultdeployer]] · [[subvaultregistry]] · [[feeengine]] ·
+  [[operatorregistry]] · [[execution-adapters]] · [[oracle-sources]]
+- Security: [[security-index]] · [[threat-model-commitments]] · [[launch-readiness-gates]]
+- Decisions: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[current-state]]

--- a/docs/vault/audit-reverification.md
+++ b/docs/vault/audit-reverification.md
@@ -1,0 +1,60 @@
+# Audit re-verification
+
+The Phase-2 re-verification pass (2026-08-28) that took the remediation's *inferred* closures and
+re-tested them end-to-end against real code — and in doing so converted an inferred C-4 closure into
+an executed refutation, surfacing the new Critical [[c6-oracle-byzantine]] (issue #48).
+
+## Why it matters
+
+The original remediation closed C-4 by **inference**: "fixing C-3/H-1/H-2/M-1 removes C-4's trigger."
+That reasoning built `VaultCore` over a directly-set `MockOracle` — it never drove the *real*
+`OracleAggregator`. The re-verification did its job: it replaced the argument with an executed test
+and found the inference false at `a ≥ 2` adversarial sources. This is the discipline the whole
+audit turns on — an inferred closure is not an executed one.
+
+## What it found
+
+Driving a real `OracleAggregator` into a `VaultCore` deposit (`AuditC4EndToEnd.t.sol`, 7 tests):
+
+- Against a correctly-curated oracle (≥5 genuinely-independent sources, `a ≤ 1`) the trigger **is**
+  gone — a single adversarial source can never move the lower median, verified down to quorum
+  (`test_safe_oneControlledSource_medianHoldsAsHonestLegsWithhold`).
+- But **two** adversarial sources + one withholding honest leg seize `fresh[1]` and re-open C-4's
+  measured 88.9% theft, through the real aggregator
+  (`test_residual_twoControlledSources_oneHonestWithholds_k4/_k3`). Identical to C-4's table — because
+  it is C-4.
+- The hostile config (two creator-controlled sources at quorum 3) passes **every** constructor check
+  (`test_hostileConfigPassesEveryConstructorCheck`).
+
+The boundary: an actor controlling `a` of the fresh `k` owns the lower median iff `k ≤ 2a`; safety
+requires `quorum ≥ 2a + 1` and, with `f` benign withholdings, `m ≥ 2a + f + 1`. See
+[[c6-oracle-byzantine]] for the full derivation.
+
+## The companion faithful-mock pass
+
+`AuditTwapFaithfulMock.t.sol` (8 tests + `FaithfulUniV3Pool.sol`, an independent v3-core `Oracle.sol`
+port) confirms the H-2 fix holds against faithful observation-ring semantics — closing H-3's
+test-blindness for the reachable dimensions.
+
+## The qualified test buckets
+
+The `test_finding_*` / `test_residual_*` cases that pass by executing an exploit now span three
+buckets, so any "N passing tests" figure must carry the qualifier:
+
+1. **Unreachable at launch by configuration** — the sub-vault suite; `AuditRootVaultsOnly` (C-1).
+2. **Config-mitigated residual** — `AuditQuorumRegimeDust` (H-8 attack a).
+3. **Live open finding** — `AuditC4EndToEnd` (C-6).
+
+## Consequence
+
+Four of five original Criticals are closed with executed evidence (`AuditRootVaultsOnly`,
+`Governance::test_phaseDurationHardCapsEnforced`, `AuditAggregatorDecodeBrick`, `AuditVoteAfterExit`).
+**C-4/C-6 keep gate 0 NO-GO.** The leading resolution is [[chainlink-direct-pivot]] — consume
+Chainlink Data Feeds directly, deleting most of the oracle-finding class.
+
+## Links
+
+- [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]] · [[c1-empty-electorate]] · [[highs]] (H-2,
+  H-3, H-8) · [[chainlink-direct-pivot]] · [[chainlinkoracle]]
+- [[oracleaggregator]] · [[oracle-sources]] · [[launch-readiness-gates]] ·
+  [[threat-model-commitments]] · [[remediation-history]] · [[security-index]]

--- a/docs/vault/auto-merge.md
+++ b/docs/vault/auto-merge.md
@@ -1,0 +1,21 @@
+# Auto-Merge
+
+Remediation work flows to `protocol/main` through per-finding PRs that merge once CI is green, rather than accumulating on a single long-lived branch. **OPERATING CONVENTION.**
+
+## Why it matters
+
+The Phase-2 remediation produced a steady stream of focused, single-finding fixes (C-1, H-8, M-15, C-6 re-verification, ChainlinkOracle, plus the disposition sweep). Landing each one as its own PR to `protocol/main` — instead of batching — keeps the live branch continuously in the best-known state, keeps each diff reviewable in isolation, and means the "what is true right now" snapshot ([[current-state]]) is always the tip of `protocol/main`, not a branch waiting to be integrated.
+
+## The decision and rationale
+
+Each finding gets its own `security/*` branch and PR; CI runs the full battery (`forge fmt --check`, `forge build --sizes`, `forge test`, `forge snapshot --check`, backend tests); on green, the PR merges to `protocol/main`. Recent examples visible in history: #43 (C-1, `security/c1-root-vaults-only`), #44 (H-8, `security/h8-quorum-regime`), #45 (M-15, `security/m15-slippage`), #46 (dispositions, `security/sprint20-dispositions`), #47 (C-6 re-verification, `security/oracle-reverification-c6`), #49 (ChainlinkOracle, `security/chainlink-oracle`).
+
+This pairs with [[continuous-autonomous-mode]]: parallel workers each own a finding, and the merge queue serializes their output onto the live branch without a human gate per PR. **Caveat, learned the hard way:** the worktree is shared across concurrent sessions, so `git add -A` is banned here — it once swept another sprint's contracts into an unrelated PR. Stage explicitly.
+
+Because the fixes are additive and gated by CI, gate 8 ("all CI gates green at the candidate ref") stays GO throughout — though a green board certifies the gates *ran*, not that the protocol is *safe* ([[launch-readiness-gates]]).
+
+## Links
+
+- Operating model: [[continuous-autonomous-mode]] · [[decisions-index]]
+- Where the merges land: [[current-state]] · [[prs-and-issues]] · [[remediation-history]]
+- Gate context: [[launch-readiness-gates]] · [[audit-reverification]]

--- a/docs/vault/build-vs-buy.md
+++ b/docs/vault/build-vs-buy.md
@@ -1,0 +1,22 @@
+# Build vs. Buy
+
+A standing owner principle: **prefer mature, audited external infrastructure over bespoke re-implementations** — especially for security-critical primitives where a network of independent operators already exists.
+
+## Why it matters
+
+The most expensive finding class in the entire audit — C-3, C-4, C-6, H-1, H-2, H-3, M-1, M-14 — all lives inside **one bespoke component**: the custom multi-source median [[oracleaggregator]] and its TWAP/Pyth source adapters. A per-vault 5-source median tried to re-implement, from scratch, the Byzantine-fault-tolerant price aggregation that Chainlink's node-operator network already provides at scale. It competed with mature infrastructure and lost: the code cannot enforce source independence, so `quorum ≥ 2a+1` is unenforceable in-contract (see [[c6-oracle-byzantine]]).
+
+## The principle and rationale
+
+A bespoke oracle aggregator competing with Chainlink's node-operator network is exactly the kind of surface to **outsource rather than harden**. Chainlink Data Feeds bring, at the network layer, what the custom aggregator could only approximate: many independent, reputation-staked operators; published deviation-threshold + heartbeat guarantees; years of mainnet Byzantine-fault tolerance — and they are **free to consume on-chain**.
+
+The [[chainlink-direct-pivot]] is the direct application of this principle: consuming the feed directly deletes the custom-aggregation attack surface and most of the oracle findings **by deletion** rather than by patch. The cautionary tale is generalizable — bespoke re-implementation of a well-solved, security-critical primitive concentrates risk in code that a small team must review alone, against adversaries the mature service has already survived.
+
+**Scope of the principle:** it argues for buying mature infrastructure for hard, adversarial, well-solved primitives (oracles, math libraries) — not for outsourcing the protocol's own novel mechanisms (the vault/governance/x402 core, which is the product). The test is whether a battle-tested external network already exists that you would be re-inventing.
+
+## Links
+
+- Applied in: [[chainlink-direct-pivot]] · cautionary tale: [[oracleaggregator]] · [[oracle-layer]]
+- Findings it explains: [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]] · [[c3-oracle-brick]] · [[highs]]
+- Related decisions: [[decisions-index]] · [[delegatecall-split-rejected]]
+- Contracts: [[chainlinkoracle]] · [[safetransferlib]]

--- a/docs/vault/c1-empty-electorate.md
+++ b/docs/vault/c1-empty-electorate.md
@@ -1,0 +1,49 @@
+# C-1 — Empty electorate: a funded sub-vault is captured for one minimum deposit
+
+A funded child vault whose only capital is its parent's allocation has an **empty electorate**, so
+any outsider can deposit one `minDepositUsdc`, become the sole eligible voter, and pass a proposal
+that drains it.
+
+## Why it matters
+
+Critical. Capture equals drain: it costs one minimum deposit (as low as 1 unit) plus gas, and the
+loss is borne by the parent's members via collapsed look-through NAV. There is no proxy, pause, or
+admin path to undo it after deployment.
+
+## Mechanism
+
+The GA-1 fix excluded the parent from the child's voting-eligible stake **and** from its holder
+count (`VaultCore.sol:425-430`), to keep full-consensus `RuleChange` reachable. The unanticipated
+consequence: in a child whose only capital is the parent's allocation,
+`pastTotalVotingEligibleShares == 0` and `pastHolderCount == 0` — the vault holds real money with no
+electorate. `deposit` is permissionless, so one deposit makes the attacker the sole eligible voter,
+and every gate (proposal threshold, `<5`-member signer regime, `1*2 > 1` quorum, outcome) passes
+trivially. `execute` is permissionless too. Because `executeRebalance` bounds output only by the
+proposer-supplied `minAmountOut` (1 wei suffices) and the router path is attacker-chosen (H-4), the
+attacker routes the vault's assets through a pool they seeded and books ~nothing.
+
+## Status
+
+**FIXED at launch** by [[root-vaults-only]] (2026-08-28, Phase 2). The report's own suggested
+in-contract fix (`pHeld = 0`, count the parent as a member) was evaluated and **rejected**: it
+breaks the legitimate parent+1-member child (the signer regime needs `1*2 > 2`, false), and the
+tension is structural — any voting denominator that excludes the parent lets a dust depositor govern
+the parent's allocation, while including it makes the child ungovernable (the parent is a contract
+with no vote path). There is **no purely-internal fix**; the correct mechanism (parent casts the
+child's vote) is a product decision deferred to a post-launch, post-audit release. `VaultFactory`
+ships with immutable `allowSubVaults = false`: `createChildVault` reverts `SubVaultsDisabled` and
+every vault is wired `subVaultRegistry = address(0)`, so no vault can ever be funded as a child and
+the empty-electorate precondition is **unreachable**. VaultCore bytes are unchanged. This closes C-1
+and the sub-vault-only Highs H-5/H-6/H-7/H-9 as a class. **Re-enabling sub-vaults reopens C-1.**
+
+## Regression test
+
+`contracts/test/audit/AuditRootVaultsOnly.t.sol` (2 tests: one reproduces the live capture with
+sub-vaults enabled, one proves it unreachable under the launch gate).
+
+## Links
+
+- [[root-vaults-only]] · [[vaultcore]] · [[vaultfactory]] · [[governance]] · [[sub-vaults]] ·
+  [[execution-adapters]]
+- [[highs]] (H-5/H-6/H-7/H-9 closed with it) · [[security-index]] · [[launch-readiness-gates]] ·
+  [[threat-model-commitments]] (SV-1/SV-7 governance not upheld)

--- a/docs/vault/c2-unbounded-governance.md
+++ b/docs/vault/c2-unbounded-governance.md
@@ -1,0 +1,46 @@
+# C-2 — Unbounded governance durations freeze every exit permanently
+
+Three of four governance duration parameters had no upper bound, so a single `propose()` call could
+pin a proposal in `Active` for ~136 years and freeze every exit in a vault forever — no vote, no
+quorum, no collusion.
+
+## Why it matters
+
+Critical (base High × immutable). Triggerable by one transaction; with `proposalThresholdBps = 0`
+(the value shipped in `base-mainnet.json`, M-6) it costs one `minDepositUsdc`. There is no cancel
+path, and the frozen vault **cannot legislate its way out**: a stuck proposal blocks every future
+proposal, including the `RuleChange` that would repair the config.
+
+## Mechanism
+
+`_validateConfig` capped only `timelockDuration` (the one parameter that does not gate exits);
+`commitDuration`, `revealDuration`, `executionWindow` had floors but no ceilings, and
+`proposalCooldown` was not validated at all. `hasPendingExecution`'s `Active` branch
+(`Governance.sol:519-521`) returns true for any proposal past its `commitDeadline` — **passage is
+irrelevant** — while `finalize` requires `block.timestamp >= revealDeadline`. So an unbounded
+`revealDuration` pins the proposal in `Active` for ~136 years. In `VaultCore` that flag is the Mode-F
+switch: `requestExit` queues (`:445`) and `settleQueuedExit` reverts `ExecutionStillPending` (`:477`),
+with no cancel path. `_isSettled` counts only `Defeated | Executed | Expired`, so `propose`'s guard
+rejects any new proposal. This falsifies **EE-10** ("no indefinite lock") and **MO-1** (the Mode-I
+fallback covers a *broken* module, not a correct governance answering `true` forever).
+
+## Status
+
+**FIXED** (earlier remediation). A phase hard-cap now bounds `commitDuration`, `revealDuration`,
+`executionWindow`, and `proposalCooldown` above — the last was previously unvalidated (the same C-2
+shape, found while fixing M-6). Mode F is also decoupled from proposals that have not passed. Requires
+redeploy + re-review; landed in the corrected tree.
+
+## Regression test
+
+`Governance.t.sol::test_phaseDurationHardCapsEnforced` pins the fix. The original exploit lived in
+`contracts/test/audit/AuditExecutionWindowFreeze.t.sol` (4 tests) and `AuditDosExitLiveness.t.sol`;
+the C-2 cases were removed when the hard caps landed (they asserted the unfixed behaviour) and
+survive in git history.
+
+## Links
+
+- [[governance]] · [[vaultcore]] · [[two-mode-exits]] · [[governance-commit-reveal]]
+- Related liveness: [[mediums-and-lows]] (M-7 serial-proposal exit freeze, M-8 opaque hash) ·
+  [[c5-vote-after-exit]] · [[threat-model-commitments]] (EE-10, MO-1 falsified) · [[security-index]] ·
+  [[remediation-history]]

--- a/docs/vault/c3-oracle-brick.md
+++ b/docs/vault/c3-oracle-brick.md
@@ -1,0 +1,43 @@
+# C-3 — One malformed price source permanently bricks all pricing on an aggregator
+
+A single price source returning anything other than ≥64 well-formed bytes makes `priceWad` revert
+**unconditionally, regardless of quorum** — permanently bricking pricing for every vault on that
+aggregator, with no recovery.
+
+## Why it matters
+
+Critical (base High × immutable). One source out of fifteen suffices, unilaterally and permanently.
+Value at risk: 100% of active share capital in every vault wired to the aggregator — no deposit can
+be accepted and no exit can settle.
+
+## Mechanism
+
+The aggregator used `try IPriceSource(...).latestPrice() returns (uint256 p, uint256 updatedAt) {...}
+catch {}` (`OracleAggregator.sol:88-90`). Solidity decodes the returned buffer in the **caller's**
+frame *after* the callee returns successfully, so a `catch` clause cannot absorb a decode failure. A
+source returning 32 bytes, 0 bytes, or living at a codeless address makes the whole call revert with
+empty returndata — **not** `StaleOracle`. A genuine `revert("boom")` is correctly absorbed (the
+passing control that isolates the defect). Two reachable paths: (a) a deploy-time typo — the
+constructor performs no `code.length` check on any source, so one mistyped address bricks the asset
+forever; (b) a creator-authored source serving well-formed data through the deposit phase, then
+flipping to a 32-byte return with a single `SSTORE`. This defeats the K-4 premise, which accepts a
+freeze requiring a *quorum failure*.
+
+## Status
+
+**FIXED** (earlier remediation). The `try/catch` was replaced with a `staticcall` + explicit
+`ret.length >= 64` length check before `abi.decode`, and the constructor now requires
+`source.code.length > 0`. A reverting or malformed source is now simply not-fresh; quorum holds
+elsewhere. Requires redeploy + re-review of every aggregator instance. Note the entire custom-
+aggregation oracle class is superseded at launch by [[chainlinkoracle]] / [[chainlink-direct-pivot]].
+
+## Regression test
+
+`contracts/test/audit/AuditAggregatorDecodeBrick.t.sol` (5 tests).
+
+## Links
+
+- [[oracleaggregator]] · [[oracle-sources]] · [[oracle-layer]] · [[chainlinkoracle]] ·
+  [[chainlink-direct-pivot]]
+- [[c6-oracle-byzantine]] · [[highs]] (H-1 lower-median) · [[threat-model-commitments]] (SF-1, K-4) ·
+  [[security-index]]

--- a/docs/vault/c4-depressed-price-theft.md
+++ b/docs/vault/c4-depressed-price-theft.md
@@ -1,0 +1,48 @@
+# C-4 — A depressed oracle price converts directly into theft of members' capital
+
+Because `_mintShares` issues shares inversely proportional to reported NAV and `deposit` mints
+immediately in the same transaction, a depressed price is atomically convertible into excess shares
+redeemable for real assets — measured at an 88.9% loss to existing members.
+
+## Why it matters
+
+Critical (already Critical — immutability adjustment is a no-op). It is the *consequence* the oracle
+findings feed: a wrong or attacker-chosen price at mint time is a direct transfer of existing
+members' capital to the depositor.
+
+## Mechanism
+
+`_mintShares` mints `amountWad * totalShares / navWad()` (`VaultCore.sol:391`); `deposit` (`:335`)
+mints immediately for any member past the one-time observation window. Measured
+(`AuditOracleToShareTheft.t.sol`), price depressed $2,500 → $100 on an 800-wETH basket: 1,000,000
+USDC in becomes a 2,777,762 USD claim; victim value 1,000,000 → 111,124 USD (−88.9%); a second test
+withdraws 733.33 wETH + 916,668 USDC against 1,000,010 deposited. The oracle findings all bias
+**downward** — exactly the exploitable direction. The `VaultCore` half is confirmed rigorously with
+the depressed price taken as given (a `MockOracle`); the oracle half is confirmed separately by C-3,
+H-1, M-1.
+
+## Status
+
+**CLOSED at `a ≤ 1` oracle sources; RE-OPENED at `a ≥ 2` by [[c6-oracle-byzantine]]** (2026-08-28,
+Phase-2 re-verification). The original "root cause closed by C-3/H-1/H-2/M-1" claim was
+**inference**, and the Phase-2 end-to-end test (`AuditC4EndToEnd.t.sol`) falsified it: against a
+correctly-curated oracle (≥5 genuinely-independent sources, no single actor controlling more than
+one) the trigger is gone — a single adversarial source can never move the lower median. But **two**
+adversarial sources (cheapest case: a malicious creator listing two sources they control, which
+passes every constructor check) seize the reported price the moment one honest leg withholds,
+re-opening this measured 88.9% theft through the *real* aggregator. That is C-6. C-4's VaultCore half
+is unchanged; its closure is now conditional on the C-6 curation requirement. The suggested mint-time
+NAV-deviation defence-in-depth (#32) is deferred (VaultCore byte budget) and **partially subsumed**
+by M-15's deposit-side `minSharesOut` overload, which now gives a depositor a transaction-level bound.
+
+## Regression test
+
+`contracts/test/audit/AuditOracleToShareTheft.t.sol` (2 tests, VaultCore half);
+`AuditC4EndToEnd.t.sol` (7 tests, Phase-2 re-verification through the real oracle).
+
+## Links
+
+- [[c6-oracle-byzantine]] · [[c3-oracle-brick]] · [[highs]] (H-1, H-2, H-4) · [[oracleaggregator]] ·
+  [[chainlinkoracle]] · [[chainlink-direct-pivot]]
+- [[vaultcore]] · [[nav-and-shares]] · [[mediums-and-lows]] (M-1, M-15) · [[audit-reverification]] ·
+  [[security-index]]

--- a/docs/vault/c5-vote-after-exit.md
+++ b/docs/vault/c5-vote-after-exit.md
@@ -1,0 +1,44 @@
+# C-5 — Voting weight survives a full exit
+
+A member can hold stake across one block boundary, propose, withdraw all capital instantly, and then
+vote the proposal through with snapshot weight they no longer own — bearing none of the price
+exposure the design's alignment rests on.
+
+## Why it matters
+
+Critical (base High × immutable). It reduces the skin-in-the-game requirement the entire timelock
+mechanism exists to create — from days to seconds. Composed with H-4 (unbounded `minAmountOut`) it is
+a complete drain primitive against **any** vault, not only sub-vaults; composed with M-8 (opaque
+`actionHash`) voters cannot even see what they approve.
+
+## Mechanism
+
+Every weight read in `Governance` is `pastVotingEligibleShares(voter, p.createdAt - 1)`, and
+`Checkpoints.getAt` returns the last checkpoint at or before that timestamp. The checkpoint written
+when a member **exits** is stamped at the current block — strictly after `createdAt - 1` — so it is
+invisible to a proposal already in flight. There is no current-balance check at `commitVote`,
+`revealVote`, `revealDelegated`, `applyStandingDefault`, or `finalize`. Critically the exit settles
+instantly: `hasPendingExecution` is false for the whole commit phase, so `requestExit` takes the
+Mode-I branch and pays out immediately at pre-rebalance NAV. Confirmed end-to-end: deposit (mints
+immediately after `skipWindow`), propose one block later, `requestExit(all)` settles instantly, then
+commit/reveal FOR with full snapshot weight — `revealVote` does not revert on a zero balance —
+`finalize` → Passed. The VO-9 control passes: stake acquired *after* creation carries zero weight;
+the defect is that VO-9 is silent on the **withdrawal** direction. This also subsumes EE-10's Mode-F
+mitigation (the lock removes eligibility only from *future* proposals).
+
+## Status
+
+**FIXED** (earlier remediation). Every weight read now takes the **minimum** of the snapshot weight
+and the current eligible weight (`weight = min(pastVotingEligibleShares(...), votingEligibleShares(voter))`)
+at all four read sites — so exiting forfeits voice on the in-flight proposal. The fix replaced four
+inline weight reads with one helper, which net *shrank* `Governance`. Requires redeploy + re-review.
+
+## Regression test
+
+`contracts/test/audit/AuditVoteAfterExit.t.sol` (2 tests, including the passing VO-9 control).
+
+## Links
+
+- [[governance]] · [[governance-commit-reveal]] · [[two-mode-exits]] · [[vaultcore]]
+- [[c2-unbounded-governance]] · [[highs]] (H-4) · [[mediums-and-lows]] (M-8) ·
+  [[threat-model-commitments]] (VO-9, EE-10) · [[security-index]]

--- a/docs/vault/c6-oracle-byzantine.md
+++ b/docs/vault/c6-oracle-byzantine.md
@@ -1,0 +1,65 @@
+# C-6 — The oracle quorum prescription is a fault-tolerance floor, silent on the Byzantine floor
+
+The custom aggregator's "m ≥ 5, quorum ≥ 3" prescription is a **fault-tolerance** floor (sound
+against benign withholdings), not a **Byzantine** one. It is silent on `quorum ≥ 2a + 1`, so two
+adversarial sources plus one withholding honest leg seize the lower median and re-open C-4's theft.
+
+## Why it matters
+
+Critical, and **new** (Phase-2 re-verification, issue #48). It re-opens C-4's measured 88.9% theft
+under a config that passes **every** constructor check. Because the tier is config/curation-
+conditional an auditor may re-rate to High — but **gate 0 does not clear while it is open**. It was
+surfaced by the pass that replaced the report's *inference* ("fixing C-3/H-1/H-2/M-1 removes C-4's
+trigger") with an executed end-to-end test driving a **real** `OracleAggregator` into a deposit.
+
+## Mechanism
+
+The H-1 remediation prescribes m ≥ 5 / quorum ≥ 3 and asserts the lower median is "bounded by the
+honest set." That is correct against *benign* withholdings (with `a = 0` controlled sources, `k` can
+fall to 3 and the median stays honest). With lower-median selection `fresh[(k-1)/2]`
+(`OracleAggregator.sol:131`, deliberately un-averaged to avoid H-1's even-`k` swing), an actor
+controlling `a` sources owns the reported price once the fresh count `k ≤ 2a`. Because `k` falls to
+the quorum through **ordinary withholding**, at m=5 / quorum 3 a single honest leg withholding drops
+`k` to 4, and two adversarial sources then own `fresh[1]`.
+
+**The withholding is routine, not hypothetical.** *Fail-closed at the source becomes fail-open at the
+aggregator*: the honest TWAP source going quiet fails closed by the H-2 fix's own logic (a pool quiet
+past `window/20` withholds), and `base-mainnet.json` records the cbETH Pyth leg live at 2549 s stale.
+
+**Measured** (`AuditC4EndToEnd.t.sol`, real aggregator → deposit): two creator-controlled sources
+depressed to 4% + the honest TWAP quiet → 1,000,000 USDC into a 2,777,762 USD claim; victim
+1,000,000 → 111,124 USD (−88.9%); in-kind exit realises 733.33 wETH + 916,668 USDC. Identical to
+C-4's table — because it **is** C-4, driven through the real oracle.
+
+**The boundary, derived and asserted.** An actor controlling `a` of the fresh `k` owns the lower
+median iff `k ≤ 2a`. Safety requires **`quorum ≥ 2a + 1`**; to also tolerate `f` benign withholdings,
+**`m ≥ 2a + f + 1`**. At quorum 3 the config tolerates exactly `a = 1`. **No clean code fix at m=5**:
+tolerating `a=2` needs quorum ≥ 5 (zero fault tolerance at m=5); genuine `a=2`-with-tolerance needs
+m ≥ 7. The cheapest adversary is the vault **creator**, who chooses the source list — two sources
+they control pass `MIN_SOURCES`, `MIN_MEDIAN`, the strict-majority rule, and M-1's distinctness loop.
+
+## Status
+
+**OPEN** at launch. Resolved in code by [[chainlinkoracle]] / [[chainlink-direct-pivot]] (PR #49): an
+additive `IOracleAggregator` that prices each asset from ONE Chainlink Data Feed — no median, no
+quorum, no per-vault source set — so C-6's median-gaming has no surface to exist (fail-closed reads, a
+per-asset sane-price band, the Base L2 sequencer-uptime guard, decimals→WAD, USDC pin; 32 tests,
+1,532 B). It deletes the whole oracle-finding class (C-3, C-4, C-6, H-1, H-2, H-3, M-1, M-14) by
+deletion. **But gate 0 stays NO-GO**: leaving the custom `OracleAggregator` user-selectable re-imports
+C-6, so a **factory-level oracle-gate** (make the custom aggregator non-deployable) is the next step —
+an owner decision — plus the external audit. Absent Chainlink, C-6 is a config/curation requirement:
+`quorum ≥ 2a + 1`, genuinely independent sources, no single actor controlling ≥ 2.
+
+## Regression test
+
+`contracts/test/audit/AuditC4EndToEnd.t.sol` (7 tests: `test_safe_*` establish the `a ≤ 1` safe
+boundary, `test_residual_*` + `test_c4EndToEnd_*` demonstrate the `a ≥ 2` theft;
+`test_hostileConfigPassesEveryConstructorCheck` proves the hostile config is admissible).
+
+## Links
+
+- [[chainlinkoracle]] · [[chainlink-direct-pivot]] · [[oracleaggregator]] · [[oracle-sources]] ·
+  [[oracle-layer]] · [[build-vs-buy]]
+- [[c4-depressed-price-theft]] · [[c3-oracle-brick]] · [[highs]] (H-1, H-2, H-3) ·
+  [[audit-reverification]] · [[threat-model-commitments]] (SF-1) · [[launch-readiness-gates]] ·
+  [[security-index]]

--- a/docs/vault/chainlink-direct-pivot.md
+++ b/docs/vault/chainlink-direct-pivot.md
@@ -1,0 +1,26 @@
+# Chainlink-Direct Pivot
+
+The resolution of C-6: price each asset from a single Chainlink Data Feed directly, instead of hardening the bespoke multi-source median aggregator. Shipped as `ChainlinkOracle.sol` (PR #49). **IMPLEMENTED / leading launch default.**
+
+## Why it matters
+
+C-6 ([[c6-oracle-byzantine]], issue #48) re-opened C-4's 88.9% theft: the custom aggregator's quorum prescription is a **fault-tolerance floor, silent on the Byzantine floor** `quorum ≥ 2a+1`. At `m=5`/`quorum=3` the two floors pull against each other — there is **no clean code fix at m=5** (tolerating `a=2` needs `quorum ≥ 5`, i.e. zero fault tolerance; genuine `a=2`-with-fault-tolerance needs `m ≥ 7`). The code cannot see how many sources a single actor controls, so hardening the aggregator only moves the problem.
+
+## The decision and rationale
+
+The entire oracle-finding class — C-3, C-4, C-6, H-1, H-2, H-3, M-1, M-14 — lives in the *custom* aggregation the protocol wrote. A Chainlink Data Feed is **itself** a decentralized aggregation of many independent, reputation-staked node operators with published deviation-threshold + heartbeat guarantees and years of mainnet Byzantine-fault tolerance: it already solves the `quorum ≥ 2a+1` problem at the network layer, far beyond a per-vault 5-source median.
+
+`ChainlinkOracle.sol` is an **additive** `IOracleAggregator` (a VaultCore can be deployed with it in the `oracle_` slot, **no VaultCore change**) that prices each asset from ONE feed — no median, no quorum, no per-vault source set — so C-6's median-gaming has **no surface to exist**. It fails closed on every bad read (revert/zero/negative/unset/future/stale), enforces a per-asset **sane-price band** (depeg clamp, since Chainlink deprecated on-aggregator min/maxAnswer), a **Base L2 sequencer-uptime guard** (down/grace), decimals→WAD normalization, and a USDC pin; construction decode-proves every feed. 32 tests (`ChainlinkOracle.t.sol`), 1,532 B. Two adversarial reviews confirm it eliminates the finding class **by deletion** — the strongest form.
+
+**Standard Chainlink Data Feeds are FREE to consume on-chain** (gas only; Data Streams / VRF / CCIP are the metered products), so cost is not an objection.
+
+**Recommendation / NEXT step in progress:** adopt Chainlink-direct as the **launch default** and make the custom [[oracleaggregator]] **non-deployable** via a factory-level oracle-gate — leaving the aggregator user-selectable re-imports C-6 for any vault that picks it. The factory gate is the next step, an owner decision. The mechanism choice (Chainlink-direct vs. curated custom aggregator with `quorum ≥ 2a+1`) is ultimately for the owner + external auditor.
+
+Accepted tradeoffs, documented: single-provider dependency (a feed freeze fails that asset closed, no fallback), assets without a Chainlink feed cannot be listed, and the deviation-band NAV arb (bounded; the vault-side defence is M-15).
+
+## Links
+
+- Resolves: [[c6-oracle-byzantine]] · related: [[c4-depressed-price-theft]] · [[c3-oracle-brick]]
+- Principle behind it: [[build-vs-buy]]
+- Contracts: [[chainlinkoracle]] · [[oracleaggregator]] · [[oracle-sources]] · [[oracle-layer]] · [[vaultfactory]] · [[vaultcore]]
+- State: [[current-state]] · [[open-items]] · [[prs-and-issues]] · [[decisions-index]]

--- a/docs/vault/chainlinkoracle.md
+++ b/docs/vault/chainlinkoracle.md
@@ -1,0 +1,77 @@
+# ChainlinkOracle
+
+The **NEW additive** price oracle: one Chainlink AggregatorV3 feed per asset, `IOracleAggregator`,
+immutable config, fail-closed. A VaultCore can be deployed with this **instead of** the bespoke
+[[oracleaggregator]] median. `contracts/src/oracle/ChainlinkOracle.sol`.
+
+## Why it matters
+
+This contract is the protocol's answer to [[c6-oracle-byzantine]]. The custom median in
+[[oracleaggregator]] could not be secured against adversarial sources inside a constructor — its
+integrity depends on a correctly-sized source set and a strict-majority quorum a creator can size
+wrong and an attacker can game by selectively stalling sources. ChainlinkOracle **removes the median
+entirely**: it trusts Chainlink's own decentralized OCR aggregation per asset. There is no median,
+no quorum, and no per-vault source list to misconfigure — so the whole C-6 / H-1 / M-1 attack
+surface disappears. This is the [[chainlink-direct-pivot]] decision made concrete.
+
+## Key state
+
+- `feedOf[asset]` — `FeedConfig { IAggregatorV3 feed; uint32 heartbeat; uint64 scale; uint128
+  minPriceWad; uint128 maxPriceWad; }`. `scale = 10**(18 - feedDecimals)`, cached at construction.
+  `feed == address(0)` is the unlisted sentinel.
+- `usdc` (immutable) — a token pinned to $1.00 (WAD), matching the TWAP source's quote-leg pin. The
+  constructor forbids an asset being both pinned USDC **and** carrying a feed.
+- `sequencerUptimeFeed` (immutable) — Chainlink L2 Sequencer Uptime Feed; `address(0)` off a
+  sequencer L2 (local / L1 / tests).
+- `GRACE_PERIOD` = 3600 s — prices in the first hour after a sequencer restart are not trusted.
+
+## How it prices (`priceWad`)
+
+Order matters, and every failure surfaces as `StaleOracle(asset)` and nothing else:
+
+1. **Sequencer gate first** (`_requireSequencerUp`) — reverts unless the L2 sequencer is up AND has
+   been up longer than the grace period. No-op when no uptime feed is configured.
+2. **USDC pin** — returns `1e18` for the pinned quote leg.
+3. **Feed read** (`try latestRoundData`) — rejects `answer <= 0`, `updatedAt == 0`, a future
+   timestamp, and staleness past the heartbeat (saturating lower bound). Normalizes by `scale`.
+4. **Sane-price band** (when enabled) — rejects a price outside `[minPriceWad, maxPriceWad]`. This
+   defends against a feed reporting a **deprecated min/maxAnswer clamp value** during a depeg /
+   flash-crash, which reads as "fresh" but out-of-band; fail closed rather than price it.
+
+Like [[oracleaggregator]] it **never returns 0** and **never returns a stale price** — every NAV
+path in a consuming vault freezes on a bad read, including exits (the accepted K-4 / SF-2 posture).
+
+## How it resolves C-6
+
+[[c6-oracle-byzantine]] is a property of *median selection over a curated source set* — it lives in
+[[oracleaggregator]]. ChainlinkOracle links the same finding with the **opposite** framing: by
+having exactly one feed per asset and delegating aggregation to Chainlink's OCR network, there is no
+"2-of-n freshness regime" for a creator to size wrong or an attacker to game. The finding is
+**resolved**, not merely mitigated, for a vault that chooses this oracle.
+
+## Tradeoffs (accepted, stated honestly)
+
+- **Single-provider dependency:** a feed deprecation / freeze fails that asset closed (safe, but the
+  vault freezes with no fallback).
+- Assets **without** a Chainlink feed on the chain cannot be listed.
+- A feed updates only on its heartbeat or a deviation-threshold move, so a price up to ~the
+  deviation band stale reads as "fresh" — a bounded, inherent-to-Chainlink NAV arb. The vault-side
+  defense is M-15's `minSharesOut` (see [[vaultcore]]).
+- **`decimals()` assumption:** `scale` is cached on the convention that Chainlink holds `decimals()`
+  constant across proxy upgrades. A decimals change on upgrade would silently mis-scale — accepted,
+  documented, convention-backed.
+
+## Construction-time proofs
+
+The constructor reads each feed's `decimals()` and calls `latestRoundData()` to prove the feed
+speaks the AggregatorV3 ABI where a mistake is still fixable. Because config is immutable, the
+per-call raw-staticcall decode guard that [[oracleaggregator]] needs (C-3) is **not** repeated — no
+listed feed can later revert-with-empty on a well-formed proxy. Codeless feeds, `decimals > 18`,
+zero-address / duplicate assets, and an ill-ordered price band are all rejected.
+
+## Links
+
+- [[contracts-index]] · [[oracleaggregator]] · [[oracle-sources]] · [[vaultcore]]
+- Architecture: [[oracle-layer]]
+- Findings: [[c6-oracle-byzantine]] · [[c3-oracle-brick]]
+- Decision: [[chainlink-direct-pivot]] · [[build-vs-buy]] · [[launch-readiness-gates]]

--- a/docs/vault/continuous-autonomous-mode.md
+++ b/docs/vault/continuous-autonomous-mode.md
@@ -1,0 +1,23 @@
+# Continuous Autonomous Mode
+
+The operating model for this build: full autonomy, constant output, parallel workers — sprint approval gates lifted so work proceeds without a per-step human sign-off. **ACTIVE (approval gates lifted 2026-08-18).**
+
+## Why it matters
+
+The protocol was built and then hardened across fifteen sprints plus a security remediation arc without pausing for approval at each sprint boundary. This mode is what let the Phase-2 remediation close twelve findings, re-verify the Criticals, and pivot the oracle stack in a tight window — but it is also why discipline around the shared worktree and evidence integrity matters so much: nobody is gating each commit.
+
+## The decision and rationale
+
+**Full autonomy:** the owner lifted the sprint approval gates, so workers plan, implement, test, and merge without stopping for confirmation on routine steps. Human decisions are reserved for genuinely irreversible or judgment-bound calls (e.g. the [[chainlink-direct-pivot]] mechanism choice, supplying real mainnet feed addresses, commissioning the external audit).
+
+**Constant output:** the expectation is continuous forward motion — a steady stream of focused, CI-gated PRs (see [[auto-merge]]) rather than large infrequent drops.
+
+**Parallel workers:** multiple sessions run concurrently, each owning a finding or sprint. This is fast but has a sharp edge: **concurrent sessions share one git worktree**, so `git add -A` is banned — it once swept another sprint's contracts work into an unrelated PR. Staging is always explicit and per-file.
+
+The guardrails that make autonomy safe here are the CI battery (gate 8), the preserved exploit tests in git history, and the discipline of re-marking evidence STALE when the tree moves ([[audit-reverification]]) — because in continuous mode there is no human checkpoint to catch a green board that has quietly stopped measuring the current code.
+
+## Links
+
+- Pairs with: [[auto-merge]] · [[decisions-index]]
+- Evidence discipline it depends on: [[audit-reverification]] · [[launch-readiness-gates]]
+- Output it produced: [[remediation-history]] · [[current-state]] · [[prs-and-issues]]

--- a/docs/vault/contracts-index.md
+++ b/docs/vault/contracts-index.md
@@ -1,0 +1,75 @@
+# Contracts Index
+
+The on-chain surface of the agent-governed-vaults protocol: a Solidity 0.8.26 package under
+`contracts/src/`, BUSL-1.1 licensed. This note is the hub of the **Contracts cluster** — start
+here and follow the `[[wikilinks]]` into each module.
+
+## Why it matters
+
+Everything the protocol promises — permissionless USDC index vaults, AI-agent governance by
+commit-reveal vote, in-kind two-mode exits, a multi-source price oracle — is enforced here or
+nowhere. The design is deliberately **admin-free**: there are no upgrade proxies, no owner
+setters, no pause guardian. Every trust-relevant choice is fixed at construction and immutable
+after, because the vault creator is treated as **untrusted by explicit design**. That posture is
+what makes constructor validation load-bearing and what shapes nearly every security finding.
+
+## The modules
+
+- [[vaultcore]] — holds ALL funds; shares, NAV, deposits, redemptions, rebalancing, sub-vault
+  flows. EIP-170-constrained (the binding size limit of the whole package).
+- [[governance]] — commit-reveal proposals, quorum, standing defaults, delegation, timelock.
+- [[oracleaggregator]] — the bespoke per-vault multi-source **median** oracle (finding
+  [[c6-oracle-byzantine]] lives here).
+- [[chainlinkoracle]] — the **NEW additive** Chainlink-direct oracle ([[chainlink-direct-pivot]])
+  that **resolves** C-6 by removing the median entirely.
+- [[oracle-sources]] — the `IPriceSource` implementations feeding OracleAggregator (Chainlink
+  adapter, Uniswap V3 TWAP, Pyth), i.e. SF-1 mechanism diversity.
+- [[vaultfactory]] — permissionless canonical deployment + attestation; carries the C-1
+  `allowSubVaults=false` launch gate ([[root-vaults-only]]).
+- [[vaultdeployer]] — the factory's one construction path; exists solely because VaultCore's
+  creation code exceeds EIP-170.
+- [[subvaultregistry]] — parent/child edges, depth cap, fee stacking, quorum inheritance.
+  **DORMANT-AT-LAUNCH** (sub-vaults disabled).
+- [[feeengine]] — 10% performance fee on realized profit, high-water-mark carry via registry.
+- [[operatorregistry]] — operator identity, cross-vault loss carry, aggregate leaderboard.
+- [[execution-adapters]] — the `IExecutionAdapter` venues rebalances route through (aggregation
+  router + direct V2 pool).
+- [[safetransferlib]] — vendored bounded ERC-20 helpers and `BoundedCall` (returndata / gas
+  hardening).
+
+## Deployment topology (wiring order)
+
+The singletons are wired once, at deploy time, then locked:
+
+1. `OperatorRegistry` and `SubVaultRegistry` deploy first (each records its `deployer`).
+2. `FeeEngine` binds to the registry.
+3. `VaultDeployer` is deployed (it embeds `type(VaultCore).creationCode`).
+4. `VaultFactory` binds registry + governance + feeEngine + subVaultRegistry + deployer, and
+   takes the `allowSubVaults` switch.
+5. `OperatorRegistry.wire(factory, feeEngine)` and `SubVaultRegistry.wire(factory)` and
+   `Governance.wireSubVaultRegistry(...)` lock the one-shot edges.
+
+Per vault: the creator calls `VaultFactory.createVault`, then (second tx) `registerVault` on
+[[governance]] with a `GovConfig`. Until registration, no proposal can exist and every exit
+settles in Mode I.
+
+## EIP-170 headroom snapshot
+
+The runtime-bytecode size cap (24,576 B) governed **what could be fixed at all** during
+remediation. Current margins (post-M-15; see [[vaultcore]] for the reconciliation):
+
+| Contract | Runtime | Margin |
+| --- | --- | --- |
+| VaultCore | ~24,293 B | **~283 B** |
+| Governance | ~12,051 B | ~12,525 B |
+| UniswapV3TwapSource | ~5,169 B | ~19,407 B |
+| VaultFactory | ~2,818 B | ~21,758 B |
+| OracleAggregator | ~1,215 B | ~23,361 B |
+
+## Links
+
+- Clusters: [[architecture-overview]] · [[security-index]] · [[current-state]] · [[decisions-index]]
+- Decisions in play here: [[root-vaults-only]] · [[chainlink-direct-pivot]] ·
+  [[build-vs-buy]] · [[delegatecall-split-rejected]]
+- Architecture: [[nav-and-shares]] · [[governance-commit-reveal]] · [[two-mode-exits]] ·
+  [[oracle-layer]] · [[sub-vaults]] · [[fees-and-carry]]

--- a/docs/vault/current-state.md
+++ b/docs/vault/current-state.md
@@ -1,0 +1,35 @@
+# Current State
+
+What is true right now. The live branch is `protocol/main`; the launch verdict is **NO-GO**. Snapshot as of the Phase-2 remediation and the C-6 / ChainlinkOracle pivot (2026-08-28).
+
+## Why it matters
+
+This protocol is immutable at deployment, so "ship" is a one-way door. This note is the single place to read the current go/no-go posture without reconstructing it from PRs and audit prose. If a row here says NO-GO, real money should not go in.
+
+## Launch verdict: NO-GO
+
+Two gates keep it there ([[launch-readiness-gates]]):
+
+- **Gate 0 — no known unfixed Critical: NO-GO, on C-6.** Four of five original Criticals are closed with **executed** evidence: C-1 ([[root-vaults-only]]), C-2, C-3, C-5. C-4/C-6 keep the row NO-GO — the Phase-2 re-verification (`AuditC4EndToEnd.t.sol`) falsified the inferred "C-4 path closed" claim and surfaced **C-6** ([[c6-oracle-byzantine]]): at `a ≥ 2` adversarial oracle sources the theft re-opens. C-6 has no clean code fix at m=5; the leading resolution is the [[chainlink-direct-pivot]].
+- **Gate 1 — external audit: NO-GO.** Not started, and nothing in these sessions could change it — an AI pre-audit is not an external audit. Commission a **full** review of the corrected tree at a new tag (`v0.4.0-audit` recommended); it must also cover the remediation itself.
+
+## Branch and evidence state
+
+- **Live branch:** `protocol/main`. Remediation lands via [[auto-merge]] per-finding PRs.
+- **Merged (Phase 2):** #43 (C-1 root-vaults-only), #44 (H-8), #45 (M-15), #46 (dispositions), #47 (C-6 re-verification), #49 (ChainlinkOracle). See [[prs-and-issues]].
+- **Open issues:** #40 (VaultCore-headroom sprint), #41 (rebuild `base-mainnet.json`), #48 (C-6 tracking).
+- **CI (gate 8): GO.** Full battery green — `forge fmt --check`, `forge build --sizes`, `forge test`, `forge snapshot --check`, and the backend suite all pass. (The last recorded `forge test` count was 252 pass / 0 fail / 0 skip on the 2026-08-27 remediation branch; later PRs added tests, so treat the count as indicative, not a live `protocol/main` figure — forge was not re-run here.) Green certifies the gates *ran*, not that the protocol is safe.
+- **Evidence STALE:** the remediation changed six contracts, so gates 2 (testnet lifecycle), 3 (soak), and 6 (canary) are re-marked STALE — their reports describe superseded bytecode. Gate 4 (live x402 settlement) is the one operational gate that survives intact. See [[audit-reverification]].
+- **`base-mainnet.json`: NOT-DEPLOYABLE** — the config no longer builds against the hardened constructors (needs 5 sources/asset at quorum 3, `maxObservationAge ≤ window/20`); real addresses are a human input.
+
+## Launch shape once GO is reached
+
+Root vaults only, majors-only baskets (WETH + cbETH), first `capacityCapUsdc` 50,000 USDC, Chainlink-direct oracle as the intended launch default. See [[go-to-market-plan]].
+
+## Links
+
+- Gates & evidence: [[launch-readiness-gates]] · [[audit-reverification]] · [[open-items]]
+- The arc that got here: [[remediation-history]] · [[prs-and-issues]]
+- Decisions in force: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[build-vs-buy]] · [[delegatecall-split-rejected]] · [[continuous-autonomous-mode]]
+- Open Criticals: [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]]
+- Plan: [[go-to-market-plan]] · [[decisions-index]] · [[security-index]]

--- a/docs/vault/decisions-index.md
+++ b/docs/vault/decisions-index.md
@@ -1,0 +1,22 @@
+# Decisions Index
+
+The hub for the protocol's load-bearing decisions — the choices that shaped the launch surface, and the reasoning behind each one.
+
+## Why it matters
+
+This protocol is **immutable at deployment**: no proxy, no pause, no admin, no migration. Every decision here is therefore permanent for the vaults it governs, so each was argued rather than asserted. When a future reader asks "why is it built this way?", the answer lives in one of these notes — and each links back to the security finding or principle that forced the call.
+
+## The decisions
+
+- [[root-vaults-only]] — sub-vaults disabled at launch (`VaultFactory.allowSubVaults = false`); the C-1 fix and the cheapest risk reduction in the whole document.
+- [[chainlink-direct-pivot]] — resolve C-6 by consuming Chainlink Data Feeds directly instead of hardening the bespoke aggregator; the leading launch-default direction.
+- [[build-vs-buy]] — the standing principle behind the pivot: prefer mature, audited external infrastructure over bespoke re-implementations. The custom oracle is the cautionary tale.
+- [[delegatecall-split-rejected]] — the EIP-170 delegatecall split came off the launch path once sub-vaults were disabled and the byte pressure eased.
+- [[auto-merge]] — how remediation PRs flow to `protocol/main`.
+- [[continuous-autonomous-mode]] — the operating model: full autonomy, constant output, parallel workers.
+
+## Links
+
+- [[current-state]] · [[remediation-history]] · [[open-items]] · [[prs-and-issues]]
+- [[security-index]] · [[launch-readiness-gates]] · [[audit-reverification]]
+- Criticals resolved by these decisions: [[c1-empty-electorate]] · [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]]

--- a/docs/vault/delegatecall-split-rejected.md
+++ b/docs/vault/delegatecall-split-rejected.md
@@ -1,0 +1,23 @@
+# Delegatecall Split — Rejected at Launch
+
+A proposed EIP-170 workaround — splitting `VaultCore` logic across a delegatecall'd library to reclaim bytecode headroom — was taken **off the launch path** once sub-vaults were disabled. **REJECTED-AT-LAUNCH.**
+
+## Why it matters
+
+`VaultCore` runs against the EIP-170 24,576-byte contract-size ceiling: at the end of the remediation session it had only **1,014 B** of margin. That budget governed *which findings could be fixed at all* — H-5, H-6, H-9 and M-15's exit-side remain unfixed precisely because they land in `VaultCore` and there is no room. A delegatecall split was the obvious way to buy headroom for that work.
+
+## The decision and rationale
+
+The split was attractive only while the un-fixed, `VaultCore`-resident findings were **on the launch path**. Two things removed that pressure:
+
+1. **[[root-vaults-only]] disabled sub-vaults**, which made H-5, H-6, H-7, H-9 **DORMANT-AT-LAUNCH** (they all require a funded child, which cannot exist). The most byte-hungry pending work was no longer launch-blocking.
+2. The remaining byte spends were absorbed without a split — notably **M-11 returned 336 B** (bounded assembly is smaller than the `abi.decode` path it replaced, and the helpers inline at every call site), which is the only reason M-2's 504-byte escrow routing fit at all.
+
+A delegatecall split is not free: it adds an indirection layer, a new trust boundary, and storage-collision risk to the most delicate contract in the system — exactly where unreviewed complexity is least welcome before an external audit. With the launch-critical `VaultCore` work either done or deferred-with-sub-vaults, the split's cost stopped being worth paying **now**. It is deferred, not deleted: if a future sub-vault release reintroduces the H-5/H-6 pressure, the split (or moving code out of `VaultCore`) returns as a live option.
+
+## Links
+
+- Enabled by: [[root-vaults-only]] · relieved findings: [[highs]] (H-5/H-6/H-9)
+- Contracts: [[vaultcore]] · [[execution-adapters]] · [[safetransferlib]]
+- Byte-budget context: [[remediation-history]] · [[open-items]] · [[launch-readiness-gates]]
+- Related decisions: [[decisions-index]] · [[build-vs-buy]]

--- a/docs/vault/execution-adapters.md
+++ b/docs/vault/execution-adapters.md
@@ -1,0 +1,61 @@
+# Execution Adapters
+
+The `IExecutionAdapter` implementations a passed rebalance routes swap legs through. Two ship: an
+aggregation-router adapter (0x/1inch-style) and a direct Uniswap-V2-pair adapter.
+`contracts/src/AggregationRouterAdapter.sol`, `contracts/src/DirectPoolAdapter.sol`.
+
+## Why it matters
+
+Rebalancing is the one path where vault funds leave for an external venue and come back. It is the
+classic drain surface — the arbitrary-calldata exploit class (SwapNet/Aperture 2026, Dexible 2023,
+Unizen 2024, LI.FI). VaultCore's `executeRebalance` allow-lists adapters fixed at creation (EX-1)
+and never trusts an adapter's return value: it debits internal accounting before each swap and
+credits the **measured balance delta** after (EX-3). The adapters enforce the same contract on their
+own side. That two adapters with entirely different venue shapes satisfy one interface is the
+concrete proof of the venue abstraction (C-2).
+
+## The shared safety contract (EX-1..EX-3)
+
+- **Target is pinned immutable** — `routeData` cannot choose its own target (EX-2). The aggregation
+  adapter pins `router`; the direct adapter pins `pair`.
+- **`minAmountOut` and `deadline` enforced HERE on measured balance deltas** — never trusted from
+  router return values or calldata-embedded slippage params (EX-3). `minAmountOut > 0` is mandatory,
+  never optional.
+- **Approvals are per-swap and revoked after; leftovers swept back to the caller.**
+
+## AggregationRouterAdapter
+
+- `router` immutable; `allowedSelector[bytes4]` allowlist fixed at construction (EX-1) —
+  `routeData`'s selector must be on it.
+- `executeSwap`: pull `tokenIn`, approve `router`, `router.call(routeData)`, measure
+  `tokenOut` delta, require `>= minAmountOut`, revoke approval, sweep unspent `tokenIn` back. Partial
+  fills never strand funds.
+
+## DirectPoolAdapter
+
+- Pinned to one immutable V2-style `pair`; `token0` / `token1` cached.
+- `executeSwap`: computes `amountOut` **on-chain** from reserves (constant-product, 0.30% fee), does
+  the pair swap, then still enforces `minAmountOut` on the measured delta — the quote is never
+  trusted as the accounting source.
+
+## Defence-in-depth from VaultCore
+
+The adapter's measured-delta check is **not** a slippage bound — it is a defence against a lying
+router. The actual slippage bound is VaultCore's **H-4** `MAX_REBALANCE_SLIPPAGE_BPS = 200` (2%),
+which values each leg against the vault's *own* oracle before executing. See [[vaultcore]]. This
+layering is deliberate: the adapter defends against the venue, the vault defends against a bad trade
+that governance approved.
+
+## Security findings that touch here
+
+- **EX-1 / EX-2 / EX-3** — the pinned-target, selector-allowlist, and measured-delta discipline
+  above.
+- **M-11** — both adapters call ERC-20 transfers through [[safetransferlib]], whose returndata-bomb
+  hardening covers the adapter call sites. See that note.
+
+## Links
+
+- [[contracts-index]] · [[vaultcore]] · [[safetransferlib]]
+- Architecture: [[nav-and-shares]]
+- Findings: [[highs]] · [[mediums-and-lows]] · [[threat-model-commitments]]
+- Decision: [[build-vs-buy]]

--- a/docs/vault/feeengine.md
+++ b/docs/vault/feeengine.md
@@ -1,0 +1,68 @@
+# FeeEngine
+
+The performance-fee module: 10% on realized profit, high-water-mark via a cross-vault loss
+carryforward read from [[operatorregistry]]. A factory-wired singleton shared by every vault.
+`contracts/src/FeeEngine.sol`.
+
+## Why it matters
+
+This is where a member's realized gain becomes an operator's fee. Crystallization happens **only at
+member redemption** (CM-3): [[vaultcore]] calls `onRealize` with the member's realized P&L, the
+engine nets it against the `(member, operator)` loss carry (read pre-update; the registry consumes
+it afterward in the same settlement), and returns 10% of the **net** gain. Because it is a
+singleton touched by every vault's exit path, a bug here — or the engine's own address being
+blacklisted by a stablecoin issuer — is a systemic exit-liveness risk, which is exactly what two of
+its findings address.
+
+## Key state
+
+- `PERF_FEE_BPS` = 1000 (10%).
+- `registry` (immutable) — the `IRegistryView` for carry reads, identity, and fee stats.
+- `claimableFees[operator][token]` — collected fees awaiting operator claim.
+- `_lock` — a reentrancy mutex (M-3, see below).
+
+## Entry points
+
+- `onRealize(member, gainUsdc, lossUsdc)` — returns the assessed fee. Requires the caller be an
+  attested vault (`operatorOf(msg.sender) != 0`).
+- `onFeeCollected(member, amountUsdc)` / `onFeeCollectedAsset(member, asset, amount)` — the vault
+  reports what it **actually transferred**; operators are credited strictly from collected amounts.
+  USD-terms stats are recorded on the cash leg only.
+- `pullEscrowed(vault, asset)` — permissionless crank to pull an in-kind fee slice the vault
+  EE-6-escrowed after a failed transfer, and credit it to the vault's operator.
+- `claimFees(token)` — operator withdraws accumulated fees.
+
+The vault treats this module as **untrusted**: it clamps the returned fee to <= 10% of gain
+(`gain / 10`) and calls the engine **bounded and non-blocking** (H-1). A hostile or broken engine
+loses its own bookkeeping, never a member's exit — see [[vaultcore]].
+
+## Security findings that live here
+
+- **M-3 (cross-vault reentrancy).** `FeeEngine` had **no mutex**, and it does **not** inherit
+  VaultCore's — `pullEscrowed` measures a balance delta straddling a full-gas external call
+  (`claimEscrowed`) that a hook token can re-enter, and the nested call targets a **different**
+  vault, so that vault's own guard is not on the path. The arithmetic: an inner `pullEscrowed`
+  credits its own `X`; the outer frame then measures the whole delta `X + X2` and credits that too,
+  so `2X + X2` is credited against `X + X2` delivered — whoever claims first is paid from another
+  operator's balance. Fixed with a **whole-engine** `nonReentrant` (per-vault would not see the
+  cross-vault nesting); `claimFees` and `pullEscrowed` both guarded. (Note: the report records that
+  ERC-777 specifically does **not** work here — this engine is not an ERC-1820 implementer — but that
+  closes one hook mechanism, not the class.)
+- **M-2 (escrow of the USDC fee leg) — remediated in [[vaultcore]], systemic *because of* this
+  contract.** `feeEngine` is the shared singleton and exactly the address class a stablecoin issuer
+  blacklists. Once listed, a reverting `safeTransfer(feeEngine, ...)` made **every** exit carrying a
+  positive performance fee, in **every** vault, revert permanently. VaultCore now degrades that leg
+  to escrow. See [[fees-and-carry]] and [[mediums-and-lows]].
+
+## HWM portability
+
+The high-water-mark is **portable across vaults per operator**: a member who realized a loss under
+an operator in vault A pays no performance fee under that operator in vault B until made whole. The
+carry lives in [[operatorregistry]] (`carryOf[member][opId]`); FeeEngine reads it, VaultCore's
+`_recordRealization` mutates it afterward.
+
+## Links
+
+- [[contracts-index]] · [[operatorregistry]] · [[vaultcore]] · [[subvaultregistry]]
+- Architecture: [[fees-and-carry]]
+- Findings: [[mediums-and-lows]] · [[threat-model-commitments]]

--- a/docs/vault/fees-and-carry.md
+++ b/docs/vault/fees-and-carry.md
@@ -1,0 +1,67 @@
+# Fees and Carry
+
+**Definition.** The performance-fee system: a 10% fee on *realized profit* crystallized only at
+member redemption ([[feeengine]]), with a high-water mark carried as a **USDC-denominated loss
+carryforward per `(member, operator)`** across all vaults sharing the [[operatorregistry]].
+
+**Why it matters.** The cross-vault HWM is what makes "no cherry-picking" real: an operator can't
+shed a losing track record by minting a fresh identity, and a member who lost under an operator
+pays no fee elsewhere until made whole. This is the **operator-registry immutable reference,
+commitment C-3** — load-bearing on VaultCore's redemption path from day one.
+
+## Performance fee (goes to the operator)
+
+`PERF_FEE_BPS = 1_000` (10%), on **realized profit only**, crystallized **only at member
+redemption** (CM-3) — realization is member-initiated by construction, so an operator cannot churn
+rebalances to force early fees. This is a **different mechanism** from the exit fee, which stays in
+the vault and accrues to remaining members ([[two-mode-exits]]) — the exit fee is described there,
+not here.
+
+## Cross-vault HWM as loss carryforward (commitment C-3, §7)
+
+NAVps is not comparable across vaults, so the portable mark is USDC-denominated carry:
+
+```
+onRealize(member, op, gain):  fee = 10% × max(0, gain − carry[member][op])
+                              carry[member][op] = max(0, carry[member][op] − gain)
+onRealize(member, op, loss):  carry[member][op] += loss
+```
+
+The engine reads carry **pre-update** from the registry; the registry consumes it afterward in the
+same settlement. A member who realized a loss under operator X in vault A pays no performance fee
+in vault B until X has made them whole. No prior art — Enzyme/dHEDGE use global per-vault marks —
+so this is treated as an **unvalidated mechanism** with extra invariant weight (§7 novelty).
+
+## Registry-gated integrity
+
+- Carry accrues **only** from vaults deployed by the canonical [[vaultfactory]] against the
+  canonical registry (CM-5) — else marks would be forgeable via throwaway vaults. Single-vault
+  carry-farming remains a documented residual (G3), gated economically by the 1% exit-fee cap
+  forcing ~100:1 transient capital fronting plus leaderboard reputation drag — a deterrent, not a
+  code fix.
+- **Leaderboard:** operator-level aggregate across **all** vaults sharing the registry; no per-vault
+  opt-out at the contract level. Aggregates only canonical-factory vaults; TVL-weighted and
+  member-count-weighted views stop dust vaults dominating (SF-4). Closed-vault history is retained
+  permanently — an operator can't wind down losers to shorten their loss window (SF-5). A fresh
+  identity = zero track record, making a reset visible and costly (CM-4; residual: reputation, not
+  funds, is the enforcement).
+
+## Hostile-module and payout defenses
+
+- The vault may **clamp** the returned fee (hostile-module defense) and reports what it actually
+  transferred via `onFeeCollected`; operators are credited strictly from *collected* amounts.
+- FeeEngine has its **own** reentrancy mutex (M-3) — it does not inherit VaultCore's, since a
+  nested `pullEscrowed` targets a *different* vault.
+- Fee withheld **uniformly** across cash and in-kind legs; asset-leg fees credited to the operator
+  via the engine's per-token claim flow (MO-4 — otherwise fully-invested vaults would pay ~zero
+  fee). Fee-assess vs carry-record are separate bounded calls; `MODULE_CALL_GAS = 300k` covers the
+  carry write (G5, not atomic but not exploitable at current params).
+- Operator-as-member receives the exit fee only via their member share like anyone else; the
+  prohibition is on *routing*, and routing is to shares, not identity (EE-9, **ACCEPTED**).
+
+## Links
+
+- [[architecture-overview]] · [[two-mode-exits]] (exit fee, the other fee) · [[nav-and-shares]]
+  (realization) · [[sub-vaults]] (fee stacking cap) · [[off-chain-stack]] (leaderboard indexer)
+- Contracts: [[feeengine]] · [[operatorregistry]] · [[vaultcore]] · [[safetransferlib]]
+- Security: [[threat-model-commitments]] · [[mediums-and-lows]]

--- a/docs/vault/go-to-market-plan.md
+++ b/docs/vault/go-to-market-plan.md
@@ -1,0 +1,36 @@
+# Go-to-Market Plan
+
+The shape of the first mainnet launch once GO is reached: what ships, at what size, with which parameters, and how it scales from there. Everything here is contingent on clearing gate 0 (C-6) and gate 1 (external audit).
+
+## Why it matters
+
+Because the protocol is immutable per vault, go-to-market is expressed almost entirely as **launch parameters** — immutable choices baked in at deploy. Staging isn't a marketing decision, it's a deployment decision: "staged caps" necessarily means *staged vaults*. This note is the argued launch configuration.
+
+## Launch configuration (argued, not asserted)
+
+- **Topology: root vaults only, zero sub-vaults.** The cheapest risk reduction anywhere — costs nothing, waits on no redeploy. See [[root-vaults-only]].
+- **Oracle: Chainlink-direct as the intended launch default** ([[chainlink-direct-pivot]]), with the custom aggregator made non-deployable via the factory oracle-gate (NEXT step). Contingent on C-6 being settled.
+- **First `capacityCapUsdc`: 50,000 USDC.** Large enough that a 10% performance fee on plausible returns pays for operations; small enough that a total-loss event — the honest worst case for a fresh immutable protocol — is survivable and compensable.
+- **First baskets: WETH + cbETH — majors only.** The TWAP source quantizes at $1e-6, a listing constraint below ~$0.01/token; no low-priced assets until a second verification pass. (Chainlink-direct requires each asset to have a Chainlink feed — a reasonable bound for a spot index of majors.)
+- **Exit fee:** `exitFeeMaxBps = 50`, decay 302,400 s (3.5 days) — the value exercised end-to-end in the soak.
+- **Governance config:** `3600/3600/0/86400`, quorum 2,500 bps root floor — the values the soak ran through five full rounds. Zero timelock is defensible *because* Mode-F exits exist.
+- **Oracle staleness:** 3,600 s/asset (not tighter — a tight bound drops the pull-based Pyth leg on most reads); `maxObservationAge ≤ window/20` is a hard constraint (90 s ceiling at the 1,800 s window).
+
+## Scaling path
+
+Raise capacity by **deploying a second vault (≥250k)** only after **≥30 incident-free days** with the canary clean. Do not launch an uncapped vault. Reinstate sub-vaults only after C-1's parent-casts-child-vote mechanism is built and audited **and** the SV-* drills are re-run against corrected contracts.
+
+## Keys & roles at launch
+
+Deployer EOA has **no post-wiring authority** (no owner functions exist); operator identity is a per-vault leaderboard identity with member-equal weight (cannot pause/upgrade/reprice/move funds); facilitator settler is stateless and only broadcasts `transferWithAuthorization`; API host and canary are keyless/read-only. Immutability means there is no admin key to compromise — and no admin key to fix a bug with.
+
+## Gate to GO
+
+Not yet. `v1.0.0-launch-candidate` is deliberately **not cut**. The path runs through [[open-items]]: settle C-6, commission the external audit, rebuild the mainnet config, re-run the STALE operational gates, record a restore drill.
+
+## Links
+
+- Current posture: [[current-state]] · [[open-items]] · [[launch-readiness-gates]]
+- Decisions shaping the launch: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[build-vs-buy]]
+- Mechanics: [[two-mode-exits]] · [[governance-commit-reveal]] · [[fees-and-carry]] · [[x402-metering]] · [[oracle-layer]]
+- History: [[remediation-history]] · [[prs-and-issues]] · [[decisions-index]]

--- a/docs/vault/governance-commit-reveal.md
+++ b/docs/vault/governance-commit-reveal.md
@@ -1,0 +1,79 @@
+# Governance (Commit-Reveal)
+
+**Definition.** The stake-weighted proposal system in [[governance]]: agents commit a hashed vote,
+reveal it after a deadline, and a passing proposal executes after a timelock — the only route to
+`executeRebalance` and to config changes on a [[vaultcore]].
+
+**Why it matters.** Governance capture is the master risk: whoever controls the vote controls the
+rebalance calldata. The oracle slippage bound (H-4) is what stops capture from becoming a *drain*,
+but the vote machinery itself — snapshots, quorum regimes, commit-reveal — is the first line.
+
+## Proposal types (structurally distinct on-chain)
+
+`enum ProposalType { Rebalance, RuleChange, ChildAllocation }`. The type is contract-fixed, not
+proposer-asserted text (VO-4), and it selects the quorum regime and payload shape:
+
+- **Rebalance** — routine; the **only** type standing defaults apply to (VO-4).
+- **RuleChange** — full-consensus + timelock; the near-immutable config path (CM-8 / K-2,
+  **ACCEPTED**). One permanently-offline member ⇒ rules frozen forever, by intent.
+- **ChildAllocation** — parent→child capital move (dead at launch, see [[sub-vaults]]).
+
+**One active proposal per vault at a time** (`activeProposalOf[vault]`), with a proposal cooldown
+(`PROPOSAL_COOLDOWN_FLOOR = 1 hour`, cap 30 days) — this is the CM-6 spam defense.
+
+## Commit-reveal
+
+- Commit `hash(support, salt)`; reveal after the commit deadline. Windows are vault-configured up
+  to hard caps: `COMMIT_HARD_CAP = 30 days`, `REVEAL_HARD_CAP = 30 days`,
+  `EXECUTION_WINDOW_HARD_CAP = 90 days`.
+- **Unrevealed commits are forfeit** (count as abstain) — non-revealers grief only themselves;
+  the quorum denominator is not starved (VO-6). Sizing note: Kleros abandoned commit-reveal (2026)
+  because voters *forget* to reveal, so reveal windows were sized generously.
+- The running tally **is** readable mid-reveal (public getter + cleartext `Revealed` events), but
+  the commit binds `support`, so a late revealer cannot switch direction on the partial tally — no
+  new exploit beyond ordinary reveal-order visibility (VO-7 / GA-2, documented residual; full
+  closure needs encrypted reveals, a deliberate v1 non-goal).
+
+## Quorum
+
+- Denominator = **voting-eligible stake at the proposal snapshot**, which *excludes* pending
+  deposits and Mode-F-locked shares ([[two-mode-exits]]). Registered parent vaults are excluded
+  too (GA-1). `QUORUM_FLOOR_BPS = 2_500` (25% protocol floor).
+- **< 5 members → absolute signer counts** (`SIGNER_REGIME_BELOW = 5`). The signer regime was
+  hardened (H-8): the FOR side must also clear the stake quorum (blocks near-zero-stake sybils
+  passing via head count) and passes on outright FOR-stake majority (blocks dust holders locking
+  out a dominant member). Regime-flip residual (buy the 5th seat) is a **listing constraint**:
+  `minDepositUsdc` must be economically meaningful (CM-7, partially remediated).
+
+## Standing defaults
+
+Count toward tally, **never quorum**; expire 72h after being set (`DEFAULT_TTL = 72 hours`); valid
+only for Rebalance proposals; must predate the proposal (`setAt < createdAt`, G4 fix). Offline
+agents auto-abstain otherwise (K-3, **ACCEPTED**).
+
+## Delegation
+
+Permitted; a delegate's aggregate *received* weight is capped
+(`CONCENTRATION_CAP_CEILING_BPS = 5_000`, i.e. ≤50%). The cap applies to received weight only, so
+a dominant/sole holder can always reveal their **own** weight (G1 fix — vaults are not dead on
+arrival). Re-checked at tally time against the snapshot, not just at delegation (VO-5).
+
+## Timelock
+
+Post-vote, vault-configurable, `TIMELOCK_HARD_CAP = 30 days`. **Mode-F redemption queueing begins
+at vote passage, not at timelock expiry** — so exit-before-execution is always available (VO-8),
+the subtlest economic seam in the design.
+
+## Module-call safety
+
+All governance/fee/registry module calls on the exit path are gas-capped
+(`MODULE_CALL_GAS = 300k`) and returndata-bounded to one word ([[safetransferlib]] /
+`BoundedCall`). A broken governance module falls back to Mode I — it loses forward pricing, never
+member liveness (MO-1).
+
+## Links
+
+- [[architecture-overview]] · [[two-mode-exits]] (Mode-F queue at passage) · [[nav-and-shares]]
+  (eligible-stake snapshot) · [[fees-and-carry]] · [[sub-vaults]]
+- Contracts: [[governance]] · [[vaultcore]]
+- Security: [[c2-unbounded-governance]] · [[c5-vote-after-exit]] · [[threat-model-commitments]]

--- a/docs/vault/governance.md
+++ b/docs/vault/governance.md
@@ -1,0 +1,105 @@
+# Governance
+
+The per-vault governance module: commit-reveal proposals, quorum tallying, standing absentee
+defaults, delegation, and the timelock + execution window. A singleton shared by every vault, keyed
+by vault address. `contracts/src/Governance.sol`.
+
+## Why it matters
+
+AI agents govern these vaults by voting, and this is where a vote becomes an authorized action
+against [[vaultcore]] — `executeRebalance`, `allocateToChild`, `redeemFromChild`, or a `RuleChange`
+that rewrites the vault's own `GovConfig`. Getting the vote accounting wrong is not a UX bug; it is
+a path to draining the vault. Three of the six criticals and most of the M-tier live in or touch
+this contract. It is also the second-largest contract by bytecode but has comfortable EIP-170
+headroom, so unlike [[vaultcore]] it was not byte-constrained during remediation.
+
+## Lifecycle
+
+`propose → commit phase → reveal phase → finalize → [timelock] → execute | expire`
+
+One active proposal per vault (`activeProposalOf`) — serialization is the CM-6 spam defense and
+keeps the Mode-F coupling in [[vaultcore]] unambiguous. Voting power is read from VaultCore
+checkpoints at `createdAt - 1` (VO-9), so stake minted in the proposal's own block — flash deposits
+included — carries zero weight.
+
+## Key state
+
+- `configOf[vault]` — the immutable-until-RuleChange `GovConfig` (phase durations, `quorumBps`,
+  `proposalThresholdBps`, `concentrationCapBps`, `proposalCooldown`).
+- `proposals[pid]` — `Proposal` with `createdAt`, phase deadlines, `snapshotTotal`, `memberCount`,
+  `forWeight` / `againstWeight` (tally, includes defaults), `revealedWeight` /
+  `revealedVoterCount` (the **quorum numerator** — defaults never count).
+- `commitOf`, `revealedOf`, `revealedSupportOf`, `defaultApplied`, `delegateAccrued`.
+- `standingDefaultOf`, `delegateOf`, `lastProposalAt` (per-proposer).
+- `subVaultRegistry` — one-shot `wireSubVaultRegistry`, for SV-6 quorum-floor inheritance.
+
+## Entry points
+
+- `registerVault(vault, cfg)` — once, by the vault creator; validates config and enforces the
+  parent quorum floor (SV-6).
+- `propose(vault, ptype, actionHash)` — `ProposalType` is `Rebalance | RuleChange | ChildAllocation`.
+- `commitVote(pid, commitment)` / `revealVote(pid, support, salt)`.
+- `revealDelegated(pid, delegator)` / `applyStandingDefault(pid, member)` — permissionless cranks.
+- `setStandingDefault` / `clearStandingDefault` / `setDelegate`.
+- `finalize(pid)` / `execute(pid, payload)` / `markExpired(pid)`.
+- `hasPendingExecution(vault)` / `isExecutor(vault, account)` — the `IGovernance` coupling read by
+  VaultCore.
+
+## Invariants and deliberate mechanics
+
+- **`hasPendingExecution` turns true at REVEAL START, not finalize** (VO-8 / K-1). Once reveals
+  begin the outcome leaks on-chain, so an exit taken after that point must be forward-priced (Mode
+  F). It turns false on Defeated / Executed / expiry (EE-10 — a queued exit can always eventually
+  settle). This is the single most load-bearing fact linking Governance to [[two-mode-exits]].
+- **Quorum regimes** (in `finalize`): `RuleChange` = full consensus (every unit of snapshot stake
+  revealed FOR, CM-8 / K-2); `<5` members at creation = the H-8 signer regime (below); otherwise
+  revealed stake >= `quorumBps` of `snapshotTotal` (VO-2).
+- **Defaults count toward the tally, never toward quorum** (VO-2 / K-3), expire 72h after being set
+  (VO-3), and are structurally limited to `Rebalance` on-chain (VO-4 — not proposer-asserted text).
+- **Payload type is never inferred from shape** — `execute` decodes strictly per the stored
+  `ProposalType`; `keccak256(payload) == actionHash` binds voters to the exact orders.
+
+## Security findings that live here
+
+- [[c2-unbounded-governance]] — the phase-duration **hard caps** (`COMMIT_HARD_CAP`,
+  `REVEAL_HARD_CAP`, `EXECUTION_WINDOW_HARD_CAP`, `TIMELOCK_HARD_CAP`, and the new
+  `PROPOSAL_COOLDOWN_CAP`). These fields are `uint32`, settable to ~136 years; unbounded, a vault
+  frozen mid-proposal could never legislate its way out (an unresolvable proposal blocks every
+  future proposal, and `hasPendingExecution` stays true so every exit freezes). Now bounded on both
+  sides.
+- [[c5-vote-after-exit]] — **`_boundedWeight` takes `min(snapshot, current)`**. This is C-5's fix
+  and it *lives here*, not in VaultCore: VaultCore only supplies the checkpoint reads. Previously an
+  attacker could deposit a dominant position, propose, exit completely (Mode I, instant), then
+  reveal FOR with full snapshot weight on stake they no longer owned — reducing the skin-in-the-game
+  requirement from days (timelock) to seconds. Taking the minimum closes the withdrawal direction
+  and finally makes EE-10's claim true (Mode-F-locked shares lose eligibility on the motivating
+  proposal).
+- **H-8 (CM-7)** — the `<5`-member regime is now an **OR of two branches**: (1) a strict majority
+  of members-at-creation revealed AND the FOR side clears the stake quorum; or (2) an outright FOR
+  stake majority regardless of head count. Branch 2 is purely additive (never locks anyone out — it
+  is *not* the M-6 floor). **Still unfixed by design:** buying the 5th seat to reach the stake
+  regime costs exactly `minDepositUsdc`, mitigated at the config layer.
+- **M-6** — the CM-6 / VO-5 defences (`proposalThresholdBps`, `concentrationCapBps`,
+  `proposalCooldown`) used to ship **disabled** in the reference configs. Now: concentration cap
+  ceiling 5000 bps (a delegate may not carry >50%), cooldown floor 1h. Deliberately **no floor on
+  `proposalThresholdBps`** — a floor was implemented, measured, and reverted (a flat membership
+  would make every member unable to propose, i.e. C-2's self-locking shape).
+- **M-7 — OPEN.** `lastProposalAt` is keyed **per-proposer**, so a second address sidesteps the
+  cooldown entirely. The bounds raise the cost of serial-proposal cycling but do **not** rate-limit
+  it. Stated honestly in the code; the cooldown cap does not close M-7.
+- Sprint-6 findings **F1** (a member's own weight is never concentration-capped — only delegated
+  weight is; self-accrual bricked dominant-holder vaults), **F2** (SV-6 floor re-checked on
+  RuleChange update), **F4** (a standing default must be set *before* the proposal and within TTL).
+
+## Size — EIP-170
+
+Runtime **~12,051 B** (~12.1 KB); EIP-170 margin **~12,525 B**. (The task's "~12.1KB" is the
+runtime *size*, not the headroom.) Governance net *shrank* during remediation despite gaining M-6's
+bounds, because C-5's fix replaced four inline weight reads with one `_boundedWeight` helper.
+
+## Links
+
+- [[contracts-index]] · [[vaultcore]] · [[subvaultregistry]]
+- Architecture: [[governance-commit-reveal]] · [[two-mode-exits]]
+- Findings: [[c2-unbounded-governance]] · [[c5-vote-after-exit]] · [[highs]] · [[mediums-and-lows]]
+- [[threat-model-commitments]]

--- a/docs/vault/highs.md
+++ b/docs/vault/highs.md
@@ -1,0 +1,92 @@
+# Highs
+
+The nine High-severity findings from the AI pre-audit. Four are fixed, four are dormant at launch
+(they need a funded child, unreachable under [[root-vaults-only]]), and one is partially fixed +
+config-mitigated.
+
+## Why it matters
+
+Highs are loss-of-funds or permanent-lockup findings one notch below Critical (each was adjusted up
+one level for immutability). The oracle Highs (H-1, H-2) feed C-4/C-6; H-4 is the unbounded-slippage
+gap that turns governance capture into a drain; H-8 is the key open High for a root-only launch.
+
+## The nine findings
+
+### H-1 — Lower median degenerates to `min()` at two fresh sources — **FIXED**
+The aggregator returned `fresh[(k-1)/2]`; at `k == 2` that is `fresh[0]`, the **minimum**, and the
+constructor permitted the documented 2-of-3 mainnet config. Bias is one-directional: downward. Fixed
+by requiring `k >= 3` and `quorum >= 3` (`MIN_MEDIAN`), so a "median" is always a median — which is
+why each asset now needs **five** sources and `base-mainnet.json` became NOT-DEPLOYABLE. Note the
+`k <= 2a` residual this leaves became [[c6-oracle-byzantine]]. Regression:
+`AuditAggregatorLowerMedian.t.sol`.
+
+### H-2 — TWAP reports a stale tick as zero seconds old — **FIXED**
+`UniswapV3TwapSource._meanTick` synthesizes its endpoint from the current tick; the live tick's
+weight is `min(A, W)/W`, reaching 1.0 once a pool is quiet for the window `W`. `latestPrice`
+hardcoded `updatedAt = block.timestamp` (`:255`), so a stale tick voted as fresh, and the constructor
+never required `maxObservationAge < window`. An earlier single-block-manipulation claim was **refuted
+against itself** (a swap writes an observation stamping the pre-swap tick, resetting `A`). What
+survives is the freshness misreport on an honestly-quiet pool. Fixed: the constructor now requires
+`maxObservationAge <= window / 20` (≤5% contamination). Regression: `AuditTwapRealCostModel.t.sol`,
+`AuditTwapFaithfulMock.t.sol`.
+
+### H-3 — The repo's own V3 mock made H-2 undetectable — **FIXED**
+`OracleSourceMocks.sol` generated cumulatives from a single current tick, so a correct historical
+TWAP and a live-tick extrapolation were numerically identical — no assertion in the 58-test Sprint-11
+oracle suite could fail for H-2's class. This is why H-2 survived internal review. Fixed by replacing
+the linear mock with a faithful observation-ring port (`FaithfulUniV3Pool.sol`). Test-only change.
+Regression: `AuditTwapFaithfulMock.t.sol` (8 tests + the faithful pool).
+
+### H-4 — EX-2's oracle-bounded slippage was never implemented — **FIXED**
+Both execution paths compared the measured output delta only against the **caller-supplied**
+`minAmountOut` (1 wei suffices); the oracle was never consulted on the execution path. The measured-
+delta check defends against a lying router (EX-3) but is not a slippage bound. Fixed:
+`executeRebalance` now bounds every leg against the vault's own oracle at
+`MAX_REBALANCE_SLIPPAGE_BPS = 200` (2%), a protocol constant (a creator-set value would be a silent
+no-op, M-6). Cost 375 VaultCore bytes.
+
+### H-5 — Child positions marked at gross look-through value — **DORMANT-AT-LAUNCH**
+`_childValueWad` marks the parent's child position at gross NAV; realization always returns strictly
+less (child exit fee, 10% perf fee, in-kind truncation), and SV-5 draws idle first, so the first
+exiter extracts the un-accrued realization drag from the remainers ($18 on identical deposits in the
+PoC). Requires a funded child → **dormant at launch** under [[root-vaults-only]]; deferred with
+sub-vaults.
+
+### H-6 — `ExitNeedsChildSettlement` is structurally unsatisfiable — **DORMANT-AT-LAUNCH**
+The shortfall loop sizes the child unwind **gross** but the child repays **net**, so a residual
+always survives the 1e-6 tolerance and `_settleExit` reverts; `++i` never revisits a child. Ordinary
+child fees and in-kind truncation (not just failing transfers) hit it on the default config,
+converting an unconditional exit right into a governance-liveness dependency. Requires a funded child
+→ **dormant at launch**; deferred with sub-vaults. (Its closure is also why the broken
+`redeemFromChild` escape hatch no longer matters at launch.)
+
+### H-7 — A frozen child governance strands the parent's exit — **DORMANT-AT-LAUNCH**
+C-2 applied to a *child*: `_childPendingExecution` returns true forever, the shortfall loop skips
+that child, `redeemFromChild` reverts `ChildSettlementPending`, and the parent's members never chose
+the child's config. Fixing C-2 removes the trigger. Requires a parent/child pair → **dormant at
+launch**; deferred with sub-vaults.
+
+### H-8 — The `<5`-member quorum regime is stake-blind and its boundary is purchasable for dust — **PARTIALLY FIXED + config-mitigated**
+The regime is selected by head count alone; a proposer buys the 5th seat for one `minDepositUsdc` to
+flip into the stake regime, or uses dust sybils to pass/grief in the signer regime. Status moved
+PLAUSIBLE → CONFIRMED by test. Fixed in code: the signer regime now also requires the FOR side to
+clear the stake quorum (kills the zero-stake sybil pass) and passes on an outright FOR-stake majority
+regardless of head count (kills the dust-griefing lockout) — additive, so no M-6 liveness cliff. The
+**regime-flip (buy the 5th seat) has no safe contract fix** and is **config-mitigated**: `minDepositUsdc`
+must be economically meaningful (base-mainnet.json smoke minimum raised 1 → 100 USDC). This is the
+key open High for a root-only launch. Regression: `AuditQuorumRegimeDust.t.sol` (3 tests).
+
+### H-9 — Read-only cross-contract reentrancy through look-through NAV — **DORMANT-AT-LAUNCH**
+`executeRebalance` and `_redeemChildMeasured` leave a `VaultCore`'s accounting understated during an
+external call; `nonReentrant` protects *that* vault, not an ancestor reading it through unguarded
+views inside `_childValueWad`/`_fullNavWad`. Per-contract mutex is definitionally no defence against a
+different contract reading mid-mutation — Slither's blind spot coincides. Requires a parent/child pair
+→ **dormant at launch**; deferred with sub-vaults.
+
+## Links
+
+- [[c1-empty-electorate]] (closes H-5/H-6/H-7/H-9 as a class) · [[c4-depressed-price-theft]] ·
+  [[c6-oracle-byzantine]] · [[root-vaults-only]]
+- [[oracleaggregator]] · [[oracle-sources]] · [[chainlinkoracle]] · [[governance]] · [[vaultcore]] ·
+  [[execution-adapters]] · [[sub-vaults]]
+- [[mediums-and-lows]] · [[threat-model-commitments]] · [[slither-triage]] · [[security-index]]

--- a/docs/vault/launch-readiness-gates.md
+++ b/docs/vault/launch-readiness-gates.md
@@ -1,0 +1,48 @@
+# Launch-readiness gates
+
+The mainnet go/no-go checklist ([LAUNCH-READINESS.md](../LAUNCH-READINESS.md)): nine gates, each with
+a verifiable artifact. **Verdict: NO-GO** — gate 0 held by the open Critical [[c6-oracle-byzantine]],
+gate 1 (external audit) not started.
+
+## Why it matters
+
+A green board measures the tests you wrote, and the tests you wrote encode the failures you already
+imagined — five Criticals sat under 189 passing tests, a clean soak, and a verified deployment. And
+the remediation **invalidated the evidence**: six contracts changed bytecode, so the testnet
+deployment, soak, and canary results now describe *superseded* contracts. Only gates 0 and 1 speak to
+safety, and both are NO-GO.
+
+## The nine gates
+
+| # | Gate | Verdict |
+|---|---|---|
+| 0 | No known unfixed Critical vulnerabilities | **NO-GO** — C-1/C-2/C-3/C-5 closed with executed evidence; C-1 closed at launch by [[root-vaults-only]]; **C-4/C-6 hold this row** (C-6 has no clean code fix at m=5; leading resolution is [[chainlink-direct-pivot]] plus a factory oracle-gate). Re-enabling sub-vaults reopens C-1. |
+| 1 | External audit completed, findings remediated | **NO-GO** — not started; an AI pre-audit is not an external audit. `v0.3.0-audit` withdrawn as an engagement reference; commission a **full** review at a new tag (`v0.4.0-audit`) covering the remediation itself. |
+| 2 | Testnet full lifecycle proven | **STALE** — the Base Sepolia deployment is now superseded bytecode; must be redeployed and re-run. |
+| 3 | Soak drills (Mode-F + sub-vault) | **STALE** — drills exercised exactly the paths the remediation touched; re-run against the corrected contracts. |
+| 4 | Live x402 settlement | **GO** (unaffected) — x402 is off-chain plus a USDC `transferWithAuthorization`; touches no contract this branch changed. The one operational gate that survives intact. |
+| 5 | Mainnet oracle stack config verified | **NO-GO** — the config no longer builds: H-1 needs quorum ≥ 3 (so 5 sources/asset), H-2 needs `maxObservationAge <= window/20`. `base-mainnet.json` is **NOT-DEPLOYABLE** with a `rebuildChecklist`. |
+| 6 | Canary operational | **STALE** — read-only and unchanged, but its evidence came from watching superseded contracts; re-earns alongside gate 3. |
+| 7 | Ops runbook exercised (a restore performed) | **CONDITIONAL** — the backup ring shipped, but a deliberate restore drill (~30 min, no keys) has not been recorded. |
+| 8 | All CI gates green | **GO** — `forge test` 252 pass / 0 fail; backend 553 (551 pass, 2 skip). Certifies the gates ran, not that the protocol is safe; `v1.0.0-launch-candidate` deliberately not cut. |
+
+## Launch parameters (§2)
+
+Root vaults only (the cheapest risk reduction — see [[root-vaults-only]]); first vault
+`capacityCapUsdc = 50,000`; `exitFeeMaxBps = 50`; governance `3600/3600/0/86400`, quorum 2,500 bps;
+oracle staleness 3,600 s per asset; **each asset now needs five price sources** (slots 4–5 carried by
+operator diversity); first baskets WETH + cbETH (majors only). EIP-170: `VaultCore` runs with **1,014
+B** of margin, the tight budget that governed what could be fixed in-contract.
+
+## The path to GO (§6)
+
+C-1 decided (root-only) · fix H-5/H-6 (need VaultCore bytes) · work H-8 + H-9 · rebuild
+`base-mainnet.json` (5 sources/asset, real addresses — a human task) · re-run the drill battery +
+soak, redeploy testnet · commission the external audit at a new tag · one recorded restore drill.
+
+## Links
+
+- [[c6-oracle-byzantine]] · [[c1-empty-electorate]] · [[c4-depressed-price-theft]] ·
+  [[root-vaults-only]] · [[chainlink-direct-pivot]]
+- [[highs]] (H-1, H-2, H-8) · [[audit-reverification]] · [[oracleaggregator]] · [[chainlinkoracle]] ·
+  [[x402-metering]] · [[current-state]] · [[go-to-market-plan]] · [[security-index]]

--- a/docs/vault/mediums-and-lows.md
+++ b/docs/vault/mediums-and-lows.md
@@ -1,0 +1,93 @@
+# Mediums and Lows
+
+The 15 Medium and 7 Low findings, with the report's launch disposition for the root-only
+configuration. Most Mediums are fixed; the rest are accepted design tradeoffs, config-mitigated, or
+dormant at launch.
+
+## Why it matters
+
+The Medium tier is where "value extraction or governance distortion" lives, plus the deploy-tooling
+and reference-config defects that make the mainnet config NOT-DEPLOYABLE. Several Lows are the
+enablers (L-1) or the zero-margin coincidences (L-2) behind larger findings.
+
+## Mediums
+
+- **M-1** — `OracleAggregator` accepted the same source address repeated (`[S,S,S]` had median `S`);
+  SF-1 independence unenforced. **FIXED** (O(m²) distinctness loop).
+- **M-2** — USDC settlement legs used reverting `safeTransfer`, not the EE-6 `tryTransfer`+escrow, so
+  a blacklisted `feeEngine` (a shared singleton) bricks every fee-paying exit protocol-wide;
+  falsifies PX-1. **FIXED** (both USDC legs routed through `tryTransfer` + `claimable`). Cost 504
+  VaultCore bytes, affordable only because M-11 returned 336.
+- **M-3** — `FeeEngine.pullEscrowed` is unguarded and its balance delta straddles a full-gas external
+  call (double-credit). **FIXED** (mutex / credit-from-callee). ERC-777 specifically does not work.
+- **M-4** — a settlement token with `dec < 6` bricks redemptions via the truncation-dust check.
+  **FIXED** (`require(usdcScalar <= SHORTFALL_DUST_WAD)`).
+- **M-5** — `navWad()` costs ~12M gas at the `MAX_CHILDREN` 8×8 fan-out (~730 `priceWad` calls vs the
+  fixture's 6); no path removes a child, so the tree can cross the block gas limit permanently.
+  **DORMANT-AT-LAUNCH** — the fan-out needs sub-vaults; at launch `navWad` loops the basket only (≤10).
+- **M-6** — the only worked config disabled its own CM-6/VO-5 defences (`proposalThresholdBps = 0`,
+  `concentrationCapBps = 10000`, `proposalCooldown = 0`, the last unvalidated). **FIXED** (concentration
+  ceiling + `proposalCooldown` bounds shipped; configs corrected). The `proposalThresholdBps` floor
+  was implemented, measured, and **reverted** — a fraction-of-live-stake floor a constructor cannot
+  see is C-2 shape (pinned in `AuditProposalThresholdFloor.t.sol`).
+- **M-7** — serial-proposal exit freeze: `propose → wait → finalize(Defeated) → propose` freezes exits
+  on a ~50% duty cycle for gas. **NOT mitigated** — the `proposalCooldown` floor is per-proposer and a
+  second address sidesteps it. Accepted residual, bounded by the ≥1h commit phase.
+- **M-8** — voters approve an opaque 32-byte `actionHash`; no on-chain payload disclosure.
+  **Accepted design tradeoff** — deliberate front-running (MEV) protection; the lapsed-`deadline`
+  sub-part is bounded by H-4's 2% slippage cap.
+- **M-9** — settlement timing is a free option over the exit performance fee (`gain/10`). **Accepted**
+  — bounded by `gain/10` and permissionless-crank market timing.
+- **M-10** — commit-reveal binds an address, not an actor: a whale splitting stake gets an informed
+  last-mover reveal at the cost of the forfeited half. **Accepted (VO-7 residual)** — inherent to
+  per-address commit-reveal.
+- **M-11** — `SafeTransferLib`'s non-`try` helpers are returndata-unbounded (MO-2 covers one of four
+  call shapes). **FIXED** — bounding the copy; the bounded-assembly path also returned 336 VaultCore
+  bytes, which made M-2 affordable.
+- **M-12** — the `VERIFIED-ON-CHAIN` badge licenses less than it appears (1 of 22 checks hard-coded
+  pass; `maxObservationAgeSeconds` never checked). **FIXED** (earlier remediation).
+- **M-13** — no deploy script consumes `base-mainnet.json`; the mainnet script has strictly weaker
+  post-conditions than the testnet one. **Deploy tooling** — not a contract defect; blocking for a
+  real mainnet deploy (tracked with #41), not for the contract security posture.
+- **M-14** — gas-capped `view` callers get a silently wrong (smaller-`k`, minimum) NAV; every
+  state-changing path is refuted with a number (a starved-source deposit needs > block gas limit).
+  **View-only, no funds at risk** — an integration constraint (do not gas-cap NAV reads).
+- **M-15** — no slippage/deadline protection on entry or exit; every deposit/exit is an unbounded
+  market order (the user-side half of C-4/H-1/H-2). **PARTIALLY FIXED** — a backward-compatible
+  `deposit(uint256 amountUsdc, uint256 minSharesOut)` overload reverts `SlippageExceeded`; deadline
+  dropped (both settle in-block) and exit-side `minValueOut` dropped for the byte budget (283 B left).
+  Partially subsumes C-4's deferred defence-in-depth. Regression: `AuditDepositSlippage.t.sol`.
+
+## Lows
+
+- **L-1** — `VaultFactory.createChildVault` performed no authorization on `parent`; the enabler that
+  removes the timelock race in C-1. **FIXED** (`msg.sender == parent.creator()`, commit `b50f652a`);
+  now moot at launch behind the C-1 `allowSubVaults` gate but retained for the enabled path.
+- **L-2** — `SHORTFALL_DUST_WAD` passes at 6 decimals with exactly zero margin (`1e12 − 1` vs `1e12`).
+  **FIXED** (assert the invariant).
+- **L-3** — `BoundedCall` returns a word built from uninitialised memory for 1–31-byte returndata;
+  `VaultCore.sol:588` does not gate on `retSize`. **FIXED** (zero `ptr` / gate on `retSize`); bounded
+  to Low by the `gain/10` clamp.
+- **L-4** — `minCardinality: 900` in `base-mainnet.json` is off by one (900 slots span 1798 s < 1800 s
+  window → constructor reverts). Fails closed; not currently triggered. Config note.
+- **L-5** — basket admission validates only `decimals() <= 18`; rebasing / double-entrypoint tokens
+  break accounting. **Accepted (creator-disclosed)** — a per-vault listing constraint.
+- **L-6** — SV-6 quorum-floor inheritance is never re-checked on children. **DORMANT-AT-LAUNCH** —
+  needs children; deferred with sub-vaults.
+- **L-7** — asymmetric absentee recall: `clearStandingDefault` is revocable mid-reveal while
+  `setDelegate` is locked. **Accepted asymmetry** — the standing default is the weaker, tally-only
+  instrument (never counts toward quorum), so member opt-out is defensible.
+
+## Informational
+
+I-1 (Pyth `conf` unvalidated pre-deploy), I-2 (`MODULE_CALL_GAS = 300_000` hardcoded on an immutable
+protocol), I-3 (`base-mainnet.json` self-contradictory status field), I-4 (dead code + four
+concentration-cap doc sites contradicting the code), I-5 (fees strandable in `FeeEngine`). Recorded,
+low or no action.
+
+## Links
+
+- [[oracleaggregator]] · [[oracle-sources]] · [[chainlinkoracle]] · [[feeengine]] · [[vaultcore]] ·
+  [[governance]] · [[vaultfactory]] · [[safetransferlib]] · [[execution-adapters]]
+- [[highs]] · [[c4-depressed-price-theft]] · [[c1-empty-electorate]] · [[root-vaults-only]] ·
+  [[threat-model-commitments]] · [[slither-triage]] · [[security-index]]

--- a/docs/vault/nav-and-shares.md
+++ b/docs/vault/nav-and-shares.md
@@ -1,0 +1,77 @@
+# NAV and Shares
+
+**Definition.** How [[vaultcore]] values the basket (NAV), converts between USDC and vault
+shares, and admits new capital through the observation window — all in WAD (1e18) internally,
+with USDC (6 decimals) scaled only at the boundary.
+
+**Why it matters.** Every deposit, redemption, fee, and vote weight is denominated against this
+accounting. Getting the pending-capital exclusion and forward pricing right is what defeats
+donation-style NAVps distortion (EE-1) and stale-valuation minting.
+
+## Not ERC-4626 (commitment C-1)
+
+In-kind redemption, swing pricing (specified only), and forward pricing each break
+`previewRedeem`/`previewWithdraw` round-trip guarantees, so the vault makes **no 4626 compliance
+claim**. It exposes 4626-shaped *read-only* views (`totalAssets`, `convertToShares`,
+`convertToAssets`) for tooling, documented indicative-only. (This is *commitment* C-1 — distinct
+from *audit* C-1, the empty-electorate critical [[c1-empty-electorate]].)
+
+## Definitions
+
+```
+NAV    = Σ_i balance_i × price_i  +  idleUSDC        (USDC terms, WAD internally)
+NAVps  = NAV × WAD / totalSupply                     (WAD; first deposit: 1e18)
+```
+
+`price_i` comes from the oracle ([[oracle-layer]]). **Sequestered (pending) deposits are excluded
+from NAV and from `idleUSDC` until activation.** If the oracle breaker is tripped, every NAV-
+reading function reverts — deposits, redemptions, execution — by design (K-4, **ACCEPTED**).
+
+Share math never reads raw `balanceOf`; it uses internal escrow accounting (defeats EE-1 donation
+manipulation). Rounding is always **against the actor** (mint rounds shares down, payout rounds
+down, fees round up), so dust accrues to the vault and the NAVps-non-decreasing invariant holds.
+
+## Deposit and forward pricing on entry
+
+Post-window (or window-skipped, or repeat deposit):
+
+```
+sharesMinted = amount × totalSupply / NAV        (amount × WAD / 1e18 if supply == 0)
+```
+
+Minted at the NAV of the *activation* transaction — **forward pricing on entry**, so a depositor
+can never mint against a stale valuation they observed 4 hours earlier.
+
+## Observation window (entry)
+
+- An agent's **first** deposit escrows USDC as a *pending deposit*: excluded from NAV, zero
+  shares, zero voting/proposal rights. After `OBSERVATION_WINDOW = 4 hours` anyone calls
+  `activate`, minting shares at activation NAV. Pending deposits are cancellable before activation.
+- **Skip:** an agent may irrevocably opt in to skipping the window for a given vault — shares mint
+  immediately. Once per agent per vault, cannot be undone. Repeat deposits by an existing member
+  mint immediately.
+- The window is a **social/observational** mechanism, **not** the Sybil defense. Flash-deposit
+  governance attacks are stopped by proposal-time stake snapshots ([[governance-commit-reveal]],
+  VO-9), not the window (EE-3).
+- **Pending capital is never frozen.** `cancelPending` reads no oracle, so an un-activated deposit
+  is always reclaimable even while the breaker is tripped (resolves OQ-1; verified by
+  `test_pendingDepositCancellableDuringOracleFreeze`). Only *active* share capital is trapped.
+
+## Other VaultCore accounting rules
+
+- **Shares are non-transferable in Sprint 1** (EE-7) — this moots share-aging fee dodges until
+  transferability is ever proposed.
+- **Creator 5% is a *withdrawal gate*, not a solvency condition** (`CREATOR_MIN_STAKE_BPS = 500`).
+  Creator redemptions revert if they would take creator share below 5% while ≥1 non-creator member
+  remains. Passive dilution below 5% by others' deposits is allowed and merely freezes creator
+  withdrawals until restored (CM-2).
+- **Capacity cap is OPTIONAL.** `capacityCapUsdc == 0` opts out (uncapped); `isCapped()` reports
+  which. When set, deposits above cap revert.
+- `MAX_BASKET_ASSETS = 10` bounds NAV-loop gas (E8).
+
+## Links
+
+- [[architecture-overview]] · [[two-mode-exits]] (redemption side) · [[oracle-layer]] (price_i) ·
+  [[fees-and-carry]] (realization at redemption) · [[governance-commit-reveal]] (eligible stake)
+- Contracts: [[vaultcore]] · [[oracleaggregator]] · [[safetransferlib]]
+- Security: [[c1-empty-electorate]] · [[threat-model-commitments]]

--- a/docs/vault/off-chain-stack.md
+++ b/docs/vault/off-chain-stack.md
@@ -1,0 +1,56 @@
+# Off-Chain Stack
+
+**Definition.** Everything outside the contracts: the event indexer, the metered read API, the
+agent SDK, the reference agent, the canary monitor, the operational logging library, and the web
+frontend — all chain-agnostic and built so the tested core needs no live RPC.
+
+**Why it matters.** The contracts are deliberately minimal (no upgrades, no admin); the intelligence
+— indexing, agent voting, monitoring — lives here. This layer is where an operator actually runs a
+vault, and where the [[x402-metering]] paid reads get their data.
+
+## Packages (`packages/`)
+
+- **indexer** — chain-agnostic event projections.
+  - `projections.mjs`: pure reducers folding normalized events into vault + operator state and the
+    all-vaults-included operator leaderboard (SF-4/SF-5); deterministic replay by
+    `(block, logIndex)`.
+  - `chain.mjs`: thin viem adapter turning on-chain logs into normalized events (the only
+    chain-coupled file).
+  - `store.mjs`: bigint/Map-safe serialization, atomic file snapshots, resume cursor.
+  - `daemon.mjs`: resume-from-snapshot → poll → fold → snapshot, with `confirmations` lag for reorg
+    safety; chain client + clock injected, so it is testable with no RPC. The tested core has zero
+    dependencies; the API reads its projections directly.
+- **agent-sdk** — client library; `eip3009.mjs` builds the `transferWithAuthorization` envelopes
+  that pay for [[x402-metering]] reads; `index.mjs` is the public surface.
+- **reference-agent** — a worked example agent (with fixtures) demonstrating the intended
+  deposit/vote/exit loop against the SDK.
+- **canary** — post-deploy health monitor: `canary-runner.mjs`, `reader.mjs`, `transitions.mjs`,
+  `signals/`, `sinks.mjs`, `state-file.mjs` — watches live vault state and emits signals on
+  anomalous transitions.
+- **oplog** — operational plumbing shared across services: `durable.mjs`, `heartbeat.mjs`,
+  `logger.mjs`, `ops-check.mjs`, `shutdown.mjs` (graceful SIGTERM handling).
+
+## Apps (`apps/`)
+
+- **api** — the metered read server; see [[x402-metering]] for the route split, the x402 payment
+  gate (`src/x402.mjs`), the facilitator (`facilitator.mjs` / `facilitator-server.mjs`), rate
+  limiting (`ratelimit.mjs`), and metrics (`metrics.mjs`). Holds no keys and no RPC client.
+- **web** — frontend: `api-client.mjs` (talks to the API), `fees.mjs` (fee display, including the
+  cumulative sub-vault fee stack when that ships), `live-adapter.mjs` (live state binding).
+
+## Design posture
+
+- **Chain-agnostic**, mirroring the contract commitment (commitment C-2): `block.timestamp`-only
+  logic on-chain, and off-chain the chain-coupled surface is isolated to a single viem adapter.
+- **Injected dependencies for testability**: the facilitator is stubbed in API tests, the chain
+  client and clock are injected into the indexer daemon — no live chain or facilitator is needed to
+  run the suites.
+- **Persistence = resumability**: a restart resumes from the last indexer snapshot rather than
+  replaying from genesis.
+
+## Links
+
+- [[architecture-overview]] · [[x402-metering]] (the API this feeds) · [[fees-and-carry]]
+  (leaderboard projections)
+- Contracts consumed via ABIs: [[vaultcore]] · [[operatorregistry]] · [[vaultfactory]]
+- State: [[current-state]]

--- a/docs/vault/open-items.md
+++ b/docs/vault/open-items.md
@@ -1,0 +1,34 @@
+# Open Items
+
+The live to-do list between now and a meaningful `v1.0.0-launch-candidate`. Everything that keeps [[current-state]] at NO-GO, plus the accepted residuals.
+
+## Why it matters
+
+Gate 0 and gate 1 are the only rows that speak to safety, and both are NO-GO. This note separates the launch-blocking work from the accepted residuals so nobody mistakes a documented, accepted tradeoff for an unfinished task — or vice versa.
+
+## Launch-blocking
+
+1. **C-6 — settle the oracle mechanism.** [[c6-oracle-byzantine]] keeps gate 0 NO-GO. `ChainlinkOracle` is shipped ([[chainlink-direct-pivot]]); the **NEXT step in progress** is a factory-level oracle-gate to adopt Chainlink-direct as launch default and make the custom [[oracleaggregator]] **non-deployable** (leaving it selectable re-imports C-6). Final mechanism choice is an owner + external-auditor decision. Tracked by issue #48.
+2. **External audit (gate 1).** Not started. Full review of the corrected tree at a new tag (`v0.4.0-audit`); must cover the remediation itself (six contracts changed, including the `OracleAggregator._tryLatestPrice` assembly).
+3. **Rebuild `base-mainnet.json` (issue #41).** Currently **NOT-DEPLOYABLE**: needs 5 sources/asset at quorum 3 and `maxObservationAge ≤ window/20`; two further source addresses per asset are a human input. (Chainlink-direct simplifies this if adopted.)
+4. **Re-run testnet lifecycle + soak + canary (gates 2, 3, 6).** STALE — earned against superseded bytecode. Redeploy testnet, re-run drills against the corrected contracts. See [[audit-reverification]].
+5. **VaultCore-headroom sprint (issue #40).** H-5/H-6/H-9 and M-15's exit-side need `VaultCore` bytes that do not exist (1,014 B margin). Dormant-at-launch behind [[root-vaults-only]], but required before sub-vaults return.
+6. **One recorded restore drill (gate 7).** ~30 min, no keys, doable anytime — CONDITIONAL until performed.
+
+## Open Highs / not-mitigated
+
+- **H-8** — partially fixed + config-mitigated; the key open High for a root-only launch.
+- **M-7 — NOT mitigated.** The `proposalCooldown` floor is per-proposer and sidesteppable with a second address; the serial-proposal exit freeze stands. Accepted residual, bounded by the ≥1h commit phase.
+
+## Accepted residuals (DORMANT / ACCEPTED — not tasks)
+
+- **Dormant-at-launch (need a funded child):** H-5, H-6, H-7, H-9, M-5, L-6 — deferred **with** the sub-vault feature via [[root-vaults-only]].
+- **Accepted design tradeoffs:** M-8 (opaque `actionHash` = MEV protection), M-9 (settlement-timing option, bounded `gain/10`), M-10 (per-address commit-reveal), L-5 (rebasing tokens, creator-disclosed), L-7 (standing-default asymmetry).
+- **Residual-risk register:** immutability, oracle-freeze-beats-mispricing, USDC-depeg on the TWAP leg, shared WETH/USDC pool, Pyth pull-based keeper, x402 broadcast-not-finality — all documented as ship-anyway with mitigations.
+
+## Links
+
+- Status: [[current-state]] · [[launch-readiness-gates]] · [[audit-reverification]]
+- Open Criticals/Highs: [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]] · [[highs]] · [[mediums-and-lows]]
+- Decisions bounding scope: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[delegatecall-split-rejected]]
+- Tracking: [[prs-and-issues]] · [[go-to-market-plan]] · [[remediation-history]]

--- a/docs/vault/operatorregistry.md
+++ b/docs/vault/operatorregistry.md
@@ -1,0 +1,62 @@
+# OperatorRegistry
+
+The canonical registry of operator identity, cross-vault loss carryforward, and the aggregate
+leaderboard. `contracts/src/OperatorRegistry.sol`. The **C-3 load-bearing reference** — every vault
+holds it as an immutable from day one.
+
+## Why it matters
+
+(Note: the "C-3 load-bearing" tag on this contract and on VaultCore's `operatorRegistry` immutable
+is a **threat-model** item — the registry must be wired from day one — and is a *different*
+numbering from HOME's [[c3-oracle-brick]] critical, which is the oracle malformed-returns finding
+that lives in [[oracleaggregator]]. Do not conflate the two C-3s.)
+
+Three requirements meet in one contract, and each is a trust anchor for the off-chain reputation and
+fee system:
+
+1. **HWM portability (§7)** — the per-`(member, operator)` USDC loss carryforward. A member who
+   realized a loss under an operator in one vault pays no performance fee under that operator in
+   another until made whole. Carry mutates **only** through attested vaults.
+2. **Leaderboard integrity (SF-4 / SF-5)** — lifetime gain/loss/fees accumulators per operator,
+   aggregated across ALL attested vaults, **monotone**: closed vaults' history is retained,
+   wind-downs recorded, nothing ever decremented. No cherry-picking is possible.
+3. **Anti-Sybil (CM-4)** — identity is the registry id. A fresh identity escapes its loss carry but
+   restarts at zero track record — visible and reputation-costly by construction.
+
+Only vaults deployed by the canonical [[vaultfactory]] are attested (CM-5), so throwaway-vault
+mark-farming requires real, visible vaults.
+
+## Key state
+
+- `operatorIdOf`, `operatorAddressOf`, `operatorCount` (ids start at 1; 0 = unregistered).
+- `_vaultOperator[vault]` — opId (0 = unattested).
+- `carryOf[member][opId]` — the portable HWM loss carryforward, USDC.
+- `statsOf[opId]` — `OperatorStats { lifetimeGainUsdc; lifetimeLossUsdc; lifetimeFeesUsdc;
+  vaultCount; }` (all monotone).
+- `factory` and `feeEngine` — one-shot `wire`, deployer-only, locked after.
+
+## Entry points
+
+- `registerOperator(address)` — permissionless and harmless (grants no authority, cannot rebind an
+  existing operator, CM-4).
+- `attestVault(vault, operator)` — **factory-only** (CM-5); auto-registers a new operator.
+- `recordRealization(member, gainUsdc, lossUsdc)` — **attested-vault-only**; losses build the carry,
+  gains consume it. Called at redemption settlement **after** [[feeengine]] has read the
+  pre-realization carry (call order fixed in `VaultCore._settleExit`).
+- `recordFeeCollected(opId, amountUsdc)` — **feeEngine-only**, feeds the aggregate stats.
+- `leaderboardEntry(opId)` — the aggregate, all-vaults-included record.
+
+## Findings
+
+No open finding lives in this contract; it is the **reference implementation** the C-3 remediation
+leans on (a load-bearing dependency wired into VaultCore at construction, never zero). Its
+correctness properties — factory-gated attestation (CM-5), monotone accumulators (SF-5), and the
+fixed call order with [[feeengine]] — are what make the marks and the leaderboard trustworthy. The
+`recordFeeCollected` caller restriction (`OnlyFeeEngine`) and the `attestVault` restriction
+(`OnlyFactory`) are the one-shot-wired authority boundaries that keep the record from being forged.
+
+## Links
+
+- [[contracts-index]] · [[feeengine]] · [[vaultfactory]] · [[vaultcore]]
+- Architecture: [[fees-and-carry]]
+- Findings: [[threat-model-commitments]] · [[security-index]]

--- a/docs/vault/oracle-layer.md
+++ b/docs/vault/oracle-layer.md
@@ -1,0 +1,77 @@
+# Oracle Layer
+
+**Definition.** How the vault prices basket assets: a multi-source median with a staleness
+circuit breaker ([[oracleaggregator]]), or — the recommended pivot — Chainlink Data Feeds consumed
+directly ([[chainlinkoracle]]). Both implement `IOracleAggregator` and both **fail closed**.
+
+**Why it matters.** NAV, share issuance, redemption value, and the rebalance slippage bound all
+read this layer. A price an attacker can move is a vault an attacker can drain — and the custom
+aggregator's Byzantine bound (**audit C-6, OPEN**) is why the Chainlink pivot exists.
+
+## Fail-closed posture (K-4 / SF-2, ACCEPTED)
+
+If fewer than `quorum` sources are fresh for an asset, `priceWad` reverts `StaleOracle` — freezing
+**every NAV-reading path including exits** in consuming vaults. No escape hatch, by design: any
+exit during staleness *is* the stale-price exit the breaker prevents. Config is **immutable after
+construction** in both implementations — no admin can swap sources, retune staleness, or lower the
+quorum; a creator wanting different sources deploys a different oracle, and members see it at
+deposit time.
+
+## OracleAggregator — custom multi-source median
+
+- Median of independent sources per asset ([[oracle-sources]]: Chainlink-push, Uniswap V3 TWAP,
+  Pyth pull-wrapper — *mechanism* diversity is the SF-1 listing criterion).
+- Floors hardened (H-1, M-1): `MIN_SOURCES = 3`, `MIN_MEDIAN = 3`, strict-majority freshness
+  quorum, staleness bounded to `(0, MAX_STALENESS_CEILING = 1 day]`. The old constructor permitted
+  quorum 2-of-3, where the lower median at k=2 is `fresh[0]` — the **minimum**, biased downward,
+  the exploitable direction for share issuance (audit C-4). M-1 also rejects literal address
+  duplication (`[S,S,S]`).
+- Consequence, stated openly: at three sources this leaves zero failure headroom, so an asset needs
+  **five** sources for integrity *and* tolerance — which is why `base-mainnet.json` is now
+  NOT-DEPLOYABLE (#41). Freezes are deliberately **more** likely now (E2/E6): a quiet TWAP pool
+  withholds (H-2) rather than quoting a stale tick as fresh.
+
+## Audit C-6 — the Byzantine bound (OPEN)
+
+Phase-2 re-verification quantified that "5 sources / quorum 3" is a **fault-tolerance** floor
+(sound against benign withholdings), **not** a Byzantine one. Because `k` falls to the quorum via
+withholding and the lower median at even `k` sits inside a 2-source minority, an actor controlling
+`a` sources owns the price once `k ≤ 2a`. Byzantine safety requires:
+
+```
+quorum ≥ 2a + 1                (own the price only with a full Byzantine minority)
+m ≥ 2a + f + 1                 (also absorb f benign withholdings)
+```
+
+m=5 **cannot** tolerate a=2. The cheapest adversary is the **vault creator listing two sources
+they control** — this passes every constructor check. See [[c6-oracle-byzantine]]. C-6 is OPEN and
+is a launch blocker.
+
+## ChainlinkOracle — the recommended pivot (already in the tree)
+
+[[chainlinkoracle]] is an **additive** `IOracleAggregator` that a VaultCore can be deployed with
+*instead* of the custom median. It already exists in `contracts/src/oracle/ChainlinkOracle.sol` —
+the pivot is a **wiring/deployment decision** ([[chainlink-direct-pivot]]), not unwritten code. It
+trusts Chainlink's own decentralized OCR aggregation per asset: **one feed per asset**, no median,
+no quorum, no per-vault source set to misconfigure or selectively stall — removing the entire
+surface C-6/H-1/M-1 live on (Byzantine-tolerant at the node-operator layer).
+
+Honest tradeoffs (**ACCEPTED** vs the custom aggregator, which C-6 proves could not be secured):
+
+- Single-provider dependency — a feed deprecation/freeze fails that asset closed (safe, but the
+  vault freezes with no fallback).
+- Assets **without** a Chainlink feed on the chain cannot be listed.
+- A feed updates only on heartbeat OR a deviation-threshold move, so a price up to ~the deviation
+  band stale reads as "fresh" — a bounded, inherent NAV arb; vault-side defence is M-15's
+  `minSharesOut`/`minValueOut`.
+- A **sane-price band** (`minPriceWad`/`maxPriceWad`) defends against a feed reporting a deprecated
+  min/maxAnswer clamp during a depeg/flash-crash; L2 sequencer-uptime feed and grace period are
+  also checked.
+
+## Links
+
+- [[architecture-overview]] · [[nav-and-shares]] (price_i) · [[two-mode-exits]] (breaker freezes
+  exits) · [[sub-vaults]] (look-through pricing)
+- Contracts: [[oracleaggregator]] · [[chainlinkoracle]] · [[oracle-sources]]
+- Security & decisions: [[c6-oracle-byzantine]] · [[c3-oracle-brick]] · [[c4-depressed-price-theft]]
+  · [[chainlink-direct-pivot]] · [[launch-readiness-gates]]

--- a/docs/vault/oracle-sources.md
+++ b/docs/vault/oracle-sources.md
@@ -1,0 +1,88 @@
+# Oracle Sources
+
+The `IPriceSource` implementations that feed [[oracleaggregator]]'s median: a Chainlink push-feed
+adapter, a Uniswap V3 arithmetic-mean-tick TWAP, and a Pyth pull-oracle wrapper. Each returns
+`(priceWad, updatedAt)` and degrades to `(0, 0)` — the aggregator's not-fresh signal — rather than
+reverting. `contracts/src/oracle/`.
+
+## Why it matters
+
+The aggregator's whole safety argument rests on **mechanism diversity** (SF-1): a spot-market TWAP
+fails in ways a Chainlink push feed and a Pyth pull feed do not, so a median across the three
+classes is not defeated by any single upstream. Correlated upstreams are *not* independent sources —
+"3 sources" behind one price mechanism is one source wearing three names. These contracts are also
+**post-audit-freeze, additive**: the TWAP and Pyth sources implement the existing `IPriceSource` and
+modify nothing inside the `v0.2.0-audit` tree.
+
+## ChainlinkSourceAdapter (push)
+
+Defined in `OracleAggregator.sol`. Wraps an `IAggregatorV3` feed, normalizes to WAD by
+`10**(18 - feedDecimals)` (cached). A non-positive answer surfaces as `(0, 0)` — the aggregator
+treats it as not-fresh, never a revert. `updatedAt` is the feed's own last-write timestamp. This is
+the "when did someone last write?" mechanism class.
+
+## UniswapV3TwapSource (spot-market TWAP)
+
+`contracts/src/oracle/UniswapV3TwapSource.sol` (Sprint 11). Prices `asset` in USD by composing up
+to two V3 TWAPs and pinning USDC to $1.00 — one hop (`asset`/`usdc`) or two hops
+(`asset`/`intermediate` then `intermediate`/`usdc`, e.g. cbETH→WETH→USDC). Everything is immutable;
+the vendored `TickMath` / `FullMath` keep the whole path in-repo.
+
+**Freshness lives here, not in the aggregator.** `latestPrice` cannot delegate its staleness to the
+aggregator because a TWAP has no writer — a hardcoded `block.timestamp` would be unconditionally
+"fresh". So the source withholds (returns `(0, 0)`) unless: (1) `observationCardinality >=
+minCardinality`; (2) the oldest retained observation is at least `window` old (so `observe()`
+interpolates over history instead of extrapolating from the live tick); and (3) the newest
+observation is no older than `maxObservationAge`.
+
+- **H-2 (live-tick weight).** `observe([window, 0])` synthesizes the endpoint from the newest
+  observation using the *current* tick; the live tick's weight in the "historical" mean is
+  `min(A, W)/W` where `A = now - newestObservation`. The old guards bounded `A` and the oldest
+  observation independently, so the shipped `1800/3600` config permitted `A = 2×` the window. Now
+  `MAX_LIVE_TICK_WEIGHT_DIVISOR = 20` caps the live tick at **<= 5% of the window**, enforced both in
+  the constructor (`maxObservationAge * 20 <= window`) and at read time. A naive
+  `require(now - newestTs < window)` was tested and is **not** enough (it still permits >90% error).
+- **H-2, second half.** `latestPrice` used to hardcode `updatedAt = block.timestamp`, so a source
+  computing over a stale tick stamped itself zero seconds old and the aggregator's staleness bound
+  could not reject it. It now reports `_newestObservationTs()` — the real age of the backing data.
+- **H-3.** The test mock was **replaced** — the old one generated cumulatives from a single live
+  tick, so a correct historical TWAP and a live-tick extrapolation were numerically identical and no
+  assertion could fail for H-2's class.
+- The whole computation runs behind `try this.computePriceWad()` so `FullMath.mulDiv` reverts and
+  `observe()` on a codeless pool both convert to `(0, 0)`.
+
+The USDC leg is a **pin, not a measurement**: a sustained depeg mis-prices every asset this source
+quotes, by exactly the depeg. The median across mechanism classes is the mitigation (one source of
+several cannot move a lower median).
+
+## PythSource (pull oracle)
+
+`contracts/src/oracle/PythSource.sol` (Sprint 11). Wraps `getPriceUnsafe` (deliberately the
+*Unsafe* variant — freshness is the aggregator's decision, made once, not duplicated here).
+Immutable `pyth`, `priceId`, `maxConfBps`. Normalizes by exponent to WAD.
+
+- **Pull-oracle staleness consequence:** `publishTime` reflects **keeper economics**, not Pyth
+  liveness — on a quiet chain the on-chain price can be hours stale while Pythnet's aggregate is a
+  second old. So `maxStaleness` must be chosen against the actual on-chain update cadence, not only
+  basket volatility; a too-tight bound silently drops this leg, turning an advertised 2-of-3 into an
+  effective 2-of-2 with no margin (see gate discussion in [[launch-readiness-gates]]).
+- **Confidence gate:** rejects a reading whose `conf` exceeds `maxConfBps` of price
+  (`MAX_CONF_BPS_CEILING` = 2000 = 20%) — a feed in disagreement with itself declines to vote.
+- Exponent bounds `[MIN_EXPO = -36, MAX_EXPO = 18]`; sub-WAD-dust prices return `(0, 0)`.
+- The constructor **reads the feed** (`getPriceUnsafe` reverts on an unknown id), so a mistyped
+  32-byte price id cannot be deployed — a silent-`(0,0)` source is invisible in a 2-of-3 quorum
+  until the day another source fails.
+
+## K-4 tie-in
+
+Because a source can withhold when its data goes quiet, a *market* going quiet becomes a **breaker
+input** (a freeze) rather than a silently-stale number — strictly the safer failure. If enough
+sources withhold, `priceWad` reverts `StaleOracle` and every NAV path freezes, including exits, with
+no hatch (the accepted K-4 / SF-2 tradeoff).
+
+## Links
+
+- [[contracts-index]] · [[oracleaggregator]] · [[chainlinkoracle]] · [[vaultcore]]
+- Architecture: [[oracle-layer]]
+- Findings: [[highs]] · [[c6-oracle-byzantine]] · [[threat-model-commitments]] ·
+  [[launch-readiness-gates]]

--- a/docs/vault/oracleaggregator.md
+++ b/docs/vault/oracleaggregator.md
@@ -1,0 +1,82 @@
+# OracleAggregator
+
+The bespoke per-vault price oracle: a **multi-source median** with a per-asset staleness circuit
+breaker. Config is immutable after construction — no admin can swap sources, retune staleness, or
+lower the quorum. `contracts/src/OracleAggregator.sol`.
+
+## Why it matters
+
+NAV is priced through this contract, so it decides what a share is worth on every deposit,
+redemption, and rebalance. A wrong or manipulable price here is a direct theft vector (mint cheap
+shares, redeem rich). It is also the contract that **could not be fully secured** against an
+adversarial source set — finding [[c6-oracle-byzantine]] is fundamental to the median design, which
+is exactly why [[chainlinkoracle]] was added as an alternative that removes the median.
+
+## Key state and constants
+
+- `_cfg[asset]` — `AssetConfig { address[] sources; uint32 maxStaleness; uint8 quorum; }`.
+- `MAX_STALENESS_CEILING` = 1 day (bounds the underflow honeypot and the latency-arb window).
+- `MIN_SOURCES` = 3 (§11 / SF-1: median of >= 3 independent sources).
+- `MIN_MEDIAN` = 3 — quorum must reach this so a config can never select `min()`.
+
+## How it prices (`priceWad`)
+
+1. Poll every source via `_tryLatestPrice` (a raw staticcall, C-3 remediation — see below).
+2. Keep the fresh set: `ok && p > 0 && updatedAt >= block.timestamp - maxStaleness`. A saturating
+   lower bound avoids underflow-panic.
+3. If fewer than `max(quorum, MIN_MEDIAN)` fresh sources: **revert `StaleOracle`** (breaker).
+4. Insertion-sort the fresh set (m <= 15) and return the **lower median** `fresh[(k-1)/2]` — no
+   averaging, so no even-k swing and no sum-overflow freeze.
+
+An unlisted asset reverts `StaleOracle`, never returns 0. Failure freezes every NAV path in
+consuming vaults, including exits (K-4, by design).
+
+## Security findings that live here
+
+- [[c6-oracle-byzantine]] — **the core one.** The lower-median selection is honest only when the
+  honest sources are a majority of the *fresh* set: with `a` adversarial sources the lower median is
+  honest iff `k > 2a`; at `k = 2a` it lands inside the adversarial minority and returns their quote.
+  `k` can fall to the quorum via withholding, and one honest leg going quiet (a TWAP on a stalled
+  pool) suffices at `m = 5`. Safety against `a` adversaries needs `quorum >= 2a+1`, and to also
+  tolerate `f` benign withholdings, `m >= 2a+f+1` — which `m = 5` cannot satisfy for `a >= 2`. **The
+  constructor cannot see `a`,** so this is a **listing requirement** (genuinely independent
+  sources), not a code check. This is why [[chainlinkoracle]] exists — see
+  [[chainlink-direct-pivot]].
+- **H-1** — the constructor now requires `quorum >= MIN_MEDIAN` and `quorum > m/2`. Previously
+  quorum 2-of-3 was allowed, so the lower median `fresh[(k-1)/2]` at `k = 2` was `fresh[0]` — the
+  **minimum**, biased one-directionally downward, the exploitable direction for share issuance
+  (C-4). Consequence, stated in the code: at `m = 3` this forces `quorum == 3` (zero fault
+  tolerance — any one source failing trips the breaker). Fault tolerance and median integrity cannot
+  both be had at `m = 3`; the resolution is **`m >= 5`**, not a lower quorum. `priceWad` re-checks
+  both bounds because deployed aggregators may carry a pre-H-1 quorum of 2.
+- **C-3** — `_tryLatestPrice` is a raw `staticcall` with an explicit 64-byte length check. A
+  `try/catch` **cannot** absorb a decode failure: Solidity decodes the returned buffer in the
+  caller's frame *after* the callee returned successfully, so a source returning 32/0 bytes (or
+  having no code) made `priceWad` revert unconditionally with empty returndata — for every wired
+  vault, permanently. The raw call also bounds the copy to two words, so a returndata bomb cannot
+  OOG the reader.
+- **M-1** — literal address-equality dedupe: `[S, S, S]` satisfied "3 sources" and any quorum but
+  its median was just `S`. Correlated upstreams behind *distinct* addresses stay out of code's reach
+  (the accepted SF-1 residual — [[c6-oracle-byzantine]] again), but literal duplicates do not.
+- **Finding 2** — staleness bounded on both sides (nonzero and <= ceiling).
+- **Finding 6** — the >= 3 sources + strict-majority-freshness floor.
+
+Also defined in this file: `ChainlinkSourceAdapter` (an `IPriceSource` — documented in
+[[oracle-sources]]) and the `IAggregatorV3` interface reused by [[chainlinkoracle]].
+
+## Launch consequence
+
+Because H-1 forces `m >= 5` for any fault tolerance, Base mainnet's shipped 3-source config is
+rejected — each asset needs 5 real, independent, non-invented source addresses. This is why
+launch-readiness gate 5 (mainnet oracle stack) is **NO-GO**. See [[launch-readiness-gates]].
+
+## Size — EIP-170
+
+Runtime ~1,215 B; margin ~23,361 B. Not size-constrained.
+
+## Links
+
+- [[contracts-index]] · [[chainlinkoracle]] · [[oracle-sources]] · [[vaultcore]]
+- Architecture: [[oracle-layer]] · [[nav-and-shares]]
+- Findings: [[c6-oracle-byzantine]] · [[c3-oracle-brick]] · [[c4-depressed-price-theft]] · [[highs]]
+- Decision: [[chainlink-direct-pivot]] · [[threat-model-commitments]] · [[launch-readiness-gates]]

--- a/docs/vault/prs-and-issues.md
+++ b/docs/vault/prs-and-issues.md
@@ -1,0 +1,37 @@
+# PRs and Issues
+
+The GitHub ledger for the Phase-2 remediation: which PRs landed which fixes on `protocol/main`, and which issues remain open. Repo: `github.com/SlumperSan/agent-governed-vaults` (private).
+
+## Why it matters
+
+In [[continuous-autonomous-mode]] with [[auto-merge]], the PR list *is* the change history — each finding is one branch, one PR, one merge. This note maps PR/issue numbers to findings so the audit prose and the git log line up.
+
+## Merged PRs (Phase 2)
+
+| PR | Branch | Lands | Finding(s) |
+| --- | --- | --- | --- |
+| **#43** | `security/c1-root-vaults-only` | `VaultFactory.allowSubVaults = false`, root-only wiring | C-1 ([[root-vaults-only]]); closes H-5/H-6/H-7/H-9 as a class |
+| **#44** | `security/h8-quorum-regime` | de-stake-blind the `<5`-member quorum regime | H-8 (fix sybil pass + dust lockout) |
+| **#45** | `security/m15-slippage` | deposit-side `minSharesOut` overload | M-15 (deposit side; exit-side deferred) |
+| **#46** | `security/sprint20-dispositions` | disposition remaining findings; correct SLITHER-TRIAGE | Medium/Low tier |
+| **#47** | `security/oracle-reverification-c6` | `AuditC4EndToEnd.t.sol`; C-4 re-verification | surfaced C-6 ([[c6-oracle-byzantine]]) |
+| **#49** | `security/chainlink-oracle` | additive `ChainlinkOracle.sol` (Chainlink Data Feeds direct) | C-6 resolution ([[chainlink-direct-pivot]]) |
+
+Earlier (Phase 1): **#39** (`security/critical-remediation`) closed the twelve findings; **#38** was the Sprint-15 battery refresh; **#42** the medium-tier pass. See [[remediation-history]].
+
+## Open issues
+
+| Issue | Subject |
+| --- | --- |
+| **#40** | VaultCore-headroom sprint — the EIP-170 budget that blocks H-5/H-6/H-9 and M-15 exit-side |
+| **#41** | Rebuild `base-mainnet.json` — 5 sources/asset at quorum 3, `maxObservationAge ≤ window/20`; human-supplied addresses |
+| **#48** | C-6 tracking — the oracle-curation / mechanism decision; **gate 0 does not clear while open** |
+
+Referenced audit issues from the pre-audit engagement: #31–#35 (the Critical filings), #32 (C-4 DiD), #33 (C-1), #34 (C-5), #24 (evidence-based launch readiness).
+
+## Links
+
+- What the PRs changed: [[remediation-history]] · [[current-state]] · [[open-items]]
+- Merge convention: [[auto-merge]] · [[continuous-autonomous-mode]]
+- Findings: [[c1-empty-electorate]] · [[c6-oracle-byzantine]] · [[c4-depressed-price-theft]] · [[highs]] · [[security-index]]
+- Decisions: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[decisions-index]]

--- a/docs/vault/remediation-history.md
+++ b/docs/vault/remediation-history.md
@@ -1,0 +1,37 @@
+# Remediation History
+
+The Phase-2 arc: from a 41-finding AI pre-audit to a root-only, Chainlink-direct launch shape — twelve findings fixed in code, C-1 closed by decision, C-6 discovered and pivoted around.
+
+## Why it matters
+
+The remediation is itself the strongest evidence for the top residual risk — **immutability**. Every fix required a full redeploy because nothing can be patched, and the fixes changed six contracts, which invalidated the testnet deployment, the soak, and the canary evidence in one move. Reading the arc explains why so much operational evidence is now STALE ([[audit-reverification]]).
+
+## The arc
+
+**Pre-audit (2026-08-25, tag `v0.3.0-audit` → `ad9396d7`).** Nine specialist passes over 3,349 LoC produced **41 findings: 5 Critical, 9 High, 15 Medium, 7 Low, 5 Informational**. Verdict: NO-GO. The `v0.3.0-audit` tag is now **withdrawn** as an engagement reference (it remains a valid historical marker of the pre-remediation tree). See [[audit-reverification]].
+
+**First remediation pass (2026-08-27, PR #39, `security/critical-remediation`).** Closed **twelve** findings with `test_remediated_*` coverage, each preserving the replaced exploit in git history:
+- Criticals: C-2 (unbounded governance durations), C-3 (oracle brick), C-5 (vote-after-exit).
+- Highs: H-1, H-2 (stale TWAP tick reported fresh), H-3 (the mock that couldn't detect H-2), H-4.
+- Mediums: M-1, M-2 (EE-6 escrow isolation), M-3, M-4, M-11 (returndata hardening, **+336 B** reclaimed), M-12. Plus an unbounded `proposalCooldown` (C-2's shape, unfiled) capped at 30 days.
+- Lows: L-1, L-2, L-3, L-4.
+- **Reverted:** M-6's `proposalThresholdBps` floor — it re-introduced C-2's shape into `propose()` (a constructor cannot see live stake distribution); the freeze is pinned as a passing test.
+
+**Phase 2 (2026-08-28).** The decision-driven closes and the re-verification:
+- **C-1 → closed by decision:** [[root-vaults-only]] (`allowSubVaults = false`, PR #43). Also closes sub-vault-only Highs H-5/H-6/H-7/H-9 as a class and makes M-5/L-6 dormant.
+- **H-8 → partially fixed + config-mitigated** (PR #44): de-stake-blinded the `<5`-member quorum regime.
+- **M-15 → partially fixed** (PR #45): deposit-side `minSharesOut`; exit-side deferred on byte budget.
+- **Dispositions swept** (PR #46): remaining Medium/Low findings dispositioned; SLITHER-TRIAGE rows corrected.
+- **C-6 discovered** (PR #47): end-to-end re-verification (`AuditC4EndToEnd.t.sol`) falsified the inferred C-4 closure and surfaced the new Critical [[c6-oracle-byzantine]].
+- **ChainlinkOracle shipped** (PR #49): the [[chainlink-direct-pivot]] — additive oracle that deletes the C-6 surface. NEXT step: factory oracle-gate to make the custom aggregator non-deployable.
+
+## Byte budget — why it decided what could be fixed
+
+`VaultCore` began the session with 1,560 B of EIP-170 margin and ended with **1,014 B**. The path was non-monotonic: H-4 cost 375 and M-4 cost 3 (→1,182); **M-11 returned 336** (→1,518); M-2 spent 504 on escrow routing. M-2 was affordable **only because M-11 came first**. H-5/H-6/H-9 and M-15's exit-side remain unfixed because they land in `VaultCore` and do not fit — which is also why the [[delegatecall-split-rejected]] was considered, then dropped once sub-vaults were disabled.
+
+## Links
+
+- Findings: [[security-index]] · [[c1-empty-electorate]] · [[c2-unbounded-governance]] · [[c3-oracle-brick]] · [[c4-depressed-price-theft]] · [[c5-vote-after-exit]] · [[c6-oracle-byzantine]] · [[highs]] · [[mediums-and-lows]]
+- Decisions: [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[delegatecall-split-rejected]] · [[build-vs-buy]]
+- State: [[current-state]] · [[open-items]] · [[prs-and-issues]] · [[audit-reverification]] · [[launch-readiness-gates]]
+- Contracts touched: [[vaultcore]] · [[governance]] · [[oracleaggregator]] · [[oracle-sources]] · [[vaultfactory]] · [[chainlinkoracle]] · [[safetransferlib]]

--- a/docs/vault/root-vaults-only.md
+++ b/docs/vault/root-vaults-only.md
@@ -1,0 +1,24 @@
+# Root Vaults Only
+
+At launch the protocol ships with sub-vaults disabled: `VaultFactory.allowSubVaults = false`, so `createChildVault` reverts and every vault is wired root-only. This is the C-1 fix. **DECIDED / FIXED (2026-08-28, Phase 2).**
+
+## Why it matters
+
+C-1 ([[c1-empty-electorate]], issue #33) let a funded sub-vault be captured outright for **one minimum deposit**, because the parent is excluded from its child's electorate entirely — leaving a vault that holds real money with an empty electorate, where capture equals drain. There is **no purely-internal fix**, so the launch surface was re-scoped rather than patched.
+
+## The decision and rationale
+
+The report's own suggested fix (`pHeld = 0`, counting the parent as a member) was implemented and analysed, and **it does not work**: at parent + 1 member the signer regime needs `1 * 2 > 2` (false), so a legitimate child could no longer pass a Rebalance, while an attacker just brings a second sybil (`2 * 2 > 3`). Real liveness cost, marginal security gain.
+
+The underlying tension is structural: **any denominator that excludes the parent lets whoever dominates the smallest pool of capital govern the largest; including it makes the child ungovernable.** The parent needs a new mechanism to cast the child's vote through its own governance — deferred to a post-launch, post-audit release.
+
+The owner's decision was to **disable sub-vaults at launch** rather than build that mechanism now. `allowSubVaults = false` means the empty-electorate capture has no target. This closes C-1 **and** the sub-vault-only Highs H-5, H-6, H-7, H-9 as a class — which is also why the broken `redeemFromChild` escape hatch (H-6) no longer matters at launch. Several Mediums/Lows (M-5, L-6) go **DORMANT-AT-LAUNCH** for the same reason.
+
+Regression: `AuditRootVaultsOnly.t.sol`. It is a launch **parameter**, costs nothing to honour, and does not wait on a redeploy. **Re-enabling sub-vaults reopens C-1** until the parent-casts-child-vote mechanism is built and audited.
+
+## Links
+
+- Resolves: [[c1-empty-electorate]] · closes as a class: [[highs]] (H-5/H-6/H-7/H-9)
+- Contracts: [[vaultfactory]] · [[sub-vaults]] · [[subvaultregistry]] · [[vaultcore]]
+- Related decisions: [[delegatecall-split-rejected]] · [[decisions-index]]
+- State: [[current-state]] · [[open-items]] · [[remediation-history]] · [[launch-readiness-gates]]

--- a/docs/vault/safetransferlib.md
+++ b/docs/vault/safetransferlib.md
@@ -1,0 +1,71 @@
+# SafeTransferLib (and BoundedCall)
+
+The vendored `lib/` primitives for hostile-token and hostile-module safety: bounded ERC-20 transfer
+helpers (`SafeTransferLib`) and gas/returndata-bounded external calls (`BoundedCall`).
+`contracts/src/lib/SafeTransferLib.sol`, `contracts/src/lib/BoundedCall.sol`. Both are vendored
+rather than imported to keep the dependency surface auditable in one sitting.
+
+## Why it matters
+
+Every fund movement and every creator-chosen bookkeeping module call passes through these two
+libraries, so they are the enforcement point for two whole finding classes: a **returndata bomb**
+must not OOG the caller, and a **reverting / gas-guzzling** token or module must degrade to escrow or
+lost-bookkeeping rather than bricking an exit. A single unbounded call shape anywhere in these
+libraries reopens the exit-liveness risk the rest of the design works to close. (BoundedCall has no
+note of its own — it is folded in here because both are `lib/` returndata/gas hardening of the same
+H-1 / H-2 / M-11 class.)
+
+## SafeTransferLib
+
+- `safeTransfer` / `safeTransferFrom` / `safeApprove` — **reverting** helpers (propagate a genuine
+  failure) that tolerate missing return values (USDT-style).
+- `tryTransfer(token, to, amount, gasLimit)` — **non-reverting**, gas-capped, for the in-kind
+  redemption escrow path (EE-6): one blacklisted/reverting basket asset must not block the whole
+  redemption; a failure returns `false` and the caller escrows the slice.
+
+### M-11
+
+The three reverting helpers used to do `(bool ok, bytes memory ret) = token.call(...)`, which copies
+the **entire** returndata buffer into memory — so a returndata-bombing token OOG'd every one of them.
+A second, quieter defect: for a token returning 1-31 bytes, `abi.decode(ret, (bool))` reverts with a
+decoder panic, making the intended `TransferFailed` error **unreachable** for exactly the
+malformed-return case it exists to report. All three now use a **bounded** assembly call copying at
+most one word, and report the intended named error. The bomb costs the callee its own memory
+expansion and this frame nothing (a buffer never copied is never paid for). `tryTransfer` was already
+bounded (H-2); M-11 brought the other three call shapes up to it.
+
+**Cross-note consequence:** the bounded assembly is *smaller* than `abi.decode`, and these helpers
+inline at every call site, so **M-11 returned ~336 B of EIP-170 headroom** — which is precisely what
+made M-2's 504 B escrow-routing fix in [[vaultcore]] affordable. Reachable call sites included
+`claimEscrowed` (so an asset that degraded to escrow could otherwise be made permanently
+unclaimable) and both [[execution-adapters]].
+
+## BoundedCall
+
+Gas- and returndata-bounded `boundedCall` / `boundedStaticCall` for creator-chosen bookkeeping
+modules ([[feeengine]], [[operatorregistry]]) and the governance `hasPendingExecution` read. Copies
+at most one word of returndata, so a bomb costs the callee its gas allowance and nothing else. This
+is the mechanism behind VaultCore's **H-1** posture (a reverting / gas-guzzling / returndata-bombing
+module loses its own bookkeeping, event-logged, but never blocks an exit) and behind
+`_pendingExecution` falling back to **Mode I** on any governance failure.
+
+### L-3
+
+The scratch word is now zeroed **before** `returndatacopy`. For 1-31 bytes of returndata the copy
+filled only the high bytes and the remainder was whatever sat at the free-memory pointer, so `word`
+carried **uninitialised memory**. Two of the five call sites gate on `retSize >= 32`; VaultCore's
+`perfFee` read did **not** — so an uninitialised word could have been read as a fee. Fixed by the
+`mstore(ptr, 0)` before the copy in both `boundedCall` and `boundedStaticCall`.
+
+## Findings summary
+
+- **M-11** — returndata-bounded reverting helpers (SafeTransferLib).
+- **H-2** — `tryTransfer` gas cap + returndata bound (the escrow path; also the TWAP finding number,
+  unrelated — see [[oracle-sources]]).
+- **H-1** — `BoundedCall` is the bounded-module-call mechanism (see [[vaultcore]]).
+- **L-3** — `BoundedCall`'s uninitialised-word fix.
+
+## Links
+
+- [[contracts-index]] · [[vaultcore]] · [[feeengine]] · [[operatorregistry]] · [[execution-adapters]]
+- Findings: [[highs]] · [[mediums-and-lows]] · [[threat-model-commitments]]

--- a/docs/vault/security-index.md
+++ b/docs/vault/security-index.md
@@ -1,0 +1,46 @@
+# Security Index
+
+The map of content for the protocol's security posture: the six Criticals, the High/Medium/Low
+tiers, and the cross-cutting notes (threat model, Slither, launch gates, re-verification) that tie
+findings to the code they live in and the decisions that resolved them.
+
+## Why it matters
+
+An AI pre-audit run against the frozen contracts on 2026-08-25 (tag `v0.3.0-audit`, commit
+`ad9396d7`) produced **41 findings — 5 Critical, 9 High, 15 Medium, 7 Low, 5 Informational**. A
+2026-08-27 remediation pass closed twelve; the 2026-08-28 Phase-2 re-verification then surfaced a
+**sixth Critical (C-6)** by converting an *inferred* C-4 closure into an *executed* refutation. The
+launch verdict is **NO-GO**: gate 0 (no unfixed Criticals) is held by C-6, and gate 1 (external
+audit) has not started. Note the pre-audit carries no liability, no attestation, and does not satisfy
+any audit gate — it is findings to fix before a paid engagement, not clearance to ship.
+
+## Disposition at the root-only launch (from the report's §1 table)
+
+- **C-1** — closed at launch by [[root-vaults-only]] (sub-vaults disabled; no internal fix exists).
+- **C-2, C-3, C-5** — FIXED with regression tests.
+- **C-4** — closed at `a ≤ 1` adversarial oracle sources; **RE-OPENED at `a ≥ 2` by C-6**.
+- **C-6** — **OPEN (new, Phase-2, issue #48)**; resolved in code by [[chainlinkoracle]] /
+  [[chainlink-direct-pivot]] (PR #49) but gate 0 stays NO-GO pending a factory oracle-gate and the
+  external audit.
+- **H-1..H-4** — FIXED. **H-5, H-6, H-7, H-9** — DORMANT-AT-LAUNCH (need a funded child). **H-8** —
+  partially fixed + config-mitigated.
+- Medium/Low tier — per the report's disposition table; see [[mediums-and-lows]].
+
+## The pattern worth carrying
+
+A green board measures the tests you wrote, and the tests you wrote encode the failures you already
+imagined. Five Criticals sat underneath 189 passing tests, a clean multi-day soak, and a verified
+deployment. **Eight documented threat-model mitigations did not hold as written** — the most
+dangerous property of the package, because a reviewer who trusts the rows will not look. See
+[[threat-model-commitments]].
+
+## Links
+
+- Criticals: [[c1-empty-electorate]] · [[c2-unbounded-governance]] · [[c3-oracle-brick]] ·
+  [[c4-depressed-price-theft]] · [[c5-vote-after-exit]] · [[c6-oracle-byzantine]]
+- Tiers & cross-cutting: [[highs]] · [[mediums-and-lows]] · [[threat-model-commitments]] ·
+  [[slither-triage]] · [[launch-readiness-gates]] · [[audit-reverification]]
+- Decisions: [[root-vaults-only]] · [[chainlink-direct-pivot]]
+- Contracts: [[vaultcore]] · [[governance]] · [[oracleaggregator]] · [[chainlinkoracle]] ·
+  [[oracle-sources]] · [[vaultfactory]]
+- State: [[current-state]] · [[remediation-history]] · [[open-items]] · [[prs-and-issues]]

--- a/docs/vault/slither-triage.md
+++ b/docs/vault/slither-triage.md
@@ -1,0 +1,55 @@
+# Slither triage
+
+The disposition of record for every Slither detector that fired ([SLITHER-TRIAGE.md](../reviews/SLITHER-TRIAGE.md)):
+fixed, or accepted with a reason. The AI audit checked it and found **four dispositions that
+generalize too far** — each "accepted" for the case it was written for while missing an adjacent one.
+
+## Why it matters
+
+CI runs Slither as an advisory (`continue-on-error: true`, non-blocking), so a new high-severity
+result does not turn CI red — this document is the human triage. Three of the four incorrect
+dispositions coincide with the analyser's own blind spots, so neither Slither nor the triage caught
+them.
+
+## The filter bug (fixed Sprint 10)
+
+The `--filter-paths` regex was **unanchored**, so `src/lib/` matched alongside Foundry's
+`contracts/lib/` — `SafeTransferLib`, `BoundedCall`, and `Checkpoints` were excluded from every
+Slither run until Sprint 10. Two detectors confirmed it (`assembly` fired zero times despite
+`SafeTransferLib`'s assembly). Anchored form: `slither . --filter-paths "^lib/|^test/|^script/"`. The
+widened run went 245 → 254 results with **no new detector class**.
+
+## Four incorrect dispositions (report §4.5)
+
+- **`calls-loop` / `costly-loop`** — the "~237k gas" bound was measured on a 1-child/1-grandchild
+  fixture (6 `priceWad` calls); the caps permit ~730 calls. `navWad` is bounded in *shape*, unbounded
+  in *cost* → **M-5** (~12M gas). (M-5 needs sub-vaults → dormant at launch.)
+- **`reentrancy-*`** — sound for same-contract reentrancy, incomplete for cross-contract: a
+  `VaultCore`'s public views are read as an oracle by its *parent* mid-mutation, and a per-contract
+  mutex is definitionally no defence against a different contract reading it → **H-9**. Slither does
+  not model this either, so the row's reasoning and the analyser's blind spot coincide. Dormant at
+  launch under [[root-vaults-only]].
+- **`timestamp`** — sound for `Governance` and `Checkpoints`, but omitted
+  `UniswapV3TwapSource.sol:255`, the one timestamp use with a security consequence → **H-2** (since
+  FIXED; the omission is now closed).
+- **`divide-before-multiply`** — correct for the payout legs, but "rounds in the vault's favour" was
+  generalized to "safe"; the same pattern at `:557` is what makes `:576`'s shortfall dust check
+  unsatisfiable and reverts a member's child-backed exit → **H-6**. Dormant at launch.
+
+Also noted (benign): **`missing-zero-check`** — `VaultCore`'s constructor zero-checks none of its
+module addresses; a zero `governance` makes `_pendingExecution` return `false` permanently, silently
+masking a mis-wired vault as "always Mode I." The canonical factory always wires real modules, so this
+bites only a hand-rolled deployment.
+
+## Rows checked and found correct
+
+`unused-return`, `incorrect-equality` (including the load-bearing same-second `Checkpoints.push`
+overwrite), `uninitialized-local`, `low-level-calls`, `assembly` (all six sites reviewed opcode by
+opcode), `too-many-digits`, `missing-inheritance`. The Sprint-10 anchor fix is genuinely good work.
+
+## Links
+
+- [[highs]] (H-2, H-6, H-9) · [[mediums-and-lows]] (M-5) · [[c1-empty-electorate]] ·
+  [[root-vaults-only]]
+- [[vaultcore]] · [[oracle-sources]] · [[safetransferlib]] · [[governance]] ·
+  [[threat-model-commitments]] · [[audit-reverification]] · [[security-index]]

--- a/docs/vault/sub-vaults.md
+++ b/docs/vault/sub-vaults.md
@@ -1,0 +1,65 @@
+# Sub-Vaults
+
+**Definition.** The parent/child composition layer ([[subvaultregistry]]): a parent vault
+allocates capital to a child that governs its own mandate, with a depth cap and recursion block.
+**Status: DORMANT-AT-LAUNCH** — disabled at the contract level.
+
+**Why it matters.** A funded child has an *empty electorate* — the one governance shape with no
+purely-internal fix. Rather than ship a capturable mechanism, the owner disabled sub-vaults for
+launch and deferred the correct design to a post-audit release.
+
+## DORMANT-AT-LAUNCH — the double disable (audit C-1)
+
+[[vaultfactory]] ships with `allowSubVaults = false` (immutable). This disables sub-vaults in
+**two** independent ways:
+
+1. `createChildVault` **reverts** — no child can be created.
+2. Every deployed vault is wired with `subVaultRegistry = address(0)`, so each vault is
+   **intrinsically root-only**: `parentVault()` is `address(0)`, `allocateToChild` reverts, and
+   the look-through pricing paths are dead code.
+
+This closes audit findings **C-1, H-5, H-6, H-7, and H-9 as a class**. See [[c1-empty-electorate]]
+and the decision note [[root-vaults-only]].
+
+## Why there is no internal fix
+
+A funded child's only capital is the parent's allocation, but the GA-1 rule excludes a registered
+parent from voting-eligible stake and holder count (otherwise the child is ungovernable, since the
+parent has no vote path). That leaves the child's *voting* electorate at zero — so one
+`minDepositUsdc` dust deposit buys sole governance control, and the proposer-supplied
+`minAmountOut` turns capture into a drain. Any denominator that excludes the parent lets a dust
+depositor govern the parent's allocation; any denominator that includes it makes the child
+ungovernable. The correct mechanism — **parent casts the child's vote** — is deferred, not hacked
+in. The sub-vault code is **retained, not deleted**, so a future factory can enable it once that
+mechanism ships.
+
+## The mechanism, for the future release (constraints recorded now)
+
+These constants live in [[subvaultregistry]] and describe the deferred design:
+
+- **Depth hard-capped at 3** (`MAX_DEPTH = 3`; root = depth 0, deepest child = depth 2, i.e. 3
+  levels). Depth = registry-recorded parent-chain length; a new vault inherits parent depth + 1
+  regardless of operator identity (SV-2).
+- **Recursive deposits blocked at contract level:** a registry walk of the full ancestor chain at
+  deposit time (O(3) by the depth cap); vault-to-vault deposits permitted *only* along registered
+  parent→child edges, closing side-channel cycles like A→B→A (SV-3).
+- **Cumulative effective fee capped** — `STACKED_EXIT_FEE_CAP_BPS = 250` (2.5% ceiling);
+  `PERF_FEE_BPS = 1_000` per level mirrors [[feeengine]]. Re-checked at allocation *and* at child
+  fee-crystallization (SV-4 / G2).
+- **Parent redemptions draw idle stables before touching child positions** (SV-5, liquidity
+  preference not a price guarantee).
+- **Child quorum floor inherits `max(childFloor, parentFloor)`** at allocation, parent floor
+  capped for inheritance (SV-6 / GA-1 fix — a parent could otherwise set floor 100% and brick the
+  child).
+- **Look-through NAV:** a parent prices its child position through the same oracle asset-level
+  path, never through child self-reported NAVps (SV-7 / E1 — recurses depth-bounded so grandchild
+  value reaches root NAV). See [[oracle-layer]].
+
+All SV-* threat rows are **DEFERRED(S5)** and unreachable in the launch config.
+
+## Links
+
+- [[architecture-overview]] · [[governance-commit-reveal]] (electorate, GA-1) · [[fees-and-carry]]
+  (fee stacking) · [[oracle-layer]] (look-through pricing) · [[two-mode-exits]]
+- Contracts: [[subvaultregistry]] · [[vaultfactory]] · [[vaultcore]]
+- Security & decisions: [[c1-empty-electorate]] · [[root-vaults-only]] · [[launch-readiness-gates]]

--- a/docs/vault/subvaultregistry.md
+++ b/docs/vault/subvaultregistry.md
@@ -1,0 +1,56 @@
+# SubVaultRegistry
+
+The registry of parent/child vault edges: depth cap, exit-fee stacking, and quorum-floor
+inheritance. `contracts/src/SubVaultRegistry.sol`. **DORMANT-AT-LAUNCH** — sub-vaults are disabled.
+
+## Why it matters
+
+Sub-vaults let a vault allocate capital into child vaults (vault-of-vaults), with look-through NAV
+pricing and stacked fees. This registry is the source of truth for who is whose child, and its
+structural rules are what make the composition safe *when enabled*. At launch it is deliberately
+inert: the C-1 empty-electorate capture ([[root-vaults-only]]) has no purely-internal fix, so
+[[vaultfactory]] ships with `allowSubVaults = false` and wires every vault with `subVaultRegistry =
+address(0)`. No parent/child edge can ever be created, so nothing in this contract runs. The code is
+**retained, not deleted**, so a future audited factory can enable it.
+
+## Structural properties (SV-1..SV-7)
+
+- **Edges are creation-time only.** A vault becomes a child ONLY at factory deployment, never
+  retroactively — so cycles are impossible by construction (a pre-existing vault can never be
+  re-registered as a child), and vault-to-vault deposits are permitted solely along registered
+  parent→child edges (SV-3, checked by `VaultCore.allocateToChild`).
+- **Depth hard-capped at 3** (`MAX_DEPTH`): root = depth 0, deepest child = depth 2 ⇒ 3 levels.
+- **Exit-fee stacking capped** (SV-4): cumulative exit-fee ceiling across the ancestor chain must
+  stay under `STACKED_EXIT_FEE_CAP_BPS` = 250 (2.5%). Checked in `registerChild` by walking
+  `parentOf` up the chain.
+- **Quorum floors inherit** (SV-6): [[governance]] consults `parentOf` at registration (and on
+  RuleChange update, Sprint-6 F2) and requires child quorum >= parent quorum.
+
+## Key state
+
+- `parentOf[child]`, `depthOf[child]` (root = 0).
+- `factory` (one-shot `wire`, deployer-only), `deployer`.
+- `PERF_FEE_BPS` = 1000 (mirrors [[feeengine]], per level).
+- Views: `stackedPerfFeeBps(vault)` = `1 - (1 - f)^levels` in bps (SV-4 display);
+  `stackedExitFeeCapBps(vault)` = summed exit-fee ceilings up the chain.
+
+## Entry points
+
+- `wire(factory)` — one-shot, deployer-only, locked after first call.
+- `registerChild(parent, child, childExitFeeMaxBps)` — **factory-only**, creation-time only; runs
+  the depth and fee-stack checks.
+
+## Findings
+
+The sub-vault criticals/highs (C-1, H-5, H-6, H-7, H-9) are all closed **as a class** by disabling
+sub-vaults at the factory — see [[root-vaults-only]] and [[vaultfactory]]. This registry carries no
+open finding of its own; its risk surface is simply switched off. The related VaultCore look-through
+machinery (recursive `_fullNavWad`, child-shortfall unwind, `pullChildEscrow`) is likewise dead at
+launch — documented in [[vaultcore]].
+
+## Links
+
+- [[contracts-index]] · [[vaultfactory]] · [[vaultcore]] · [[governance]] · [[feeengine]]
+- Architecture: [[sub-vaults]]
+- Findings: [[c1-empty-electorate]] · [[highs]]
+- Decision: [[root-vaults-only]] · [[current-state]]

--- a/docs/vault/threat-model-commitments.md
+++ b/docs/vault/threat-model-commitments.md
@@ -1,0 +1,60 @@
+# Threat-model commitments
+
+The protocol's threat model ([THREAT-MODEL.md](../THREAT-MODEL.md)) is a 45-row traceability matrix.
+The audit's most important finding is not any single bug but that **eight documented mitigations do
+not hold as written** — the property that makes an unusually thorough threat model dangerous, because
+a reviewer who trusts the rows will not look.
+
+## Why it matters
+
+Each falsified row names the exact attack that defeats it. A green threat model plus 189 passing
+tests concealed five Criticals. These are the rows to re-verify against the corrected tree, not
+trust.
+
+## The eight mitigations that did not hold (report §4.2)
+
+- **EX-2** — "minOut bound from oracle median ± tolerance" was **NOT IMPLEMENTED** (H-4); the oracle
+  was never consulted on the execution path. Now IMPLEMENTED (2% `MAX_REBALANCE_SLIPPAGE_BPS`).
+- **CM-7** — "regime snapshotted per proposal" binds the wrong side of creation (H-8). **PARTIALLY
+  REMEDIATED**: the signer regime now also requires FOR-stake quorum and passes on an outright
+  FOR-stake majority; the regime-flip residual is config-mitigated (meaningful `minDepositUsdc`).
+- **EE-10** — "no indefinite lock; Mode-F shares lose eligibility at queue time" **DOES NOT HOLD** on
+  three counts: C-2 (no bounded deadline), C-5 (exited and Mode-F-queued shares both keep weight on
+  the in-flight proposal), M-7 (~31-day repeatable lock even at a compliant config).
+- **VO-7** — "commit binds direction, no last-mover advantage" — **residual materially larger** (M-10;
+  direction-binding is per address, not per actor).
+- **MO-1** — "a broken governance loses forward pricing, never liveness" — **scope claim falsified**
+  (C-2; the Mode-I fallback covers a *broken* module, not a correct governance answering `true`
+  forever).
+- **MO-2** — "malformed transfers degrade to escrow, never revert" — **partially falsified** (M-11;
+  returndata bounding covers `tryTransfer` only, one of four call shapes).
+- **SF-1** — "multi-source median; no single source can move an asset" — **NOT UPHELD** (M-1
+  independence unenforced; H-1 median fails at the documented quorum). Now **quantified by C-6**: the
+  "5 sources / quorum 3" prescription is a fault-tolerance floor, silent on the Byzantine floor
+  `quorum ≥ 2a+1`; the cheapest adversary is the creator listing two sources they control. Resolution
+  under evaluation: consume Chainlink Data Feeds directly (Byzantine-tolerant at the node-operator
+  layer).
+- **PX-1** — "in-kind escrow keeps non-USDC assets exitable" — **partially false** (M-2; the reverting
+  USDC leg takes the whole settlement down).
+
+Also: **SV-1 / SV-7** — look-through *pricing* is correct, but child *governance* is not upheld (C-1).
+
+## Rows that held
+
+EE-1 (NAV never reads `balanceOf` — donation defence holds), VO-9 (upheld in the deposit direction;
+silent on withdrawal — C-5), EE-7 (shares non-transferable), MO-3/MO-4 (queue-time gate + uniform fee
+withholding), PX-4 (upheld as to authority). The §5 accepted-row challenge agreed with K-2, G3/CM-5,
+EE-8, EE-9, CM-4 and disagreed with E7/EE-5, PX-1, E4, E5, VO-7 (residuals larger than stated).
+
+## Sub-vault rows disabled at launch
+
+The entire **SV** section (SV-1..SV-7) is unreachable at launch — `VaultFactory` ships
+`allowSubVaults = false` (see [[root-vaults-only]]). Those rows remain the threat model for the
+future sub-vault release, resolved with the parent-casts-child-vote mechanism.
+
+## Links
+
+- [[c1-empty-electorate]] · [[c2-unbounded-governance]] · [[c5-vote-after-exit]] ·
+  [[c6-oracle-byzantine]] · [[highs]] (H-4, H-8) · [[mediums-and-lows]] (M-1, M-2, M-7, M-10, M-11)
+- [[root-vaults-only]] · [[chainlink-direct-pivot]] · [[oracleaggregator]] · [[oracle-layer]] ·
+  [[governance]] · [[sub-vaults]] · [[slither-triage]] · [[security-index]]

--- a/docs/vault/two-mode-exits.md
+++ b/docs/vault/two-mode-exits.md
@@ -1,0 +1,73 @@
+# Two-Mode Exits
+
+**Definition.** The redemption side of [[vaultcore]] (commitment C-4): shares burn at
+*settlement*, never at request, and settle either instantly (Mode I) or forward-priced after a
+pending rebalance executes (Mode F). Default payout is pro-rata **in kind**.
+
+**Why it matters.** Mode F closes the free option of exiting at pre-rebalance prices while already
+knowing the rebalance outcome (resolves K-1). In-kind payout makes oversized exits harmless with
+no dilution on remainers — which is *why* swing pricing is not needed in v1.
+
+## Mode I vs Mode F (commitment C-4)
+
+- **Mode I (instant):** no passed-but-unexecuted rebalance exists → the request settles in the
+  same transaction at current NAV. The common path; this is what "instant exit at pro-rata NAV"
+  means.
+- **Mode F (forward):** a rebalance has passed its vote but not yet executed → the request is
+  queued and settles at **post-execution NAV**. Queued requests are irrevocable and settle
+  automatically in the rebalance-execution transaction. Queueing starts at **vote passage**, not
+  timelock expiry ([[governance-commit-reveal]], VO-8).
+
+Between request and settlement in Mode F, shares stay outstanding (still earn/lose with the vault,
+still count in `totalSupply`) but are **locked**: non-transferable and excluded from voting-
+eligible stake — closing the exit-then-veto vector (EE-10). If a passed proposal expires
+unexecuted, queued exits settle at then-current NAV — no indefinite lock.
+
+## In-kind redemption (default)
+
+For `s` shares of supply `T`, the redeemer receives `s/T × balance_i` of every basket asset plus
+`s/T × idleUSDC`, minus the exit fee. In-kind is the manipulation-resistant path: no forced
+selling, so no slippage borne by remainers; the exiter carries their own execution cost.
+
+- **Per-asset transfer failure isolates** — a failed/blacklisted/misbehaving token's slice is
+  escrowed for later claim rather than reverting the whole redemption (EE-6). `tryTransfer` is
+  assembly, gas-capped, bounded to one returndata word (MO-2); malformed results degrade to escrow
+  rather than reverting ([[safetransferlib]]).
+
+## Exit fee (stays in the vault, never to operator)
+
+```
+fee(t) = feeMax × max(0, 1 − t / decayPeriod)     feeMax ≤ EXIT_FEE_CAP_BPS = 100 (1% cap)
+```
+
+`feeMax`/`decayPeriod` are vault-set at creation (immutable after funding, K-2 regime). The
+redeemer's shares burn in full but the fee fraction of their pro-rata slice **stays in the vault**,
+mechanically accruing to remaining members' NAVps. Never routed to the operator; **waived when the
+redeemer is the last member** (no one to accrue to). This is a *different mechanism* from the 10%
+performance fee, which goes to the operator via [[fees-and-carry]] — do not conflate them.
+
+**Invariant: NAVps for remaining members is non-decreasing across any redemption.** Proven by the
+invariant suites without any swing haircut.
+
+## Swing pricing — SPECIFIED, NOT IN v1 (DEFERRED)
+
+v1 ships **in-kind redemption only**. Swing pricing exists solely to neutralize first-mover
+dilution of *cash* redemptions, and there is no cash-redemption path in v1, so there is nothing to
+swing — the NAVps-non-decreasing invariant already holds. The `σ(x)` formula is the spec for a
+future, optional cash path (delivered *through the execution adapter* so the vault needs no venue
+liquidity), and is **out of the audited surface**. EE-11 (split-to-dodge) is therefore N/A in v1.
+
+## Interaction with the oracle breaker
+
+Redemptions read NAV, so a tripped oracle breaker freezes exits too (K-4 / SF-2, **ACCEPTED** — no
+escape hatch, since any exit-during-staleness *is* the stale-price exit the breaker prevents). Only
+*active* share capital is trapped; pending/observation-window capital is always reclaimable
+([[nav-and-shares]]). See [[oracle-layer]].
+
+## Links
+
+- [[architecture-overview]] · [[nav-and-shares]] (NAV, forward pricing on entry) ·
+  [[governance-commit-reveal]] (Mode-F queue at passage) · [[fees-and-carry]] (perf fee vs exit
+  fee) · [[oracle-layer]] (breaker freezes exits) · [[execution-adapters]]
+- Contracts: [[vaultcore]] · [[safetransferlib]]
+- Security: [[c4-depressed-price-theft]] · [[threat-model-commitments]]

--- a/docs/vault/vaultcore.md
+++ b/docs/vault/vaultcore.md
@@ -1,0 +1,110 @@
+# VaultCore
+
+The single contract that **holds all vault funds** and does all share accounting: deposits with a
+4-hour observation window, two-mode redemption, in-kind payout with per-asset escrow isolation,
+tenure-decaying exit fees, capacity caps, cost-basis tracking, rebalancing, and sub-vault
+allocation. `contracts/src/VaultCore.sol`.
+
+## Why it matters
+
+This is the custody contract. Every USDC and every basket token a member deposits lives here, and
+every payout leaves from here. There is no admin, no upgrade path, and no setter: the constructor
+fixes every trust-relevant parameter and the code is immutable after. It is **not ERC-4626**
+(commitment C-1): redemption is in-kind, pricing is forward, and the 4626-shaped views
+(`totalAssets`, `convertToShares`, `convertToAssets`) are labeled **indicative only**. Because it
+holds the money and can never be patched, it is also the contract where the **EIP-170 size cap is
+binding** — several audit fixes could only be afforded by first *shrinking* other code.
+
+## Key state
+
+- **Immutables:** `usdc`, `usdcScalar` (`10**(18-decimals)`, read at runtime — never assumed),
+  `creator`, `operatorRegistry`, `governance`, `feeEngine`, `oracle`, `subVaultRegistry`,
+  `capacityCapUsdc` (0 = uncapped), `minDepositUsdc`, `exitFeeMaxBps` (<= `EXIT_FEE_CAP_BPS` = 100),
+  `exitFeeDecayPeriod`, and the `isAllowedAdapter` allowlist.
+- **Basket:** `basketAssets[]` (<= `MAX_BASKET_ASSETS` = 10), `assetUnit`, internal `assetBalance`
+  and `idleUsdc` — NAV **never reads `balanceOf`** (donation defense, EE-1).
+- **Shares:** `totalShares` (WAD), `sharesOf`, `costBasisUsdc`, `lastDepositTime` (tenure clock),
+  `nonCreatorMemberCount`, `holderCount`.
+- **Observation window:** `pendingDeposit`, `windowCleared`, `skipOptIn`, `totalPendingUsdc`
+  (escrowed, excluded from NAV).
+- **Mode-F queue:** `queuedExitShares`, `totalQueuedShares` (locked shares: no vote, no transfer).
+- **Snapshots (VO-9):** `Checkpoints.History` for eligible stake, total eligible, holder count —
+  read by [[governance]] at `createdAt - 1`.
+- **Sub-vaults:** `childVaults[]` (<= `MAX_CHILDREN` = 8), `MAX_LOOKTHROUGH_DEPTH` = 3.
+- **Escrow:** `claimable[member][asset]` (EE-6 isolation).
+
+## Entry points
+
+- `deposit(uint256)` / `deposit(uint256, uint256 minSharesOut)` — first-ever deposit escrows into
+  the 4-hour window; repeat / window-cleared deposits mint immediately. `minSharesOut` is the M-15
+  immediate-path slippage bound.
+- `activate(address)` / `cancelPending()` / `skipWindow()` — window lifecycle.
+- `requestExit(uint256)` — Mode I (settle now) or Mode F (queue) per `_pendingExecution`;
+  `settleQueuedExit(address)` — settle a queued exit once execution is no longer pending.
+- `executeRebalance(address adapter, SwapOrder[])` — **governance-only**, allowlisted adapter.
+- `allocateToChild` / `redeemFromChild` / `pullChildEscrow` — governance-only sub-vault flows
+  (dead at launch, see [[root-vaults-only]]).
+- `claimEscrowed(address asset)` — pull an EE-6-escrowed slice.
+- Views: `navWad`, `navPerShareWad`, `votingEligibleShares`, `pastVotingEligibleShares`,
+  `pastTotalVotingEligibleShares`, `pastHolderCount`.
+
+## Invariants and deliberate properties
+
+- **NAVps is non-decreasing across any redemption** (§4.6): the exit-fee fraction of every slice
+  stays in the vault for remaining members. Fee waived for a sole holder (would route to self).
+- **Oracle staleness reverts every NAV path, including exits** (K-4 / SF-2). No escape hatch — an
+  exit during staleness is exactly the stale-price exit the breaker prevents.
+- **Shares are non-transferable** in this design (EE-7).
+- **Creator 5% is a withdrawal gate, not a solvency condition** (CM-2): `_checkCreatorGate` binds
+  creator *action* while non-creator members remain; evaluated at Mode-F **queue** time (L-1).
+- **NAV uses internal accounting only** — a token donation cannot mint free shares (EE-1).
+
+## Security findings that live here
+
+- [[c1-empty-electorate]] — the 4626 non-compliance and indicative-only views are C-1's honest
+  labeling; the electorate gate itself is enforced in [[vaultfactory]].
+- [[c4-depressed-price-theft]] — the **two-mode exit** (Mode I / Mode F) is C-4's remediation; see
+  [[two-mode-exits]]. `requestExit` picks the mode from governance state.
+- **H-1** — bookkeeping modules (feeEngine, operatorRegistry) are called **bounded and
+  non-blocking** via `BoundedCall` (gas cap `MODULE_CALL_GAS` = 300k). A reverting / gas-guzzling /
+  returndata-bombing module loses its own bookkeeping (event-logged) but can never block an exit.
+  See [[safetransferlib]].
+- **H-4** — `MAX_REBALANCE_SLIPPAGE_BPS` = 200 (2%) bounds each rebalance leg against the vault's
+  *own* oracle. Deliberately a **protocol constant, not a creator parameter**: a creator-set
+  `maxSlippageBps = 10000` would be a silent no-op — the M-6 mistake. The measured-delta check
+  (`received >= minAmountOut`) is a defense against a lying router (EX-3), **not** a slippage bound.
+- **M-2** — the USDC fee/payout legs now degrade to **escrow** on a failed transfer, exactly like
+  in-kind slices. Previously a blacklisted member (or the singleton feeEngine being blacklisted)
+  could permanently brick every exit carrying a positive performance fee. This fix cost 504 B and
+  was affordable only because [[safetransferlib]]'s M-11 fix returned 336 B first.
+- **M-4 / L-2** — the constructor `require(usdcScalar <= SHORTFALL_DUST_WAD)` pins the settlement
+  decimal floor. `dec >= 6` was *required but unenforced*: below 6 decimals almost every exit
+  reverted (misleadingly as `ExitNeedsChildSettlement`). It also documents L-2 — at the canonical 6
+  decimals the old bound held with exactly **one unit of slack**, by coincidence and undocumented;
+  now a constructor invariant.
+- **M-15** — `deposit(uint256, uint256 minSharesOut)` is the **immediate-path** slippage defense.
+  Exit has no `minValueOut` overload — dropped for the byte budget (documented residual). See
+  [[mediums-and-lows]].
+- Sub-vault look-through (Sprint-6 Findings 1/4/5) — recursive `_fullNavWad`, skip-child-mid-
+  rebalance, and reduce-shortfall-by-what-actually-arrived. Dead at launch.
+
+## Size — EIP-170
+
+VaultCore is the **only** contract meaningfully near the cap. Current margin is **~283 B**.
+
+> Reconciliation (three docs, three points in time): the LAUNCH-READINESS table's **1,014 B**
+> predates M-15's `deposit(uint256,uint256)` overload, which spent **731 B** → ~283 B left; the
+> AUDIT-HANDOFF **1,182 B** is an earlier intermediate value (before M-11 returned bytes and M-2
+> spent them). The overload is present in the current source (`:358`), so ~283 B is the live figure.
+
+This is why **H-5, H-6, H-9 and the exit-side `minValueOut`** all remain unfixed — they land in
+VaultCore and several would not fit even alone. Any future VaultCore fix likely requires moving
+code out (see [[delegatecall-split-rejected]] for the rejected split).
+
+## Links
+
+- [[contracts-index]] · [[governance]] · [[oracleaggregator]] · [[feeengine]] ·
+  [[operatorregistry]] · [[execution-adapters]] · [[safetransferlib]] · [[subvaultregistry]]
+- Architecture: [[nav-and-shares]] · [[two-mode-exits]] · [[fees-and-carry]] · [[sub-vaults]]
+- Findings: [[c1-empty-electorate]] · [[c4-depressed-price-theft]] · [[highs]] · [[mediums-and-lows]]
+- [[threat-model-commitments]] · [[launch-readiness-gates]]

--- a/docs/vault/vaultdeployer.md
+++ b/docs/vault/vaultdeployer.md
@@ -1,0 +1,53 @@
+# VaultDeployer
+
+The factory's one and only vault construction path. It holds `type(VaultCore).creationCode` as
+on-chain data and `CREATE`s new vaults from it. `contracts/src/VaultDeployer.sol`.
+
+## Why it matters
+
+It exists for exactly one reason: **EIP-170**. VaultCore's creation code is 24,731 B — larger than
+the 24,576 B runtime cap all by itself — so *any* contract that writes `new VaultCore(...)` embeds a
+blob that cannot fit in a deployable contract. [[vaultfactory]] was 2,665 B over the cap for this
+reason (#10). Splitting the creation code into a dedicated deployer is what made the factory
+deployable at all. It is the newest contract in the package (Sprint 7).
+
+## How it works
+
+- **Constructor** takes `type(VaultCore).creationCode` (initcode is capped at 49,152 B by EIP-3860,
+  so it fits there) and copies it into **two immutable, non-executable data contracts** (`codeChunkA`,
+  `codeChunkB`) via the SSTORE2 convention — each chunk is prefixed with a `STOP` byte so it can
+  never be executed.
+- **`deploy(bytes ctorArgs)`** reads both chunks back, appends the caller's ABI-encoded constructor
+  arguments, and `CREATE`s. The bytes that reach `CREATE` are therefore fixed at compile time and
+  verifiable on-chain. A failing VaultCore constructor bubbles its own revert data unchanged (so
+  callers still observe `VaultCore.BadConfig()`).
+- **`creationCode()`** reassembles both chunks — a verification aid that must equal the compiled
+  `type(VaultCore).creationCode`.
+
+## Trust — none
+
+This contract holds **no authority**: no owner, no state after construction, no privileged
+relationship with any singleton. Calling `deploy` directly yields an **unattested** VaultCore —
+exactly what anyone could already obtain by deploying VaultCore themselves. Attestation stays
+anchored in [[operatorregistry]], whose `attestVault` is callable only by the wired
+[[vaultfactory]] (CM-5). What the factory's immutable `deployer` pin buys is the *other* direction:
+the factory can only ever `CREATE` through this one code path.
+
+## Findings
+
+No standalone security findings live here — it is a mechanical byte-plumbing contract. It is
+relevant to the [[delegatecall-split-rejected]] decision (an alternative way to relieve VaultCore's
+EIP-170 pressure that was considered and rejected) and it is the reason the factory's own size is
+comfortable (see [[vaultfactory]]).
+
+## Size — EIP-170
+
+Runtime tiny (~60-line contract); its *initcode* is the large artifact (it carries VaultCore's
+creation code), which fits under the EIP-3860 initcode cap. VaultCore itself remains the binding
+constraint — see [[vaultcore]].
+
+## Links
+
+- [[contracts-index]] · [[vaultfactory]] · [[vaultcore]]
+- Decision: [[delegatecall-split-rejected]]
+- [[launch-readiness-gates]]

--- a/docs/vault/vaultfactory.md
+++ b/docs/vault/vaultfactory.md
@@ -1,0 +1,76 @@
+# VaultFactory
+
+The permissionless, canonical vault-deployment and attestation contract. Anyone can deploy a vault;
+only vaults deployed here are attested to their operator. `contracts/src/VaultFactory.sol`.
+
+## Why it matters
+
+The canonical factory is what makes the whole reputation system trustworthy (CM-5, SF-4, PX-3):
+carry marks and leaderboard rows in [[operatorregistry]] can only be produced by real,
+protocol-shaped vaults, because only factory-deployed vaults are attested. Creation stays fully
+permissionless — attestation is automatic and identity-keyed, never curated. It is also the single
+place the **C-1 launch gate** is enforced, which is why one immutable bool on this contract closes
+an entire class of criticals.
+
+## Key state
+
+- Immutables: `registry`, `governance`, `feeEngine`, `subVaultRegistry`, `vaultDeployer`, and the
+  **`allowSubVaults`** switch.
+- `allVaults[]` — every vault ever deployed here.
+
+## Entry points
+
+- `createVault(VaultParams)` — deploy + attest a **root** vault; `msg.sender` becomes creator (the
+  5% gate identity) and attested operator.
+- `createChildVault(VaultParams, parent)` — deploy a child; **reverts `SubVaultsDisabled` at
+  launch**.
+- `vaultCount()` — length of `allVaults`.
+
+Construction goes through `_deploy`, which ABI-encodes VaultCore's constructor tuple and calls
+`vaultDeployer.deploy(...)` (see [[vaultdeployer]] — the factory can't `new VaultCore(...)` because
+that blob exceeds EIP-170). A failing VaultCore constructor bubbles its own revert unchanged.
+
+## Security findings that live here
+
+- [[c1-empty-electorate]] — **the `allowSubVaults = false` gate ([[root-vaults-only]]).** A funded
+  sub-vault has an **empty electorate**: the parent's non-voting exclusion (GA-1) means its only
+  capital is the parent's allocation while its voting-eligible stake and holder count are both zero,
+  so one `minDepositUsdc` buys sole governance control — and the proposer-supplied `minAmountOut`
+  turns capture into **drain**. There is no purely-internal fix (any denominator excluding the
+  parent lets a dust depositor govern the parent's allocation; including it makes the child
+  ungovernable). The decision is to ship launch with sub-vaults **disabled at the contract level**:
+  - `createChildVault` reverts;
+  - `_deploy` wires every vault with `subVaultRegistry = address(0)`, so each is intrinsically
+    root-only — `parentVault()` is `address(0)`, `allocateToChild` reverts, the look-through paths
+    are dead.
+  - This closes **C-1, H-5, H-6, H-7 and H-9 as a class.** The sub-vault code is **retained, not
+    deleted**, so a future factory can enable it once the parent-casts-child-vote mechanism ships and
+    is audited.
+- **L-1 (in `createChildVault`)** — the child path now requires `msg.sender ==
+  parent.creator()`. Previously it performed **no authorization on `parent`**: anyone could
+  permanently attach an arbitrary child under any vault (edges are creation-time-only, no removal)
+  and, as the child's creator, register a `GovConfig` with `timelockDuration = 0` — removing the
+  parent's only race in C-1. Low standalone, load-bearing in composition. (Dormant at launch behind
+  the same gate, but retained.)
+
+The child path also enforces same-USDC and basket-subset-of-parent, so in-kind child redemptions
+always map into parent accounting and look-through pricing (SV-7) is always possible.
+
+## Two-step bring-up
+
+Not a trust gap, documented UX: after `createVault` the creator registers the vault's `GovConfig`
+with [[governance]] in a second transaction. Until then no proposal can exist and exits settle in
+Mode I.
+
+## Size — EIP-170
+
+Runtime ~2,818 B; margin ~21,758 B. (Historically VaultFactory was 2,665 B **over** the cap because
+it embedded VaultCore's creation code inline — the reason [[vaultdeployer]] exists.)
+
+## Links
+
+- [[contracts-index]] · [[vaultdeployer]] · [[vaultcore]] · [[operatorregistry]] ·
+  [[subvaultregistry]] · [[governance]]
+- Architecture: [[sub-vaults]] · [[nav-and-shares]]
+- Findings: [[c1-empty-electorate]] · [[highs]]
+- Decision: [[root-vaults-only]] · [[threat-model-commitments]] · [[launch-readiness-gates]]

--- a/docs/vault/x402-metering.md
+++ b/docs/vault/x402-metering.md
@@ -1,0 +1,53 @@
+# x402 Metering
+
+**Definition.** The paid read layer (`apps/api`): metered HTTP access to indexer-derived vault
+data — analytics, operator leaderboard, signals — settled in USDC on Base via the x402 (V2)
+facilitator flow. **The contracts have no x402 dependency whatsoever.**
+
+**Why it matters.** The load-bearing architectural claim is **zero contract coupling**: x402 lives
+entirely off-chain, so no x402 failure (replay, facilitator compromise) can touch vault funds.
+Deposits are plain on-chain USDC transfers; the vault never special-cases a paid request.
+
+## The boundary (§9, PX-2)
+
+x402 lives only in `apps/api`. Contracts have no HTTP-payment coupling. If x402-initiated deposits
+were ever wanted, they compose *externally* — an agent pays itself into a wallet, then deposits —
+and the vault treats that like any other deposit. PX-2 is **DEFERRED(S7)** / **ACCEPTED**: any
+x402 failure is contained to the API; agents apply their own spend limits.
+
+## x402 V2 flow (server holds no keys, moves no funds)
+
+`src/x402.mjs` implements the payment gate:
+
+- **402 challenge** via a `PAYMENT-REQUIRED` header.
+- Client authorizes with `PAYMENT-SIGNATURE` — a base64 EIP-3009 `transferWithAuthorization`
+  envelope. Settlement is executed by an **injected facilitator**, never this server.
+- `PAYMENT-RESPONSE` echoes the receipt.
+
+Settlement is USDC on Base via EIP-3009, executed by the facilitator per the x402 V2 scheme
+(dedicated `PAYMENT-*` headers, no contract-layer coupling — confirmed in research).
+
+## Route split — x402 IS the rate limiter
+
+`src/server.mjs` (Node-http):
+
+- **Free:** `/health`, `/.well-known/x402`, `/metrics`. Protected by a per-IP token bucket
+  (`src/ratelimit.mjs`) on the free routes only.
+- **Paid:** `/vaults`, `/vaults/:addr`, `/vaults/:addr/members/:m`, `/operators/leaderboard`. These
+  are **self-limiting** — every metered read costs the caller USDC, so **x402 itself is the rate
+  limiter**; no token bucket is applied.
+
+Request caps (method, URL length, body size) are applied before any handler work.
+
+## Observability
+
+`src/metrics.mjs` exposes plain-text counters, including
+`vault_indexer_snapshot_age_seconds` — the indexer-lag signal. The API holds **no RPC client** by
+design, so it reports snapshot age rather than a blocks-behind figure it cannot know. It reads the
+[[off-chain-stack]] indexer's projections directly.
+
+## Links
+
+- [[architecture-overview]] · [[off-chain-stack]] (indexer feeding the reads) · [[fees-and-carry]]
+  (leaderboard data source)
+- Security: [[threat-model-commitments]] (PX-2)


### PR DESCRIPTION
A persistent, graph-structured context store at `docs/vault/` — Obsidian-style, a HOME map-of-content plus `[[wikilinks]]`, so any session or worker can pull project context. **Built by 4 parallel workers** off a shared HOME frame (the graph-engineering / "speed with consistency" pattern).

**Clusters (48 notes):**
- **Architecture** — nav/shares, governance, two-mode exits, sub-vaults, oracle, fees, x402, off-chain stack
- **Contracts** — one note per module (VaultCore, Governance, OracleAggregator, ChainlinkOracle, VaultFactory, …) + index
- **Security** — C-1..C-6, highs, mediums/lows, threat-model commitments, slither-triage, launch gates, audit re-verification
- **Decisions/Principles** — root-vaults-only, chainlink-direct-pivot, build-vs-buy, auto-merge, delegatecall-split-rejected, continuous-autonomous-mode
- **State/Roadmap** — current-state, remediation-history, open-items, prs-and-issues, go-to-market-plan

Findings are filed where their code lives; the two `C-n` namespaces (design commitments vs audit findings) are disambiguated throughout. Docs-only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
