### PR TITLE
docs(vault): refresh for C-6 deploy scaffolding (#53-#57)

### DIFF
--- a/docs/vault/chainlinkoracle.md
+++ b/docs/vault/chainlinkoracle.md
@@ -14,6 +14,15 @@ entirely**: it trusts Chainlink's own decentralized OCR aggregation per asset. T
 no quorum, and no per-vault source list to misconfigure — so the whole C-6 / H-1 / M-1 attack
 surface disappears. This is the [[chainlink-direct-pivot]] decision made concrete.
 
+## Deploy scaffolding (Phase 3)
+
+Fully merged and ready for operator handoff:
+- **`DeployChainlinkOracle.s.sol`** — deployment script; populates `base-mainnet.json` feed config at runtime.
+- **`scripts/verify-chainlink-oracle.mjs`** — on-chain verifier confirms each feed is live and responsive before go-live.
+- **Integration test** (`AuditC6Integration.t.sol`) — ChainlinkOracle × VaultCore end-to-end flow.
+- **Fuzz suite** — property-based safety of price staleness, bounds-checking, sequencer uptime, and feed failure paths.
+- See [[go-to-market-plan]] for the safe deploy sequence.
+
 ## Key state
 
 - `feedOf[asset]` — `FeedConfig { IAggregatorV3 feed; uint32 heartbeat; uint64 scale; uint128

--- a/docs/vault/current-state.md
+++ b/docs/vault/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-What is true right now. The live branch is `protocol/main` (@ `a265b9dd`); the launch verdict is **NO-GO**. Snapshot as of the Phase-2 remediation and the C-6 / ChainlinkOracle pivot plus the factory oracle-gate (2026-08-28).
+What is true right now. The live branch is `protocol/main` (@ `78ea1f87`); the launch verdict is **NO-GO**. Snapshot as of Phase-2 remediation, C-6 / ChainlinkOracle pivot, factory oracle-gate, and C-6 deploy scaffolding (2026-08-28).
 
 ## Why it matters
 
@@ -10,13 +10,13 @@ This protocol is immutable at deployment, so "ship" is a one-way door. This note
 
 Two gates keep it there ([[launch-readiness-gates]]):
 
-- **Gate 0 — no known unfixed Critical: NO-GO, on C-6.** Four of five original Criticals are closed with **executed** evidence: C-1 ([[root-vaults-only]]), C-2, C-3, C-5. C-4/C-6 keep the row NO-GO — the Phase-2 re-verification (`AuditC4EndToEnd.t.sol`) falsified the inferred "C-4 path closed" claim and surfaced **C-6** ([[c6-oracle-byzantine]]): at `a ≥ 2` adversarial oracle sources the theft re-opens. C-6 has no clean code fix at m=5; the resolution is the [[chainlink-direct-pivot]]. The C-6 **remediation mechanism is now complete in code** — the safe [[chainlinkoracle]] (#49) plus [[vaultfactory]]'s `allowedOracles_` factory oracle-gate (**DONE, PR #50**). Gate 0 stays NO-GO only until the mainnet deploy config populates the allowlist with real blessed-oracle addresses and the external audit clears; issue #48 tracks that residual.
+- **Gate 0 — no known unfixed Critical: NO-GO, on C-6.** Four of five original Criticals are closed with **executed** evidence: C-1 ([[root-vaults-only]]), C-2, C-3, C-5. C-4/C-6 keep the row NO-GO — the Phase-2 re-verification (`AuditC4EndToEnd.t.sol`) falsified the inferred "C-4 path closed" claim and surfaced **C-6** ([[c6-oracle-byzantine]]): at `a ≥ 2` adversarial oracle sources the theft re-opens. C-6 has no clean code fix at m=5; the resolution is the [[chainlink-direct-pivot]]. The C-6 **remediation mechanism and deploy scaffolding are now complete in code** — the safe [[chainlinkoracle]] (#49), [[vaultfactory]]'s `allowedOracles_` factory oracle-gate (#50), `DeployChainlinkOracle.s.sol` + `scripts/verify-chainlink-oracle.mjs` (#55), and `Deploy.s.sol` guard (#53). The **only missing piece is populating the config with real Base Chainlink feed addresses** (fill placeholders → verify → set `BLESSED_ORACLES` → deploy). Gate 0 stays NO-GO until then and the external audit clears; issue #48 tracks that residual.
 - **Gate 1 — external audit: NO-GO.** Not started, and nothing in these sessions could change it — an AI pre-audit is not an external audit. Commission a **full** review of the corrected tree at a new tag (`v0.4.0-audit` recommended); it must also cover the remediation itself.
 
 ## Branch and evidence state
 
 - **Live branch:** `protocol/main` @ `a265b9dd`. Remediation lands via [[auto-merge]] per-finding PRs.
-- **Merged (Phase 2):** #43 (C-1 root-vaults-only), #44 (H-8), #45 (M-15), #46 (dispositions), #47 (C-6 re-verification), #49 (ChainlinkOracle), #50 (C-6 factory oracle-gate), #51 (vault). See [[prs-and-issues]].
+- **Merged (Phase 2):** #43 (C-1 root-vaults-only), #44 (H-8), #45 (M-15), #46 (dispositions), #47 (C-6 re-verification), #49 (ChainlinkOracle), #50 (C-6 factory oracle-gate), #51 (vault), #53 (deploy guard), #54–57 (C-6 scaffolding: tests, config, fuzz, docs). See [[prs-and-issues]].
 - **Open issues:** #40 (VaultCore-headroom sprint), #41 (rebuild `base-mainnet.json`), #48 (C-6 tracking).
 - **CI (gate 8): GO.** Full battery green — `forge fmt --check`, `forge build --sizes`, `forge test`, `forge snapshot --check`, and the backend suite all pass. (The last recorded `forge test` count was 252 pass / 0 fail / 0 skip on the 2026-08-27 remediation branch; later PRs added tests, so treat the count as indicative, not a live `protocol/main` figure — forge was not re-run here.) Green certifies the gates *ran*, not that the protocol is safe.
 - **Evidence STALE:** the remediation changed six contracts, so gates 2 (testnet lifecycle), 3 (soak), and 6 (canary) are re-marked STALE — their reports describe superseded bytecode. Gate 4 (live x402 settlement) is the one operational gate that survives intact. See [[audit-reverification]].

--- a/docs/vault/go-to-market-plan.md
+++ b/docs/vault/go-to-market-plan.md
@@ -16,6 +16,17 @@ Because the protocol is immutable per vault, go-to-market is expressed almost en
 - **Governance config:** `3600/3600/0/86400`, quorum 2,500 bps root floor — the values the soak ran through five full rounds. Zero timelock is defensible *because* Mode-F exits exist.
 - **Oracle staleness:** 3,600 s/asset (not tighter — a tight bound drops the pull-based Pyth leg on most reads); `maxObservationAge ≤ window/20` is a hard constraint (90 s ceiling at the 1,800 s window).
 
+## Mainnet deploy sequence (Phase 3)
+
+The C-6 oracle-gate is fully scaffolded ([#53–57]); the safe bring-up order is:
+1. **Populate `base-mainnet.json`** — fill [[chainlinkoracle]] `feedOf[asset]` config placeholders with real Base Chainlink feed addresses.
+2. **`DeployChainlinkOracle.s.sol`** — deploy and test the oracle contract with verified addresses.
+3. **`scripts/verify-chainlink-oracle.mjs`** — on-chain verifier confirms feeds are live and responding.
+4. **Set `BLESSED_ORACLES`** — populate the factory's immutable allowlist with the verified oracle address (the gate that enables `createVault`).
+5. **`Deploy.s.sol`** — mainnet deployment now succeeds (guard reverts if allowlist is empty).
+
+Defer the bespoke [[oracleaggregator]] to a second-generation vault post-audit, pending the parent-casts-child-vote mechanism.
+
 ## Scaling path
 
 Raise capacity by **deploying a second vault (≥250k)** only after **≥30 incident-free days** with the canary clean. Do not launch an uncapped vault. Reinstate sub-vaults only after C-1's parent-casts-child-vote mechanism is built and audited **and** the SV-* drills are re-run against corrected contracts.

--- a/docs/vault/prs-and-issues.md
+++ b/docs/vault/prs-and-issues.md
@@ -18,6 +18,11 @@ In [[continuous-autonomous-mode]] with [[auto-merge]], the PR list *is* the chan
 | **#49** | `security/chainlink-oracle` | additive `ChainlinkOracle.sol` (Chainlink Data Feeds direct) | C-6 resolution ([[chainlink-direct-pivot]]) |
 | **#50** | `security/c6-factory-oracle-gate` | [[vaultfactory]] immutable `allowedOracles_` allowlist; `createVault`/`createChildVault` revert `OracleNotAllowed` when enforced; `AuditOracleAllowlist.t.sol` | C-6 factory oracle-gate — completes the mechanism ([[c6-oracle-byzantine]]) |
 | **#51** | `security/c6-vault` | the vault itself | C-6 ([[chainlink-direct-pivot]]) |
+| **#53** | `security/deploy-guard` | `Deploy.s.sol` guard reverts if `BLESSED_ORACLES` allowlist empty on Base-mainnet | Deploy-time safety for C-6 oracle gate ([[vaultfactory]]) |
+| **#54** | `security/c6-integration-tests` | `ChainlinkOracle` × `VaultCore` integration test suite | C-6 end-to-end ([[chainlinkoracle]]) |
+| **#55** | `security/chainlink-config` | `base-mainnet.json` `chainlinkOracle` config block with feed placeholders; `scripts/verify-chainlink-oracle.mjs` on-chain verifier | C-6 deploy config ([[chainlinkoracle]]) |
+| **#56** | `security/chainlink-fuzz` | `ChainlinkOracle` fuzz suite | C-6 property-based safety ([[chainlinkoracle]]) |
+| **#57** | `docs/deployment-restructure` | `DEPLOYMENT.md` restructured: §1 deploy+verify `ChainlinkOracle` first → §2 factory with `BLESSED_ORACLES` → §3 custom oracle marked **DEFERRED** | C-6 deploy sequence ([[go-to-market-plan]]) |
 
 Earlier (Phase 1): **#39** (`security/critical-remediation`) closed the twelve findings; **#38** was the Sprint-15 battery refresh; **#42** the medium-tier pass. See [[remediation-history]].
 

--- a/docs/vault/vaultfactory.md
+++ b/docs/vault/vaultfactory.md
@@ -62,9 +62,10 @@ that blob exceeds EIP-170). A failing VaultCore constructor bubbles its own reve
   list is permissive (enforcement off). This is the contract-level lever that makes the custom
   aggregator non-deployable and pins vaults to the blessed [[chainlinkoracle]] — the second half of
   the C-6 remediation, alongside the safe oracle (#49). See [[chainlink-direct-pivot]]. Regression:
-  `AuditOracleAllowlist.t.sol`. (Gate 0 stays NO-GO until the mainnet deploy config populates the
-  allowlist with real blessed-oracle addresses and the external audit clears — the *mechanism* is now
-  complete.)
+  `AuditOracleAllowlist.t.sol`. Mainnet deployment is guarded by `Deploy.s.sol` (PR #53) which
+  **reverts if the `BLESSED_ORACLES` allowlist is empty**, preventing accidental unsafe deploys. Gate 0
+  stays NO-GO until the config is populated with real addresses and the external audit clears — the
+  *mechanism* is now complete.
 
 The child path also enforces same-USDC and basket-subset-of-parent, so in-kind child redemptions
 always map into parent accounting and look-through pricing (SV-7) is always possible.


### PR DESCRIPTION
Updates 5 knowledge-vault notes (prs-and-issues, current-state, go-to-market-plan, chainlinkoracle, vaultfactory) for the merged deploy guard / integration + fuzz tests / config + verifier / runbook. Docs-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)