### PR TITLE
docs(Governance): name the H-8 standing-defaults asymmetry (Audit Council info)

### DIFF
--- a/contracts/src/Governance.sol
+++ b/contracts/src/Governance.sol
@@ -533,6 +533,14 @@ contract Governance is IGovernance {
             bool headMajorityWithStake = p.revealedVoterCount * 2 > p.memberCount
                 && p.forWeight * BPS >= uint256(configOf[p.vault].quorumBps) * p.snapshotTotal;
             bool forStakeMajority = p.forWeight * 2 > p.snapshotTotal;
+            // NOTE (Audit Council, informational): `forWeight` includes APPLIED STANDING DEFAULTS,
+            // so branch 2 can pass a Rebalance on a >50% pre-declared-default majority with zero live
+            // reveals — whereas the >=5-member stake regime below counts `revealedWeight` only
+            // (defaults never count toward quorum, VO-2/K-3). This asymmetry is design-consistent and
+            // non-exploitable: standing defaults are Rebalance-only (VO-4), must pre-date the proposal
+            // (`setAt < createdAt`), and are genuine stakeholder pre-declarations — a >50% default
+            // majority IS a real mandate. It only ever WIDENS passing (additive), so it introduces no
+            // freeze. Named here so an auditor sees it is intended, not overlooked.
             quorumOk = headMajorityWithStake || forStakeMajority;
         } else {
             // Stake quorum: revealed (live) weight only — defaults never count (VO-2).


### PR DESCRIPTION
The Phase-2 Audit Council review of H-8/C-1/M-15 came back **ALL ACCEPT (9.8 overall, no Critical/High/Medium)**. Its one Informational note: the H-8 additive branch's `forWeight` includes applied standing defaults (a >50% pre-declared-default majority can pass a Rebalance with zero live reveals) — design-consistent and non-exploitable. Named in-code so an auditor sees it's intended. Comment-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)