### PR TITLE
feat(oracle): base-mainnet chainlinkOracle populated with on-chain-verified Base addresses

### DIFF
--- a/contracts/config/base-mainnet.json
+++ b/contracts/config/base-mainnet.json
@@ -1,8 +1,9 @@
 {
   "chainName": "base-mainnet",
   "chainId": 8453,
-  "status": "NOT-DEPLOYABLE — REBUILD REQUIRED AFTER THE 2026-08-27 SECURITY REMEDIATION",
-  "blockingNote": "THIS FILE CANNOT BE DEPLOYED AS WRITTEN. Three independent constructor requirements added by the security remediation now reject it, and each needs a human decision plus real on-chain addresses that must not be invented: (1) H-1 — every asset carries quorum 2, and OracleAggregator now requires quorum >= MIN_MEDIAN (3), because a two-element lower median is a MINIMUM, not a median; (2) H-1 again — with only 3 sources per asset, quorum 3 means any single dark source freezes the asset, so each asset needs >= 5 sources to have BOTH median integrity and failure headroom, i.e. two further independently-operated sources per asset whose addresses are not in this file; (3) H-2 — twapDefaults pairs windowSeconds 1800 with maxObservationAgeSeconds 3600, and UniswapV3TwapSource now requires maxObservationAge <= window / 20 (= 90s at this window), because the newest observation age is exactly the live tick's weight in the reported mean. Both rejections are pinned as tests: MixedOracleSources::test_remediated_theOldThreeSourceQuorumTwoShapeIsRejected and AuditTwapRealCostModel::test_remediated_constructorRejectsMaxObsAgeAboveTheWindowFraction. The on-chain verification below remains TRUE of the addresses it checked, and is retained for that reason — but it is now evidence about a configuration that no longer builds. Re-run scripts/verify-mainnet-config.mjs after rebuilding, and note M-12: that script cannot observe maxObservationAgeSeconds at all, so it would not have caught (3).",
+  "status": "LAUNCH ORACLE = `chainlinkOracle` block (VERIFIED-ON-CHAIN 2026-08-29). The custom multi-source `assets`/`twapDefaults`/`pyth` sections are the DEFERRED, pre-C-6 path and remain NOT-DEPLOYABLE (see chainlinkOracleNote / blockingNote).",
+  "chainlinkOracleNote": "C-6 launch resolution: the protocol now uses Chainlink Data Feeds DIRECTLY (the `chainlinkOracle` block below), not the bespoke median. That block is populated with on-chain-verified Base addresses (WETH via ETH/USD, cbBTC via BTC/USD, the Base L2 sequencer feed, USDC pinned) and passes `scripts/verify-chainlink-oracle.mjs` (12/12). Deploy path: DeployChainlinkOracle.s.sol -> verify -> BLESSED_ORACLES -> Deploy.s.sol. The `blockingNote` below applies ONLY to the deferred custom-aggregator sections, which the C-6 factory allowlist makes non-selectable at launch anyway.",
+  "blockingNote": "(DEFERRED custom-oracle path only — superseded by chainlinkOracle for launch.) THIS SECTION CANNOT BE DEPLOYED AS WRITTEN. Three independent constructor requirements added by the security remediation now reject it, and each needs a human decision plus real on-chain addresses that must not be invented: (1) H-1 — every asset carries quorum 2, and OracleAggregator now requires quorum >= MIN_MEDIAN (3), because a two-element lower median is a MINIMUM, not a median; (2) H-1 again — with only 3 sources per asset, quorum 3 means any single dark source freezes the asset, so each asset needs >= 5 sources to have BOTH median integrity and failure headroom, i.e. two further independently-operated sources per asset whose addresses are not in this file; (3) H-2 — twapDefaults pairs windowSeconds 1800 with maxObservationAgeSeconds 3600, and UniswapV3TwapSource now requires maxObservationAge <= window / 20 (= 90s at this window), because the newest observation age is exactly the live tick's weight in the reported mean. Both rejections are pinned as tests: MixedOracleSources::test_remediated_theOldThreeSourceQuorumTwoShapeIsRejected and AuditTwapRealCostModel::test_remediated_constructorRejectsMaxObsAgeAboveTheWindowFraction. The on-chain verification below remains TRUE of the addresses it checked, and is retained for that reason — but it is now evidence about a configuration that no longer builds. Re-run scripts/verify-mainnet-config.mjs after rebuilding, and note M-12: that script cannot observe maxObservationAgeSeconds at all, so it would not have caught (3).",
   "rebuildChecklist": [
     "Choose 2 further sources per asset (mechanism- or at least operator-diverse; see MixedOracleSources.t.sol for why operator diversity has to carry the 4th and 5th slots while only three mechanism classes are implemented), and record their real Base mainnet addresses.",
     "Set quorum to 3 for every asset (MIN_MEDIAN, strict majority of 5, and two failures of headroom). ⚠ C-6: quorum 3 of 5 is only a FAULT-TOLERANCE floor — it tolerates exactly ONE adversarial source (a=1). It is NOT Byzantine-safe against two: a single honest leg withholding drops the fresh set to 4 and two controlled sources own the lower median (re-opening C-4's 88.9% theft). Byzantine safety needs quorum >= 2a+1 and m >= 2a+f+1. m=5 CANNOT tolerate a=2 with any fault tolerance. So EITHER guarantee the 5 sources are genuinely independent with no single actor controlling >1 (a listing/curation requirement the contract cannot enforce), OR list m>=7 for a=2, OR — recommended — abandon the custom aggregator and consume Chainlink Data Feeds directly (already Byzantine-tolerant at the node-operator layer). See AI-AUDIT-REPORT.md C-6.",
@@ -150,33 +151,40 @@
   },
 
   "chainlinkOracle": {
-    "status": "NOT-POPULATED — requires real, on-chain-verified Chainlink Base feed addresses (human input)",
+    "status": "VERIFIED-ON-CHAIN 2026-08-29 — Base mainnet (chainId 8453), RPC https://mainnet.base.org",
     "purpose": "The C-6 launch resolution (see AI-AUDIT-REPORT.md C-6): replace the bespoke multi-source median with a ChainlinkOracle that prices each asset from ONE genuine Chainlink Data Feed. Deploy it with DeployChainlinkOracle.s.sol, verify with scripts/verify-chainlink-oracle.mjs, then set BLESSED_ORACLES to its address for Deploy.s.sol (which refuses a Base-mainnet deploy with an empty allowlist).",
-    "doNotInvent": "Every address below is a PLACEHOLDER. Do not fill with a guessed/copy-pasted address — a wrong or fake feed prices every vault against it wrong, permanently (immutable). Resolve each from Chainlink's official Base mainnet Data Feeds page and verify on-chain.",
-    "sequencerUptimeFeed": "0x0000000000000000000000000000000000000000",
-    "sequencerUptimeFeedNote": "Base mainnet Chainlink L2 Sequencer Uptime Feed. MANDATORY on Base — ChainlinkOracle reverts every price without it. Resolve from Chainlink's 'L2 Sequencer Uptime Feeds' docs for Base and verify code.length > 0.",
+    "verifiedOnChain": "Every feed/token/sequencer address below was read from Base mainnet 2026-08-29 and matched: ETH/USD proxy decimals()==8, description()=='ETH / USD', latestRoundData() answer ~$2440 fresh; BTC/USD proxy decimals()==8, description()=='BTC / USD', answer ~$77,700 fresh; sequencer feed has code, latestRoundData() answer==0 (up) with startedAt long past; WETH token is the canonical Base predeploy 0x4200..0006 (18 dp); cbBTC symbol()=='cbBTC' (8 dp); USDC is Circle-native 0x8335..2913. Re-run scripts/verify-chainlink-oracle.mjs before deploying regardless (read-only, no key).",
+    "sequencerUptimeFeed": "0xBCF85224fc0756B9Fa45aA7892530B47e10b6433",
+    "sequencerUptimeFeedNote": "Base mainnet Chainlink L2 Sequencer Uptime Feed (verified: has code, latestRoundData answer==0=up). MANDATORY on Base — ChainlinkOracle reverts every price without it. GRACE_PERIOD is 3600s (ChainlinkOracle constant).",
     "usdcPin": true,
-    "usdcPinNote": "USDC pinned to 1e18 in ChainlinkOracle (usdc = the config `usdc` above). Do NOT also list USDC in `assets` (the ChainlinkOracle constructor rejects that). A sustained USDC depeg is mispriced by the pin; list a USDC/USD feed instead if that risk must be measured.",
+    "usdcPinNote": "USDC pinned to 1e18 in ChainlinkOracle (usdc = the config `usdc` above = 0x8335..2913). Do NOT also list USDC in `assets` (the ChainlinkOracle constructor rejects that). A sustained USDC depeg is mispriced by the pin; list a USDC/USD feed instead if that risk must be measured.",
     "assets": [
       {
         "symbol": "WETH",
-        "asset": "<REAL Base WETH token address>",
-        "feed": "<REAL Chainlink ETH/USD Data Feed proxy on Base>",
-        "heartbeatSeconds": 1200,
-        "minPriceWad": "0",
-        "maxPriceWad": "0",
-        "note": "Set heartbeatSeconds to the feed's OWN heartbeat from Chainlink's Base feed page (+ a small buffer). Set minPriceWad/maxPriceWad to a sane band (0/0 = disabled) before listing volatile/depeg-prone collateral — the band is the deprecated-min/maxAnswer-clamp defence."
+        "asset": "0x4200000000000000000000000000000000000006",
+        "feed": "0x50015f8b17fb2C290Dde41fDc246ed0dcEE93a8b",
+        "feedDescription": "Chainlink ETH / USD (8 decimals)",
+        "heartbeatSeconds": 3600,
+        "heartbeatNote": "The feed's own heartbeat is 1200s; 3600 is the ChainlinkOracle staleness bound (heartbeat + generous L2 buffer, so a healthy 1200s feed never false-trips while a >1h-frozen feed fails closed).",
+        "minPriceWad": "100000000000000000000",
+        "maxPriceWad": "100000000000000000000000",
+        "bandNote": "sane-price band $100 .. $100,000 (WAD). ETH ~ $2,440 at verification — comfortably inside. The band is the depeg/clamp defence, not a tight collar."
       },
       {
-        "symbol": "cbETH",
-        "asset": "<REAL Base cbETH token address>",
-        "feed": "<REAL Chainlink cbETH/USD Data Feed proxy on Base>",
-        "heartbeatSeconds": 86400,
-        "minPriceWad": "0",
-        "maxPriceWad": "0",
-        "note": "Same verification as WETH. cbETH heartbeat is typically longer; confirm on the feed page."
+        "symbol": "cbBTC",
+        "asset": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+        "feed": "0x32F587986D3fb47601157c19615d568BeD0BCabc",
+        "feedDescription": "Chainlink BTC / USD (8 decimals)",
+        "heartbeatSeconds": 3600,
+        "heartbeatNote": "Feed heartbeat 1200s; 3600 staleness bound (heartbeat + L2 buffer).",
+        "minPriceWad": "1000000000000000000000",
+        "maxPriceWad": "1000000000000000000000000",
+        "bandNote": "sane-price band $1,000 .. $1,000,000 (WAD). BTC ~ $77,700 at verification — inside. Coinbase Wrapped BTC (cbBTC, 8 dp) on Base."
       }
     ],
+    "notListed": {
+      "cbETH": "No Chainlink cbETH/USD Data Feed exists on Base (only CBETH/ETH, an exchange-rate feed). ChainlinkOracle is single-feed-per-asset, so cbETH cannot be priced without composing cbETH/ETH x ETH/USD — out of launch scope. This is the documented single-provider asset-coverage tradeoff (C-6)."
+    },
     "verification": [
       "For each asset feed: code.length > 0; decimals() <= 18; latestRoundData() answer > 0 and updatedAt fresh within heartbeatSeconds.",
       "For each asset: a sane-price band MUST be set — minPriceWad > 0 and maxPriceWad >= minPriceWad (the depeg-clamp defence; 0/0 is rejected by the verifier for mainnet).",

--- a/scripts/verify-chainlink-oracle.mjs
+++ b/scripts/verify-chainlink-oracle.mjs
@@ -60,11 +60,17 @@ function callUint(addr, sig) {
   }
 }
 function latestRoundData(addr) {
-  // (roundId, answer, startedAt, updatedAt, answeredInRound)
+  // (roundId, answer, startedAt, updatedAt, answeredInRound). `cast` prints one value per line and
+  // annotates large ints with a scientific-notation suffix, e.g. "244049270000 [2.44e11]" — take
+  // the leading integer token of each line and ignore the annotation.
   try {
     const out = cast(['call', addr, 'latestRoundData()(uint80,int256,uint256,uint256,uint80)', '--rpc-url', RPC]);
-    const parts = out.split(/\s+/).filter(Boolean);
-    return { answer: BigInt(parts[1]), updatedAt: BigInt(parts[3]) };
+    const nums = out
+      .split('\n')
+      .map((l) => l.trim().split(/\s+/)[0])
+      .filter((x) => /^-?\d+$/.test(x));
+    if (nums.length < 5) return null;
+    return { answer: BigInt(nums[1]), startedAt: BigInt(nums[2]), updatedAt: BigInt(nums[3]) };
   } catch {
     return null;
   }


### PR DESCRIPTION
Populates the C-6 launch oracle config with **on-chain-verified** Base addresses (fetched from Chainlink's own feeds directory + L2-sequencer docs, then verified via `cast` against Base mainnet — nothing invented). **`verify-chainlink-oracle.mjs` now passes 12/12 on-chain.**

| Asset | Token | Feed | Verified |
|---|---|---|---|
| WETH | `0x4200…0006` | ETH/USD `0x50015f8b…3a8b` | "ETH / USD", 8 dp, ~$2,440 fresh |
| cbBTC | `0xcbB7C0…33Bf` | BTC/USD `0x32F58798…Cabc` | "BTC / USD", 8 dp, ~$77,700 fresh |
| USDC (pinned) | `0x8335…2913` | — | Circle-native |
| sequencer | — | `0xBCF85224…6433` | answer 0 = up |

- Staleness 3600s (feed heartbeat 1200s + L2 buffer); sane-price bands set (the depeg-clamp defence).
- **cbETH not listed**: no Chainlink cbETH/USD feed exists on Base (only cbETH/ETH) — documented single-provider coverage tradeoff.
- **Fixed a real verifier bug** found by running it: `cast`'s `[1.8e19]` sci-notation suffix on tuple returns broke the `latestRoundData` parser (read as a revert). Now robust.

**Ready-to-deploy env (after re-running the verifier):**
```
ORACLE_ASSETS=0x4200000000000000000000000000000000000006,0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf
ORACLE_FEEDS=0x50015f8b17fb2C290Dde41fDc246ed0dcEE93a8b,0x32F587986D3fb47601157c19615d568BeD0BCabc
ORACLE_HEARTBEATS=3600,3600
ORACLE_MIN_WAD=100000000000000000000,1000000000000000000000
ORACLE_MAX_WAD=100000000000000000000000,1000000000000000000000000
ORACLE_USDC=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
ORACLE_SEQUENCER=0xBCF85224fc0756B9Fa45aA7892530B47e10b6433
```
Config + tooling only; no contract change. **Gate-0 residual (real oracle addresses) is now resolved — only the external audit remains.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
