### PR TITLE
Record verified Base Sepolia pivot redeploy (address book)

### DIFF
--- a/contracts/config/deployments/base-sepolia.json
+++ b/contracts/config/deployments/base-sepolia.json
@@ -1,53 +1,44 @@
 {
   "chainName": "base-sepolia",
   "chainId": 84532,
-  "deployedAt": "2026-08-21T00:00:00Z",
-  "deployBlock": 45784186,
-  "startBlock": 45784186,
+  "deployedAt": "2026-08-29T00:00:00Z",
+  "deployBlock": 46111530,
+  "startBlock": 46111530,
   "deployer": "0x0f80606a2283fD9C67cE2eEC79B90E95907F9f35",
-  "sourceCommit": "153d4cf3",
-  "rpc": "https://base-sepolia-rpc.publicnode.com",
+  "sourceCommit": "5934ef22",
+  "rpc": "https://sepolia.base.org",
   "explorer": "https://sepolia.basescan.org",
-  "note": "Addresses below were verified independently on-chain (codesize + wiring reads via cast), not taken from the deploy log. See the deviation recorded in docs/TESTNET-REPORT.md: forge's per-transaction console labels and the broadcast JSON's contractName<->hash alignment were both scrambled for this run; the '== Return ==' block, Basescan verification, and on-chain reads all agree with what is recorded here.",
+  "note": "C-6 PIVOT REDEPLOY (2026-08-29). This is the Chainlink-direct stack: DeployTestnet.s.sol now deploys a ChainlinkOracle (one genuine Chainlink feed per asset) seeded into the factory oracle allowlist, replacing the retired custom OracleAggregator. Every address below was verified INDEPENDENTLY ON-CHAIN via cast (feedOf/priceWad on the oracle, and factory.registry()/governance()/feeEngine()/subVaultRegistry()/vaultDeployer() wiring reads) — NOT taken from the deploy log, whose printed per-tx summary was label-scrambled again (the run-latest.json contractName<->address map was correct this time, and agrees with the on-chain reads recorded here). Live oracle reads at verification: priceWad(WETH)=~$2,431.77, priceWad(LINK)=~$11.31, priceWad(USDC)=$1.00. Prior custom-oracle deployment (deployBlock 45784186) is in git history.",
 
   "singletons": {
-    "OperatorRegistry": "0xC5F3A734618019C4abE512dD9BF3D5B852494bDB",
-    "SubVaultRegistry": "0x0C60b9a4C207dd622CcC0Ee3C51b5c274cb7B979",
-    "FeeEngine": "0xDEb08dCF5ceaf00c95E2C355CB63aC334C7e3fBc",
-    "Governance": "0x4AddcAc4834a8672edb4Aef25c33D7909865091c",
-    "VaultDeployer": "0x2c70858BA8796398CC7638389155d1Cc0426533D",
-    "VaultFactory": "0x79279FBa3b6F6736f07cbBFcB7Cf0559466D5bfB"
+    "OperatorRegistry": "0xd702E688110CB2B2503bEBc2087D984C4Ab18307",
+    "SubVaultRegistry": "0x075Cd3455A5CE0f828f4D3B6B3A124313930eeE0",
+    "FeeEngine": "0xfC04958049B28f2990076a9841e1dc7d5cC113A9",
+    "Governance": "0xcd9B2E37D14c57362f005355757bfa6Db450C206",
+    "VaultDeployer": "0x891633092Cff72f6566785C9c9B6b574c178e036",
+    "VaultFactory": "0x72767FAD4C8254D20Fc06e4a47DFd16683AAFD0A"
   },
 
   "oracle": {
-    "OracleAggregator": "0xEc1976579Af27b3dF5fd103390acAb22E4b566F4",
+    "ChainlinkOracle": "0x6371E14C0682882e75E8382caf0216545B1f43C6",
     "maxStalenessSeconds": 86400,
+    "note": "C-6 launch model: ONE genuine Chainlink Data Feed per asset (no multi-source median/quorum). deployment.mjs reads each asset's single `feed` as a one-element source set. USDC is pinned to $1 inside the oracle. The oracle is the sole entry in the factory's oracle allowlist (oracleAllowlistEnforced=true, isAllowedOracle(oracle)=true, verified on-chain).",
     "assets": {
       "WETH": {
         "token": "0x4200000000000000000000000000000000000006",
-        "quorum": 2,
-        "sources": [
-          "0x790A308f1ac06FeD4C79884BAD25d0C721C5B125",
-          "0xc36198FD2c7C62738159ED1FF965679105FAF05a",
-          "0xc44B853F037b4fF33B831C9a2B341686dEC88Fd1"
-        ],
+        "feed": "0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1",
         "underlyingFeed": "0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1"
       },
       "LINK": {
         "token": "0xE4aB69C077896252FAFBD49EFD26B5D171A32410",
-        "quorum": 2,
-        "sources": [
-          "0xd415F712E84737c711942332e22c5EFB8B457869",
-          "0x9B2B1DF61C9f452899ae6258f18c3008Bf466fFF",
-          "0x61a840C5f3F56f954A0433DfeD17088D7418e096"
-        ],
+        "feed": "0xb113F5A928BCfF189C998ab20d753a47F9dE5A61",
         "underlyingFeed": "0xb113F5A928BCfF189C998ab20d753a47F9dE5A61"
       }
     }
   },
 
   "execution": {
-    "AggregationRouterAdapter": "0x1D8794279035CC04C9BCF939AB956845916998c1",
+    "AggregationRouterAdapter": "0xf3e08c8b00281750d531a48473d053009038a9b1",
     "router": "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4",
     "routerName": "Uniswap SwapRouter02 (Base Sepolia)"
   },
@@ -56,31 +47,17 @@
     "usdc": "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
   },
 
-  "vaultCoreDataContracts": {
-    "note": "Created by VaultDeployer's constructor as SSTORE2-style non-executable data holding VaultCore's creation code. 12366 + 12367 = 24733 bytes, minus the two STOP prefix bytes = 24731, exactly VaultCore's initcode size. These are data, not compiled contracts, so forge's verifier reports 'no matching bytecode' for them -- expected, not an error.",
-    "chunks": [
-      "0xf449c167f1d0d98a22e4c8072e69c779fb8884bb",
-      "0x896114bac81da0965febf6b21bd2f984d1b93e1f"
-    ]
-  },
-
   "verifiedWiring": {
-    "registry.factory()": "0x79279FBa3b6F6736f07cbBFcB7Cf0559466D5bfB",
-    "registry.feeEngine()": "0xDEb08dCF5ceaf00c95E2C355CB63aC334C7e3fBc",
-    "subReg.factory()": "0x79279FBa3b6F6736f07cbBFcB7Cf0559466D5bfB",
-    "gov.subVaultRegistry()": "0x0C60b9a4C207dd622CcC0Ee3C51b5c274cb7B979",
-    "factory.registry()": "0xC5F3A734618019C4abE512dD9BF3D5B852494bDB",
-    "factory.governance()": "0x4AddcAc4834a8672edb4Aef25c33D7909865091c",
-    "factory.feeEngine()": "0xDEb08dCF5ceaf00c95E2C355CB63aC334C7e3fBc",
-    "factory.subVaultRegistry()": "0x0C60b9a4C207dd622CcC0Ee3C51b5c274cb7B979",
-    "factory.vaultDeployer()": "0x2c70858BA8796398CC7638389155d1Cc0426533D",
+    "registry.factory()": "0x72767FAD4C8254D20Fc06e4a47DFd16683AAFD0A",
+    "gov.subVaultRegistry()": "0x075Cd3455A5CE0f828f4D3B6B3A124313930eeE0",
+    "factory.registry()": "0xd702E688110CB2B2503bEBc2087D984C4Ab18307",
+    "factory.governance()": "0xcd9B2E37D14c57362f005355757bfa6Db450C206",
+    "factory.feeEngine()": "0xfC04958049B28f2990076a9841e1dc7d5cC113A9",
+    "factory.subVaultRegistry()": "0x075Cd3455A5CE0f828f4D3B6B3A124313930eeE0",
+    "factory.vaultDeployer()": "0x891633092Cff72f6566785C9c9B6b574c178e036",
+    "factory.oracleAllowlistEnforced()": true,
+    "factory.isAllowedOracle(ChainlinkOracle)": true,
+    "factory.allowSubVaults()": true,
     "routerAdapter.router()": "0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4"
-  },
-
-  "gas": {
-    "totalGasUsed": 13158066,
-    "gasPriceWei": 6000000,
-    "totalPaidEth": "0.000078948396",
-    "note": "Per-contract gas is recorded in docs/TESTNET-REPORT.md, keyed by address from cast receipt rather than from the broadcast JSON."
   }
 }

--- a/scripts/test/soak-deployment.test.mjs
+++ b/scripts/test/soak-deployment.test.mjs
@@ -129,11 +129,15 @@ test('the committed base-sepolia address book parses and is chain-84532', () => 
   assert.equal(d.chainId, 84532);
   assert.equal(d.maxStalenessSeconds, 86400);
   assert.equal(d.assets.length, 2);
-  // The documented testnet compromise: 3 sources per asset over ONE underlying feed.
+  // C-6 pivot: the committed book is now the Chainlink-direct stack — ONE genuine Chainlink feed
+  // per asset (no multi-source median), so a single-element source set and quorum 1.
   for (const a of d.assets) {
-    assert.equal(a.sources.length, 3, `${a.symbol} should list 3 adapter sources`);
-    assert.equal(a.quorum, 2, `${a.symbol} should run 2-of-3 quorum`);
+    assert.equal(a.sources.length, 1, `${a.symbol} should list its single Chainlink feed`);
+    assert.equal(a.quorum, 1, `${a.symbol} is single-feed => quorum 1`);
+    assert.equal(a.sources[0], a.underlyingFeed, `${a.symbol} source === underlying feed`);
   }
+  // The oracle resolves to the deployed ChainlinkOracle in the factory allowlist.
+  assert.equal(d.aggregator, '0x6371E14C0682882e75E8382caf0216545B1f43C6');
 });
 
 // ── freeze-safety classifier (drill 4) ────────────────────────────────────────


### PR DESCRIPTION
Regenerates the committed Base Sepolia address book to the C-6 Chainlink-direct deploy (deployBlock 46111530), every address **verified on-chain** via cast (oracle prices live: WETH ~$2,431.77, LINK ~$11.31, USDC $1; factory allowlist enforced + oracle blessed). Updates the book-shape test to single-feed/quorum-1. scripts tests 15/15.