### PR TITLE
tooling: one-command local CI mirror, status board, and saved review workflows

### DIFF
--- a/.claude/workflows/adversarial-review.js
+++ b/.claude/workflows/adversarial-review.js
@@ -1,0 +1,197 @@
+export const meta = {
+  name: 'adversarial-review',
+  description: 'Find bugs across target files, then adversarially refute each finding before reporting it',
+  whenToUse:
+    'Security or correctness review of a specific change or subsystem. This is the pattern that found the ' +
+    'permanent-brick bug (PR #70) and the three deploy footguns (PR #69). Pass target files via args.',
+  phases: [
+    { title: 'Find', detail: 'one finder per target file, each with its own lens' },
+    { title: 'Refute', detail: 'independent skeptics per finding, prompted to kill it' },
+    { title: 'Synthesize', detail: 'rank survivors and name what was NOT covered' },
+  ],
+};
+
+/*
+ * WHY THIS SHAPE.
+ *
+ * A finder pool alone produces plausible-but-wrong findings at a high rate, and every one of those
+ * costs a human reviewer real time. The refute stage exists to make a finding EARN its place: each
+ * survivor has been attacked by independent skeptics who were told that killing it is the win.
+ *
+ * The verifiers use DIFFERENT LENSES rather than being N copies of one skeptic. A wrong finding
+ * usually fails in one specific way -- it misreads the code, or it is real but unreachable, or it is
+ * already mitigated elsewhere -- and identical verifiers share blind spots. Diversity catches what
+ * redundancy cannot.
+ *
+ * Findings verify as soon as their finder returns (pipeline, not parallel): file A's findings are
+ * being refuted while file B is still being read. A barrier here would waste the fast finders'
+ * time for no benefit, because refutation needs only ONE finding, never the whole set.
+ */
+
+// ---------------------------------------------------------------- args
+
+const raw = args ?? {};
+const targets = (Array.isArray(raw) ? raw : (raw.targets ?? [])).map((t) =>
+  typeof t === 'string' ? { file: t, lens: 'correctness, security, and unstated assumptions' } : t,
+);
+
+if (!targets.length) {
+  throw new Error(
+    'adversarial-review needs targets. Pass args as ["path/a.sol","path/b.sol"] or ' +
+      '{targets:[{file,lens}], verifiers, context, maxTargets, maxFindings}.',
+  );
+}
+
+const VERIFIERS = raw.verifiers ?? 2;
+const CONTEXT = raw.context ?? '';
+// Caps keep one invocation inside the session's agent budget. They are LOGGED, never silent:
+// a truncated review that reads as "we covered everything" is worse than no review.
+const MAX_TARGETS = raw.maxTargets ?? 5;
+const MAX_FINDINGS = raw.maxFindings ?? 6;
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'severity', 'location', 'claim', 'exploit'],
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low', 'info'] },
+          location: { type: 'string', description: 'file:line' },
+          claim: { type: 'string', description: 'the defect, stated so it can be checked' },
+          exploit: { type: 'string', description: 'concrete inputs/state -> wrong outcome' },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'reason', 'confidence'],
+  properties: {
+    refuted: { type: 'boolean' },
+    reason: { type: 'string' },
+    confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+  },
+};
+
+// Each lens attacks a finding from a different direction. Order matters only for readability.
+const LENSES = [
+  {
+    key: 'misread',
+    ask: 'Did the finder MISREAD the code? Re-read the cited lines and the functions they call. Does the code actually do what the claim says?',
+  },
+  {
+    key: 'reachable',
+    ask: 'Is this REACHABLE? Find a caller and a concrete state where it fires. Access control, a require earlier in the path, or an impossible precondition all kill it.',
+  },
+  {
+    key: 'mitigated',
+    ask: 'Is this ALREADY MITIGATED elsewhere -- a check in the caller, a factory-level guard, an invariant, or an existing test that would fail if this were real?',
+  },
+];
+
+// ---------------------------------------------------------------- run
+
+const used = targets.slice(0, MAX_TARGETS);
+if (targets.length > used.length) {
+  log(`CAP: reviewing ${used.length} of ${targets.length} targets. NOT covered: ${targets.slice(MAX_TARGETS).map((t) => t.file).join(', ')}`);
+}
+
+phase('Find');
+log(`${used.length} finders over: ${used.map((t) => t.file).join(', ')}`);
+
+const perTarget = await pipeline(
+  used,
+  // Stage 1 -- read the file and report defects.
+  (t) =>
+    agent(
+      `Review ${t.file} in this repository for defects, with particular attention to: ${t.lens}.
+${CONTEXT ? `\nExtra context for this review:\n${CONTEXT}\n` : ''}
+Read the file AND the code it calls into -- a claim about behaviour you did not read is a guess.
+Report only concrete, code-grounded defects. Precision over volume: a wrong finding costs a human
+reviewer more than a missed low-severity one. An empty findings array is a perfectly good answer
+for sound code.`,
+      { label: `find:${t.file.split('/').pop()}`, phase: 'Find', schema: FINDINGS_SCHEMA },
+    ),
+
+  // Stage 2 -- refute each of THIS target's findings immediately, without waiting for other targets.
+  (found, t) => {
+    const list = (found?.findings ?? []).slice(0, MAX_FINDINGS);
+    if ((found?.findings ?? []).length > list.length) {
+      log(`CAP: ${t.file} returned ${found.findings.length} findings; verifying the first ${list.length}.`);
+    }
+    if (!list.length) return [];
+
+    return parallel(
+      list.map((f) => () =>
+        parallel(
+          LENSES.slice(0, VERIFIERS).map((lens) => () =>
+            agent(
+              `Your job is to REFUTE this claimed defect in ${t.file}. Killing it is the win.
+
+  Title:    ${f.title}
+  Location: ${f.location}
+  Claim:    ${f.claim}
+  Exploit:  ${f.exploit}
+
+Attack it specifically on this axis: ${lens.ask}
+
+Read the actual code before answering. If you cannot establish that the claim holds, set
+refuted=true -- the burden of proof is on the finding, not on you.`,
+              { label: `refute:${lens.key}`, phase: 'Refute', schema: VERDICT_SCHEMA },
+            ),
+          ),
+        ).then((votes) => {
+          const cast = votes.filter(Boolean);
+          const kills = cast.filter((v) => v.refuted).length;
+          // A finding survives only on a clear majority of NON-refutations. Ties and total
+          // verifier failure both count against it: unverified is not the same as confirmed.
+          const survives = cast.length > 0 && kills * 2 < cast.length;
+          return { ...f, file: t.file, survives, votes: cast, kills, cast: cast.length };
+        }),
+      ),
+    );
+  },
+);
+
+const all = perTarget.flat().filter(Boolean);
+const confirmed = all.filter((f) => f.survives);
+const killed = all.filter((f) => !f.survives);
+
+log(`${all.length} findings examined -> ${confirmed.length} survived refutation, ${killed.length} killed.`);
+
+if (!confirmed.length) {
+  return {
+    confirmed: [],
+    killed: killed.map((f) => ({ title: f.title, file: f.file, why: f.votes.find((v) => v.refuted)?.reason })),
+    summary: 'No finding survived adversarial refutation.',
+  };
+}
+
+phase('Synthesize');
+const report = await agent(
+  `Write a review report from these findings, all of which already survived independent refutation.
+
+${JSON.stringify(confirmed.map(({ votes, ...f }) => f), null, 2)}
+
+Rank by real-world risk: blast radius, reversibility, and how plausibly the triggering conditions
+occur -- not by the label the finder attached. For each, give the defect, the concrete failure, and
+the smallest fix that closes it.
+
+Then add a short "not covered" section naming what this review did NOT examine: files outside
+${JSON.stringify(used.map((t) => t.file))}, and any lens you think the findings above suggest is
+missing. Do not pad it -- name real gaps only.`,
+  { label: 'synthesize', phase: 'Synthesize' },
+);
+
+return {
+  confirmed,
+  killed: killed.map((f) => ({ title: f.title, file: f.file, why: f.votes.find((v) => v.refuted)?.reason })),
+  report,
+};

--- a/.claude/workflows/department-buildout.js
+++ b/.claude/workflows/department-buildout.js
@@ -1,0 +1,145 @@
+export const meta = {
+  name: 'department-buildout',
+  description: 'Author N independent charters/plans in parallel from one brief, then integrate them into a single plan',
+  whenToUse:
+    'Any "write the whole set at once" job where the pieces are independent but must end up consistent: ' +
+    'department charters, per-vertical go-to-market plans, runbooks per subsystem, per-module threat models. ' +
+    'This is the pattern that produced the 8 department charters + Company Plan.',
+  phases: [
+    { title: 'Author', detail: 'one agent per unit, working from the shared brief' },
+    { title: 'Integrate', detail: 'reconcile conflicts and surface decisions the author pass could not make' },
+  ],
+};
+
+/*
+ * WHY THIS SHAPE.
+ *
+ * Writing N documents in one context makes them blur: later sections inherit the vocabulary and
+ * assumptions of earlier ones, and the whole set converges on a single voice that agrees with
+ * itself. Independent authors disagree, and the disagreements are the valuable output -- they are
+ * exactly where an unstated assumption is hiding.
+ *
+ * So the integrate pass is NOT a summarizer. Its job is to find where the authors contradict each
+ * other and to name the decisions that no author had standing to make. A synthesis that reports
+ * "all units are aligned" has usually just flattened the signal.
+ */
+
+// ---------------------------------------------------------------- args
+
+const raw = args ?? {};
+const units = (Array.isArray(raw) ? raw : (raw.units ?? [])).map((u) =>
+  typeof u === 'string' ? { name: u, focus: '' } : u,
+);
+const BRIEF = raw.brief ?? '';
+const OUT_DIR = raw.outDir ?? '';
+const MAX_UNITS = raw.maxUnits ?? 9;
+
+if (!units.length || !BRIEF) {
+  throw new Error(
+    'department-buildout needs a brief and units. Pass args as ' +
+      '{brief:"...", units:[{name,focus}|"name"], outDir?:"...", maxUnits?:9}.',
+  );
+}
+
+const UNIT_SCHEMA = {
+  type: 'object',
+  required: ['unit', 'document', 'assumptions', 'decisionsNeeded', 'dependencies'],
+  properties: {
+    unit: { type: 'string' },
+    document: { type: 'string', description: 'the full charter/plan in markdown' },
+    assumptions: {
+      type: 'array',
+      description: 'what this author had to assume because the brief did not say',
+      items: { type: 'string' },
+    },
+    decisionsNeeded: {
+      type: 'array',
+      description: 'decisions only the founder/owner can make, that this unit is blocked on or shaped by',
+      items: { type: 'string' },
+    },
+    dependencies: {
+      type: 'array',
+      description: 'other units this one depends on, and what it needs from them',
+      items: { type: 'string' },
+    },
+  },
+};
+
+// ---------------------------------------------------------------- run
+
+const used = units.slice(0, MAX_UNITS);
+if (units.length > used.length) {
+  log(`CAP: authoring ${used.length} of ${units.length} units. NOT written: ${units.slice(MAX_UNITS).map((u) => u.name).join(', ')}`);
+}
+
+phase('Author');
+log(`${used.length} authors: ${used.map((u) => u.name).join(', ')}`);
+
+const written = (
+  await parallel(
+    used.map((u) => () =>
+      agent(
+        `You are authoring the "${u.name}" document, one of ${used.length} being written independently and in
+parallel from the same brief. You will not see the others, and that is deliberate -- write what
+YOUR unit actually requires, even where you suspect it conflicts with a neighbour.
+
+SHARED BRIEF
+${BRIEF}
+
+YOUR UNIT: ${u.name}${u.focus ? `\nFOCUS: ${u.focus}` : ''}
+
+Ground the document in this repository: read the code, config, docs and tests that bear on your
+unit rather than writing from generic domain knowledge. A charter that could have been written
+without opening the repo is not worth having.
+
+Be concrete and specific. Where the brief is silent, make a defensible choice, write it into
+"assumptions", and keep going -- do not stall or hedge the document itself. Where a choice is
+genuinely not yours to make, put it in "decisionsNeeded" and say what turns on each option.`,
+        { label: `author:${u.name}`, phase: 'Author', schema: UNIT_SCHEMA },
+      ),
+    ),
+  )
+).filter(Boolean);
+
+log(`${written.length}/${used.length} units authored.`);
+if (!written.length) return { units: [], error: 'every author failed' };
+
+// A BARRIER IS CORRECT HERE, and it is the one place in these workflows where it is: the integrator
+// compares every unit against every other, so it genuinely needs the complete set at once.
+phase('Integrate');
+
+const integrated = await agent(
+  `Integrate ${written.length} independently authored units into one coherent plan.
+
+${written
+  .map(
+    (w) => `### ${w.unit}
+ASSUMPTIONS: ${JSON.stringify(w.assumptions)}
+DECISIONS NEEDED: ${JSON.stringify(w.decisionsNeeded)}
+DEPENDS ON: ${JSON.stringify(w.dependencies)}
+
+${w.document}`,
+  )
+  .join('\n\n---\n\n')}
+
+Your job is NOT to summarize. Produce:
+
+1. CONFLICTS -- where two units assume incompatible things, or both claim the same responsibility,
+   or one's dependency is something another never committed to provide. Quote both sides. If you
+   find none, say so explicitly and state what you checked, because "everything agrees" is more
+   often a flattened synthesis than a real result.
+2. THE BINDING CONSTRAINT -- across all units, what actually gates progress? Argue for it against
+   the next most plausible candidate.
+3. DECISIONS FOR THE OWNER -- deduplicated across units, each with the options and what each one
+   costs or forecloses.
+4. CRITICAL PATH -- the ordered sequence, with what can run in parallel alongside it.
+
+${OUT_DIR ? `Write the integrated plan and each unit document under ${OUT_DIR}.` : ''}`,
+  { label: 'integrate', phase: 'Integrate' },
+);
+
+return {
+  units: written.map((w) => ({ unit: w.unit, assumptions: w.assumptions, decisionsNeeded: w.decisionsNeeded })),
+  documents: Object.fromEntries(written.map((w) => [w.unit, w.document])),
+  integrated,
+};

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ scripts/soak/.state-*.json
 skills-lock.json
 # Local, per-machine Claude Code settings (never shared).
 .claude/settings.local.json
+
+# Local pre-merge gate result (scripts/gate.mjs). Describes THIS machine last run,
+# not a property of the branch, so it is never committed.
+.gate-state.json

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,0 +1,79 @@
+# NOW — start here
+
+**The cold-start file.** Read this first, then run `npm run cc`. Together they should make a fresh
+session productive without re-reading the history.
+
+Keep it SHORT and keep it CURRENT. If a section here grows past a screen, the detail belongs in the
+document it points at. A stale NOW.md is worse than none, so update it in the same commit as the
+work it describes.
+
+- **Live facts** (branch, gate result, deployed addresses, launch gate board, open PRs) are computed
+  by `npm run cc` — never duplicate them here, they will drift.
+- **Reasoning** lives in `docs/LAUNCH-READINESS.md` (go/no-go, argued) and the Obsidian vault
+  (`Agent-Governed Vaults/`) — narrative, decisions, session handoffs.
+- **This file** holds only what neither of those gives you: what is being worked on right now, what
+  is blocked on a human, and the traps that are not visible in the code.
+
+---
+
+## Right now
+
+- **Launch is NO-GO, but no longer for security reasons.** Every security gate is cleared. What
+  remains is operational (testnet re-runs, a restore drill), legal, and calendar-bound.
+- **Smoke test is parked mid-lifecycle on Base Sepolia**, at the `activate` step. It is idempotent
+  and resumable; the last attempt failed only on a mistyped keystore password. Remaining phases sit
+  behind ~2h of protocol timelocks.
+- **CI is unavailable** — GitHub Actions minutes exhausted 2026-08-29, back around 2026-09-01.
+  `npm run gate` is the substitute and mirrors `ci.yml` step for step. Do not trust a red CI in this
+  window without reproducing it locally: PR #71's "backend fail" was minutes exhaustion, not code.
+- **Batch related changes into one PR.** A CI round trip is 6–7 minutes, so three PRs for three
+  related fixes costs 20 minutes of waiting for nothing.
+
+## Blocked on a human
+
+These need a funded key or a decision, and no amount of agent work advances them:
+
+1. **Resume the smoke lifecycle** (needs the `deployer` keystore password) — unblocks launch gate 2.
+2. **Soak + canary re-run** on the pivoted tree — unblocks gates 3 and 6. Wired and ready:
+   `scripts/soak/run-soak.ps1`.
+3. **Recorded restore drill** — gate 7. ~30 minutes, read-only, no keys needed.
+4. **Launch parameter: `proposalThresholdBps = 500`.** Keep it or lower it — immutable per vault
+   once shipped. See the trap below.
+
+## Traps that are not visible in the code
+
+- **The operator needs ≥5% of eligible stake permanently, or loses the right to propose anything —
+  including the change that would lower the threshold.** Dilution is passive: other members deposit,
+  `totalShares` grows, nothing re-checks. This is a deliberate design choice, not a bug (a floor was
+  implemented, measured, and reverted — `test/audit/AuditProposalThresholdFloor.t.sol` — because a
+  constructor cannot observe live stake distribution). Consequence: the operator seed is *derived,
+  not chosen*, and "zero capital cost to the operator" is false — say *low*, and state the number.
+- **This is a shared worktree.** Never `git add -A`; it has already swept another session's work
+  into a PR. Commit named paths only.
+- **`OperatorRegistry` attestation has no rebind**, so the operator payout address is permanent.
+  It should be a Safe, not an EOA.
+- **The oracle is single-provider Chainlink.** Heartbeat + sane-price band + sequencer gate are the
+  only defences against a bad answer. Assets are limited to WETH + cbBTC — Base has no cbETH/USD
+  feed. A feed deprecation fails that asset *closed*, which is safe but has no fallback.
+- **The sequencer guard has never run against a real uptime feed.** Testnet leaves it `address(0)`
+  by design, so its first real execution would be on mainnet.
+
+## The loop
+
+```bash
+npm run gate
+```
+
+Mirrors CI locally in about 30 seconds. `--quick` drops the gas snapshot; `--only <step>` re-runs one
+step; `--list` explains every step and the deliberate divergences from CI.
+
+```bash
+npm run cc
+```
+
+The command center: tree state, whether the gate result actually certifies *this* commit, the launch
+gate board, deployed addresses, and open PRs. `--md` emits the same content as markdown for a handoff
+note.
+
+Reusable multi-agent patterns are saved workflows, not re-authored scripts — see
+`.claude/workflows/` (`adversarial-review`, `department-buildout`) and `docs/WORKFLOWS.md`.

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -1,0 +1,124 @@
+# SWARM.md — the contract every parallel agent reads first
+
+This is the shared spec for parallel development on this repo. Read it before writing a line.
+
+It exists because parallel agents without a shared contract produce *divergent* output — five
+different naming conventions, five different opinions about what "done" means, and a merge that
+costs more than the parallelism saved. The method is borrowed from Bun's Zig→Rust rewrite, which
+moved 535k lines with 64 concurrent agents in 11 days: **the first three hours went into writing the
+porting guide, not into porting.** That guide is what made the other 64 agents agree.
+
+---
+
+## 1. The unit of work
+
+**One agent owns one module.** Not one feature spanning six files — one file, or one tightly-bounded
+set. Ownership is exclusive for the life of the task: if you need to change a file another agent
+owns, say so in your report rather than changing it.
+
+Work is divvied by module boundary precisely so that merges are trivial. A conflict means the
+decomposition was wrong, not that the merge was unlucky.
+
+## 2. The work queue is mechanical, never invented
+
+Bun used compiler errors: 16,000 of them, grouped by crate, handed to 64 fixers. The queue was
+machine-generated, unambiguous, and finite, so no agent ever had to guess what to do next.
+
+Our equivalents, in order of preference:
+
+1. **`npm run gate` failures** — the CI mirror. Unambiguous, fast, and authoritative.
+2. **Slither output** — `cd contracts && slither . --filter-paths "^lib/|^test/|^script/" --json -`.
+   312 results today, grouped by detector. Advisory in CI, which means nobody has triaged them.
+3. **`forge build --sizes` margins** — EIP-170 headroom is the binding constraint on several
+   deferred features. A byte freed is a feature unblocked.
+4. **Named findings** in `docs/LAUNCH-READINESS.md` and `docs/NOW.md`.
+
+If you find yourself inventing work, stop: pick from a queue instead.
+
+## 3. The review pattern: 1 implementer → 2 adversarial reviewers → 1 fixer
+
+This is not optional and it is not a formality. Bun caught three real bugs this way that would
+otherwise have shipped — a use-after-free from a premature `Box` drop, a `trunc()` that needed to be
+`floor()` for negative values, and an eager `unwrap_or()` that panicked where a closure was intended.
+All three passed the implementer's own review.
+
+Rules that make it work:
+
+- **Reviewers see the diff, not the plan.** They are told to *find the way it is wrong*, not to
+  assess whether it seems reasonable. A reviewer who reports "looks good" has not done the job.
+- **Reviewers are independent.** They do not see each other's verdicts.
+- **The burden of proof is on the change.** A reviewer who cannot convince themselves the change is
+  correct votes to reject. Unverified is not the same as correct.
+- **The fixer is a separate step.** The implementer does not grade their own homework.
+
+## 4. Mechanical faithfulness — do not refactor opportunistically
+
+Bun's rule was: *do the rewrite that looks like we transpiled the Zig code.* No cleanup along the
+way, no "while I'm here". Opportunistic refactoring is what turns a reviewable 30-line diff into an
+unreviewable 400-line one, and it is where regressions hide.
+
+If you spot something worth fixing that is outside your task, **report it — do not fix it.** It
+becomes an item on the queue for someone who owns that module.
+
+## 5. Keep the codebase light
+
+- **Delete dead code rather than maintaining it.** Retired subsystems are not free: they carry
+  audit surface, Slither noise, compile time, licence obligations, and reader confusion.
+- **No stub-outs.** A `TODO`, a swallowed error, or a function that returns a placeholder is not a
+  completed task. If you cannot do it, report that you could not.
+- **No paragraph-long comments justifying a workaround.** Bun's reviewers rejected these on sight:
+  if it takes a paragraph to defend the code, fix the code. (This is distinct from explaining *why*
+  a non-obvious constraint exists — that comment is valuable and belongs there.)
+- **Minimise `assembly`.** Where it is unavoidable, it should be a single bounded block with the
+  invariant stated above it.
+
+## 6. Tests are an invariant, not a variable
+
+Bun's rewrite ran the same test suite before and after, and reported **0 tests skipped or deleted**
+across ~60,000 tests. That is the standard here.
+
+- Never delete a test to make a change pass. Never add `skip`. Never loosen an assertion.
+- The audit tests under `contracts/test/audit/` are **exploit demonstrations and remediation
+  proofs**. They are the evidence record for findings C-1 through C-6. If your change makes one
+  unbuildable, that is a design problem with your change — solve it, or report the conflict. Do not
+  delete the evidence.
+- New behaviour needs a new test. "The existing suite still passes" is necessary, not sufficient.
+
+## 7. Definition of done
+
+A task is done when **all** of these hold:
+
+1. `npm run gate` passes from the repo root. It mirrors CI step for step (~31s warm).
+2. If gas legitimately changed: regenerated via `cd contracts && forge snapshot --nmt "testFuzz"`,
+   and **said so explicitly** in the report.
+3. If `src/` changed: EIP-170 margin measured before and after, and reported as numbers.
+4. Work is committed on your own branch, in your own worktree.
+5. Your report states what you changed, what you found but deliberately did *not* change, and what
+   you are uncertain about.
+
+"I believe it works" is not done. The gate output is the evidence.
+
+## 8. Git discipline
+
+- **NEVER `git add -A`.** This is a shared worktree and it has already swept another session's work
+  into a PR once. Stage named paths, always.
+- **Atomic commits.** Bun ran 695 commits/hour across 64 agents by keeping each commit small and
+  single-purpose. Do not batch unrelated changes into one commit.
+- **No `git stash`, `git reset --hard`, or `git checkout --` on files you did not create.** Another
+  agent's work may be in the tree.
+- Branch names are prefixed by intent: `fix/`, `feat/`, `test/`, `chore/`, `docs/`.
+
+## 9. Batch related changes into one PR
+
+A CI round trip costs 6–7 minutes. Three PRs for three related fixes costs 20 minutes of waiting for
+nothing. One PR per coherent change, not one PR per file.
+
+## 10. What is out of scope for any agent
+
+Escalate; do not act:
+
+- Anything requiring a private key, a funded account, or a `--broadcast`.
+- Mainnet deploys, fund movement, or anything irreversible on-chain.
+- Changing launch parameters (`proposalThresholdBps`, caps, timelock durations) — these are
+  founder decisions with permanent consequences, documented in `docs/NOW.md`.
+- Weakening a security gate to make something pass. If a gate blocks you, the gate is probably right.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,91 @@
+# Saved multi-agent workflows
+
+Reusable orchestration patterns live in `.claude/workflows/` as scripts, so they are invoked by name
+rather than re-authored from memory each time. Re-authoring is where the quality drifts: the
+adversarial review that found the permanent-brick bug worked because of specific structural choices
+(independent refuters, diverse lenses, majority-kill), and those are exactly the details that get
+dropped when a script is rewritten from a one-line description.
+
+Invoke one by name, passing `args`:
+
+```
+Workflow({ name: 'adversarial-review', args: { targets: [...] } })
+```
+
+---
+
+## `adversarial-review`
+
+**Find → refute → synthesize.** One finder per target file, then independent skeptics attack each
+finding before it is reported. This is the pattern behind PR #70 (the creatable permanent brick) and
+PR #69 (three deploy-script footguns).
+
+```js
+args = {
+  targets: [
+    { file: 'contracts/src/VaultFactory.sol', lens: 'the oracle allowlist curation gate' },
+    'contracts/script/Deploy.s.sol',              // string form gets a generic lens
+  ],
+  verifiers: 2,        // 1-3; which refutation lenses to use (misread / reachable / mitigated)
+  context: '',         // extra briefing, e.g. what changed in this PR and why
+  maxTargets: 5,       // caps are LOGGED, never silent
+  maxFindings: 6,      // per target
+}
+```
+
+Returns `{ confirmed, killed, report }`. `killed` is kept deliberately — knowing what was proposed
+and refuted is how you tell a thorough review from a lucky one.
+
+**Why it is shaped this way.** A finder pool alone produces plausible-but-wrong findings at a high
+rate, and each one costs a human reviewer real time. Three things do the work:
+
+- **Refuters are told that killing the finding is the win.** The burden of proof sits on the
+  finding. A verifier that cannot establish the claim votes to refute.
+- **Lenses differ rather than repeat.** A wrong finding usually fails in one specific way — it
+  misread the code, or it is real but unreachable, or it is already mitigated elsewhere. Identical
+  verifiers share blind spots; different ones do not.
+- **Ties and verifier failures count against the finding.** Unverified is not the same as confirmed.
+
+Findings refute as soon as their finder returns, so file A's findings are under attack while file B
+is still being read. There is no barrier, because refutation needs one finding, never the whole set.
+
+## `department-buildout`
+
+**Author N documents in parallel from one brief, then integrate.** Produced the eight department
+charters and the Company Plan. Generalizes to any "write the whole set at once" job: per-vertical
+plans, per-subsystem runbooks, per-module threat models.
+
+```js
+args = {
+  brief: 'the shared context every author works from',
+  units: [{ name: 'Security', focus: '...' }, 'Legal'],
+  outDir: 'Business/',   // optional; where the integrator writes
+  maxUnits: 9,
+}
+```
+
+Returns `{ units, documents, integrated }`.
+
+**Why it is shaped this way.** Writing N documents in one context makes them blur — later sections
+inherit the vocabulary and assumptions of earlier ones, and the set converges on a single voice that
+agrees with itself. Independent authors disagree, and the disagreements are the valuable output:
+they mark where an unstated assumption is hiding.
+
+So the integrate pass is **not a summarizer**. It hunts for contradictions between units, names the
+binding constraint and argues for it against the runner-up, and collects the decisions no author had
+standing to make. A synthesis reporting "all units are aligned" has usually just flattened the
+signal — the workflow tells the integrator to say what it checked when it finds no conflicts.
+
+This is the one place a barrier is correct: the integrator compares every unit against every other,
+so it genuinely needs the complete set.
+
+---
+
+## Adding a workflow
+
+A pattern earns a file here once it has been run twice and worked. Before then it is a script, not a
+pattern. When you add one, write down *why* the structure is what it is — a future reader can see
+the shape from the code, but not the failure mode it was built to avoid.
+
+Both scripts log their caps (`CAP: reviewing 5 of 8 targets. NOT covered: …`). Keep that habit: a
+truncated run that reads as "we covered everything" is worse than one that admits its limits.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "apps/*"
   ],
   "scripts": {
+    "gate": "node scripts/gate.mjs",
+    "cc": "node scripts/status.mjs",
     "build:contracts": "cd contracts && forge build",
     "test:contracts": "cd contracts && forge test -vv",
     "test:backend": "node --test packages/oplog/test/*.test.mjs packages/indexer/test/*.test.mjs packages/canary/test/*.test.mjs packages/agent-sdk/test/*.test.mjs packages/reference-agent/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs scripts/test/*.test.mjs",

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Local pre-merge gate: run everything `.github/workflows/ci.yml` gates on, in one command,
+ * on this machine.
+ *
+ *     npm run gate            # full mirror of CI, fail-fast
+ *     npm run gate -- --quick # skip the gas snapshot (the expensive duplicate test run)
+ *     npm run gate -- --all   # run every step even after one fails (full damage report)
+ *     npm run gate -- --only fmt,backend
+ *     npm run gate -- --list
+ *
+ * WHY THIS EXISTS. A CI round trip costs 6-7 minutes, and GitHub Actions minutes ran out on
+ * 2026-08-29 (~72h outage), which made "push and see" impossible. But the gate is not a stopgap:
+ * even with CI healthy, finding a `forge fmt` violation locally in 3 seconds beats finding it
+ * remotely in 7 minutes.
+ *
+ * THE CONTRACT: this file must mirror ci.yml, not a summary of it. A gate that checks a SUBSET of
+ * CI is worse than no gate, because it green-lights a PR that CI then fails -- the exact round trip
+ * it was built to remove. When you edit ci.yml, edit this file in the same commit.
+ *
+ * Deliberate divergences from CI, all of them noted at runtime by `--list`:
+ *   - `npm ci` is NOT run. It would delete and reinstall node_modules on every gate run (minutes,
+ *     every time) to catch a class of failure that only appears when package-lock.json changes.
+ *     Run `npm ci` by hand when you touch the lockfile; that is the one case where a green gate
+ *     can still meet a red CI.
+ *   - Slither is advisory here exactly as it is in CI (`continue-on-error: true`), and is SKIPPED
+ *     with a notice when it is not installed. A gate that turns red because an optional Python
+ *     tool is missing teaches people to ignore red, which costs more than the check is worth.
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONTRACTS = path.join(REPO, 'contracts');
+const WIN = process.platform === 'win32';
+
+// The six entrypoints CI syntax-checks. They have no unit tests -- they are exercised by hand
+// against a live chain -- so parsing them is the only thing standing between a typo and a
+// 6-hour smoke run or a production boot that dies on load.
+const ENTRYPOINTS = [
+  'scripts/smoke-test.mjs',
+  'scripts/verify-chainlink-oracle.mjs',
+  'apps/api/src/serve.mjs',
+  'packages/indexer/src/index-runner.mjs',
+  'packages/canary/src/canary-runner.mjs',
+  'packages/oplog/src/ops-check.mjs',
+];
+
+/**
+ * @typedef {object} Step
+ * @property {string} id            short name for --only
+ * @property {string} title         what shows in the log
+ * @property {string} cmd
+ * @property {string[]} args
+ * @property {string} [cwd]
+ * @property {number} [expectExit]  a step whose CONTRACT is a non-zero exit code
+ * @property {boolean} [advisory]   failure warns, never fails the gate (mirrors continue-on-error)
+ * @property {boolean} [quickSkip]  dropped by --quick
+ * @property {string} [why]         printed by --list
+ */
+
+/** @type {Step[]} */
+const STEPS = [
+  {
+    id: 'fmt',
+    title: 'forge fmt --check',
+    cmd: 'forge',
+    args: ['fmt', '--check'],
+    cwd: CONTRACTS,
+    why: 'Seconds to run and the single most common CI failure. Always first.',
+  },
+  {
+    id: 'syntax',
+    title: 'node --check (entrypoints)',
+    // `node --check` takes exactly one file, so this step fans out over ENTRYPOINTS in
+    // runSyntaxStep() rather than being a single spawn. cmd/args are unused for it.
+    cmd: process.execPath,
+    args: [],
+    why: 'Untested-by-design operational scripts. A parse error here reaches a live chain.',
+  },
+  {
+    id: 'build',
+    title: 'forge build',
+    cmd: 'forge',
+    args: ['build'],
+    cwd: CONTRACTS,
+    // ORDERING IS LOad-BEARING: abis.test.mjs cross-checks the indexer's embedded event fragments
+    // against compiled artifacts, and SKIPS ITSELF when contracts/out is absent. Build before
+    // `backend` or the ABI drift guard goes quiet and the backend suite reports a false green.
+    why: 'Must precede `backend`: abis.test.mjs silently skips without contracts/out.',
+  },
+  {
+    id: 'opscheck',
+    title: 'ops-check exits 1 on absent heartbeats',
+    cmd: process.execPath,
+    args: [path.join(REPO, 'packages/oplog/src/ops-check.mjs'), '--dir=./no-such-dir'],
+    expectExit: 1,
+    // ops-check is a cron job and a compose healthcheck, so its exit CODE is the whole contract.
+    // It must FAIL (1) on missing heartbeats -- not crash (2), which would look like an outage,
+    // and not pass (0), which would silently disarm the alerting.
+    why: 'Its exit code IS the contract: must be 1, not 0 (disarmed alerting) and not 2 (crash).',
+  },
+  {
+    id: 'backend',
+    title: 'npm run test:backend',
+    cmd: WIN ? 'npm.cmd' : 'npm',
+    args: ['run', 'test:backend'],
+    cwd: REPO,
+    why: 'Backend + frontend logic suite. Needs `build` first (see above).',
+  },
+  {
+    id: 'test',
+    title: 'forge test',
+    cmd: 'forge',
+    args: ['test'],
+    cwd: CONTRACTS,
+    // Unseeded on purpose, matching CI: every run draws a fresh fuzz/invariant corpus so the suite
+    // keeps hunting for new counterexamples instead of replaying one fixture. The consequence is
+    // that a fuzz failure here can be a GENUINE new counterexample rather than a broken gate --
+    // read the output before assuming the gate is at fault.
+    why: 'Fuzz corpus is unseeded (as in CI), so a red run may be a real new counterexample.',
+  },
+  {
+    id: 'snapshot',
+    title: 'forge snapshot --check (gas, no regressions)',
+    cmd: 'forge',
+    args: ['snapshot', '--check', '--nmt', 'testFuzz|c4EndToEnd'],
+    cwd: CONTRACTS,
+    quickSkip: true,
+    // The --nmt filter is not optional and not arbitrary; ci.yml carries the full reasoning.
+    // Short version: fuzz gas is a mean over a non-reproducible corpus, and the two c4EndToEnd
+    // tests probe storage via stdStorage whose trial SSTORE/SLOAD gas differs by a few units
+    // between Windows and Linux. Gating either measures noise.
+    // Regenerate deliberately with: cd contracts && forge snapshot --nmt "testFuzz"
+    why: 'Re-runs the suite, so it roughly doubles gate time -- this is what --quick drops.',
+  },
+  {
+    id: 'sizes',
+    title: 'forge build --sizes (EIP-170)',
+    cmd: 'forge',
+    args: ['build', '--sizes'],
+    cwd: CONTRACTS,
+    // Stays last, as in CI. This gate used to be RED on purpose (issue #10, VaultFactory over the
+    // EIP-170 cap) -- a real undeployability defect kept visible rather than suppressed. Never add
+    // `code_size_limit` to foundry.toml and never drop --sizes to make it green: that turns
+    // undeployability back into a passing check.
+    why: 'Undeployability is a real defect. Never silence it with foundry.toml code_size_limit.',
+  },
+  {
+    id: 'slither',
+    title: 'slither (advisory)',
+    cmd: 'slither',
+    args: ['.', '--filter-paths', '^lib/|^test/|^script/'],
+    cwd: CONTRACTS,
+    advisory: true,
+    // Anchored filter paths, matching ci.yml. The old unanchored "lib|test|script" also matched
+    // src/lib/, silently excluding SafeTransferLib, BoundedCall and Checkpoints -- ~150 LoC of
+    // Medium-risk primitives carrying the H-1 and H-2 fixes -- from every Slither run this project
+    // ever did. Keep the anchors.
+    why: 'Advisory in CI too. Skipped with a notice when slither is not installed.',
+  },
+];
+
+// node --check accepts exactly one file, so the syntax step is a fan-out rather than one spawn.
+const SYNTAX_STEP = 'syntax';
+
+// ---------------------------------------------------------------------------- args
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const QUICK = has('--quick');
+const RUN_ALL = has('--all') || has('--no-fail-fast');
+const ONLY = (() => {
+  const i = argv.findIndex((a) => a === '--only' || a.startsWith('--only='));
+  if (i === -1) return null;
+  const raw = argv[i].includes('=') ? argv[i].split('=')[1] : argv[i + 1];
+  return raw ? new Set(raw.split(',').map((s) => s.trim()).filter(Boolean)) : null;
+})();
+
+if (has('--help') || has('-h') || has('--list')) {
+  console.log('\nLocal pre-merge gate -- mirrors .github/workflows/ci.yml.\n');
+  for (const s of STEPS) {
+    const tags = [s.advisory && 'advisory', s.quickSkip && 'dropped by --quick', s.expectExit !== undefined && `expects exit ${s.expectExit}`]
+      .filter(Boolean)
+      .join(', ');
+    console.log(`  ${s.id.padEnd(10)} ${s.title}${tags ? `  [${tags}]` : ''}`);
+    if (s.why) console.log(`  ${''.padEnd(10)}   ${s.why}`);
+  }
+  console.log('\nDeliberate divergences from CI:');
+  console.log('  - `npm ci` is not run here. Run it by hand when package-lock.json changes;');
+  console.log('    that is the one case where a green gate can still meet a red CI.');
+  console.log('  - Slither is advisory (as in CI) and skipped when not installed.\n');
+  console.log('Flags: --quick  --all/--no-fail-fast  --only a,b  --list\n');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------- runners
+
+const C = process.stdout.isTTY
+  ? { g: '\x1b[32m', r: '\x1b[31m', y: '\x1b[33m', d: '\x1b[2m', b: '\x1b[1m', x: '\x1b[0m' }
+  : { g: '', r: '', y: '', d: '', b: '', x: '' };
+
+const secs = (ms) => `${(ms / 1000).toFixed(1)}s`;
+
+/**
+ * SHELL POLICY -- read before changing any spawn in this file.
+ *
+ * Running through cmd.exe (`shell: true`) corrupts arguments in two ways this gate hit for real:
+ *   1. An absolute path containing a space is split. `process.execPath` is
+ *      "C:\Program Files\nodejs\node.exe", which cmd.exe runs as the command `C:\Program`.
+ *   2. Shell metacharacters inside a quoted argument are still interpreted. The gas gate's
+ *      `--nmt "testFuzz|c4EndToEnd"` became a PIPE into a command named `c4EndToEnd`.
+ * Both failed loudly here, but the dangerous version is silent: a mangled `--nmt` that happens to
+ * still exit 0 would mean the gate is checking something other than what it claims.
+ *
+ * So: resolve bare names to a real path ONCE via `where`/`which`, then spawn with `shell: false`.
+ * The single exception is a Windows `.cmd`/`.bat` wrapper (npm): Node refuses to spawn those
+ * without a shell (CVE-2024-27980), so those go through cmd.exe -- and we assert their arguments
+ * are metacharacter-free rather than trusting quoting.
+ */
+const UNSAFE_IN_CMD = /[&|<>^()"%!]/;
+/** @type {Map<string, string|null>} */
+const binCache = new Map();
+
+/** Resolve a bare command name to an absolute path, or null when it is not installed. */
+function resolveBin(name) {
+  if (path.isAbsolute(name)) return name;
+  if (binCache.has(name)) return binCache.get(name) ?? null;
+  const r = spawnSync(WIN ? 'where' : 'which', [name], { encoding: 'utf8' });
+  const lines = (r.stdout || '').split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+  // `where npm` lists both the extensionless shell script and npm.cmd; only the latter is
+  // runnable here, so prefer a real executable extension over the first line.
+  const pick = lines.find((l) => /\.(exe|cmd|bat)$/i.test(l)) ?? lines[0] ?? null;
+  binCache.set(name, pick);
+  return pick;
+}
+
+/** Spawn a command, streaming output through, and resolve its exit code (127 when not found). */
+function run(cmd, args, cwd) {
+  return new Promise((resolve) => {
+    const bin = resolveBin(cmd);
+    if (!bin) return resolve(127);
+    const needsShell = WIN && /\.(cmd|bat)$/i.test(bin);
+    if (needsShell) {
+      const bad = args.filter((a) => UNSAFE_IN_CMD.test(a));
+      if (bad.length) {
+        // Refuse rather than run a silently different command than the one printed.
+        console.error(
+          `${C.r}refusing to run ${cmd} through cmd.exe with shell-unsafe args:${C.x} ${bad.join(' ')}\n` +
+            `  A .cmd wrapper cannot be spawned without a shell, and cmd.exe would reinterpret these.\n` +
+            `  Invoke the underlying executable directly in scripts/gate.mjs instead.`,
+        );
+        return resolve(1);
+      }
+    }
+    // With shell:true, Node concatenates rather than escaping, so the binary path has to carry its
+    // own quotes -- npm.cmd lives at "C:\Program Files\nodejs\npm.cmd" and cmd.exe would otherwise
+    // split it at the space and try to run `C:\Program`. Args are metacharacter-free by the check
+    // above, so plain concatenation of the rest is safe.
+    const p = spawn(needsShell ? `"${bin}"` : bin, args, { cwd, stdio: 'inherit', shell: needsShell });
+    p.on('error', (e) => resolve(/** @type {any} */ (e).code === 'ENOENT' ? 127 : 1));
+    p.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+/** Is a binary reachable? Used for preflight and for the slither skip. */
+function present(bin) {
+  return resolveBin(bin) !== null;
+}
+
+async function runSyntaxStep() {
+  for (const f of ENTRYPOINTS) {
+    const abs = path.join(REPO, f);
+    if (!existsSync(abs)) {
+      // A renamed or deleted entrypoint means this gate has silently stopped covering it.
+      console.error(`${C.r}missing entrypoint: ${f}${C.x} -- update ENTRYPOINTS in scripts/gate.mjs`);
+      return 1;
+    }
+    const code = await run(process.execPath, ['--check', abs], REPO);
+    if (code !== 0) return code;
+  }
+  return 0;
+}
+
+/**
+ * Persist the run for `npm run cc`. Untracked (see .gitignore) -- it describes THIS machine's last
+ * run, not a property of the branch, so committing it would just create merge conflicts.
+ */
+function writeGateState(results, totalMs) {
+  const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: REPO, encoding: 'utf8' });
+  const dirty = spawnSync('git', ['status', '--porcelain'], { cwd: REPO, encoding: 'utf8' });
+  const state = {
+    at: new Date().toISOString(),
+    commit: (head.stdout || '').trim() || null,
+    // A gate run against a dirty tree does not certify the commit; the board must not imply it did.
+    treeDirty: Boolean((dirty.stdout || '').trim()),
+    totalMs,
+    mode: { quick: QUICK, runAll: RUN_ALL, only: ONLY ? [...ONLY] : null },
+    passed: !results.some((r) => r.state === 'fail'),
+    steps: results.map((r) => ({ id: r.s.id, state: r.state, ms: r.ms })),
+  };
+  try {
+    writeFileSync(path.join(REPO, '.gate-state.json'), JSON.stringify(state, null, 2) + '\n');
+  } catch {
+    // Never let bookkeeping fail the gate -- the verdict on the console is the real product.
+  }
+}
+
+// ---------------------------------------------------------------------------- main
+
+async function main() {
+  const t0 = Date.now();
+
+  // PREFLIGHT. A gate that passes because its tools are missing is worse than no gate at all.
+  if (!present('forge')) {
+    console.error(
+      `\n${C.r}forge is not on PATH.${C.x} Every contract step would be skipped and the gate would ` +
+        `report a meaningless pass.\nInstall Foundry v1.7.1 (the version CI pins) and re-run.\n`,
+    );
+    process.exit(2);
+  }
+  const hasSlither = present('slither');
+
+  let steps = STEPS.filter((s) => (ONLY ? ONLY.has(s.id) : true)).filter((s) => !(QUICK && s.quickSkip));
+  if (ONLY) {
+    const unknown = [...ONLY].filter((id) => !STEPS.some((s) => s.id === id));
+    if (unknown.length) {
+      console.error(`${C.r}unknown step(s): ${unknown.join(', ')}${C.x}  (see --list)`);
+      process.exit(2);
+    }
+  }
+
+  const mode = [QUICK && 'quick', RUN_ALL && 'run-all', ONLY && `only=${[...ONLY].join(',')}`].filter(Boolean).join(' ');
+  console.log(`\n${C.b}pre-merge gate${C.x} ${C.d}(mirrors ci.yml)${C.x}${mode ? ` ${C.d}[${mode}]${C.x}` : ''}`);
+  console.log(`${C.d}${steps.length} steps${QUICK ? ' -- gas snapshot dropped by --quick' : ''}${C.x}\n`);
+
+  const results = [];
+  let failed = false;
+
+  for (const [i, s] of steps.entries()) {
+    const label = `[${i + 1}/${steps.length}] ${s.title}`;
+
+    if (s.id === 'slither' && !hasSlither) {
+      console.log(`${C.y}SKIP${C.x} ${label} ${C.d}-- slither not installed (advisory in CI too)${C.x}\n`);
+      results.push({ s, state: 'skip', ms: 0 });
+      continue;
+    }
+
+    console.log(`${C.b}${label}${C.x}`);
+    const st = Date.now();
+    const code = s.id === SYNTAX_STEP ? await runSyntaxStep() : await run(s.cmd, s.args, s.cwd ?? REPO);
+    const ms = Date.now() - st;
+
+    const expected = s.expectExit ?? 0;
+    let ok = code === expected;
+    let note = '';
+    if (!ok && s.expectExit !== undefined) note = ` (expected exit ${expected}, got ${code})`;
+    if (code === 127) note = ` (command not found: ${s.cmd})`;
+
+    if (ok) {
+      console.log(`${C.g}PASS${C.x} ${s.title} ${C.d}${secs(ms)}${C.x}\n`);
+      results.push({ s, state: 'pass', ms });
+    } else if (s.advisory) {
+      console.log(`${C.y}WARN${C.x} ${s.title}${note} ${C.d}${secs(ms)} -- advisory, does not fail the gate${C.x}\n`);
+      results.push({ s, state: 'warn', ms });
+    } else {
+      console.log(`${C.r}FAIL${C.x} ${s.title}${note} ${C.d}${secs(ms)}${C.x}\n`);
+      results.push({ s, state: 'fail', ms, code });
+      failed = true;
+      if (!RUN_ALL) {
+        results.push(...steps.slice(i + 1).map((rest) => ({ s: rest, state: 'notrun', ms: 0 })));
+        break;
+      }
+    }
+  }
+
+  // Record the run so `npm run cc` can report gate health WITHOUT re-running it -- and, more
+  // importantly, can report the COMMIT the gate last passed on. A green gate from three commits
+  // ago is not evidence about the working tree, and the status board has to be able to say so.
+  writeGateState(results, Date.now() - t0);
+
+  // ------------------------------------------------------------------ summary
+  console.log(`${C.b}${'-'.repeat(64)}${C.x}`);
+  for (const r of results) {
+    const tag =
+      { pass: `${C.g}pass${C.x}`, fail: `${C.r}FAIL${C.x}`, warn: `${C.y}warn${C.x}`, skip: `${C.d}skip${C.x}`, notrun: `${C.d}not run${C.x}` }[
+        r.state
+      ] ?? r.state;
+    console.log(`  ${tag.padEnd(16)} ${r.s.id.padEnd(10)} ${r.ms ? C.d + secs(r.ms) + C.x : ''}`);
+  }
+  const total = secs(Date.now() - t0);
+  console.log(`${C.b}${'-'.repeat(64)}${C.x}`);
+
+  if (failed) {
+    const first = results.find((r) => r.state === 'fail');
+    console.log(`\n${C.r}${C.b}GATE FAILED${C.x} on ${C.b}${first?.s.id}${C.x} ${C.d}(${total})${C.x}`);
+    console.log(`${C.d}Re-run just that step: npm run gate -- --only ${first?.s.id}${C.x}`);
+    if (first?.s.id === 'test' || first?.s.id === 'snapshot') {
+      // Do not let a genuine finding get filed as "the gate is flaky".
+      console.log(
+        `${C.d}Note: the fuzz corpus is unseeded, so this may be a REAL new counterexample rather than\n` +
+          `      a broken gate. Read the failing case before dismissing it.${C.x}`,
+      );
+    }
+    console.log('');
+    process.exit(1);
+  }
+
+  const warned = results.filter((r) => r.state === 'warn').length;
+  console.log(`\n${C.g}${C.b}GATE PASSED${C.x} ${C.d}(${total})${C.x}${warned ? ` ${C.y}${warned} advisory warning(s)${C.x}` : ''}`);
+  if (QUICK) console.log(`${C.y}--quick: the gas snapshot did NOT run. Run the full gate before merging.${C.x}`);
+  console.log(`${C.d}Reminder: package-lock.json changes are not covered -- run \`npm ci\` by hand if you touched it.${C.x}\n`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Command center: one screen answering "where does this project stand right now?"
+ *
+ *     npm run cc              # the board
+ *     npm run cc -- --md      # same content as markdown (paste into Obsidian / a PR / a handoff)
+ *     npm run cc -- --no-gh   # skip the GitHub lookups (offline, or when gh is slow)
+ *
+ * DESIGN RULE: this file reports FACTS IT COMPUTES and POINTS AT the prose it cannot.
+ * It reads git, the last gate run, the deployment address book, and the go/no-go table -- all of
+ * which have an unambiguous machine-readable answer. It deliberately does NOT try to summarize the
+ * narrative documents, because a status board that paraphrases prose drifts from it silently, and
+ * a board you cannot trust is worse than no board. For the reasoning behind any row, it gives you
+ * the path to the document that argues it.
+ *
+ * Corollary: everything here is derived. There is no status stored in this script, so it cannot go
+ * stale on its own -- if a row is wrong, the source it reads is wrong, which is the bug you want.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const argv = process.argv.slice(2);
+const MD = argv.includes('--md');
+const NO_GH = argv.includes('--no-gh');
+
+const TTY = process.stdout.isTTY && !MD;
+const C = TTY
+  ? { g: '\x1b[32m', r: '\x1b[31m', y: '\x1b[33m', c: '\x1b[36m', d: '\x1b[2m', b: '\x1b[1m', x: '\x1b[0m' }
+  : { g: '', r: '', y: '', c: '', d: '', b: '', x: '' };
+
+const out = [];
+const say = (s = '') => out.push(s);
+
+/** Run a command for its stdout; empty string on any failure. Never throws, never blocks forever. */
+function sh(cmd, args, opts = {}) {
+  // shell:false deliberately. Everything this file shells out to (git, gh) is a real .exe that
+  // Node resolves from PATH on its own, and running through cmd.exe would both reinterpret
+  // arguments and emit Node's shell-args deprecation warning into the board's output.
+  const r = spawnSync(cmd, args, { cwd: REPO, encoding: 'utf8', timeout: 10_000, ...opts });
+  return r.status === 0 ? (r.stdout || '').trim() : '';
+}
+
+const ago = (ms) => {
+  const s = Math.round(ms / 1000);
+  if (s < 90) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 90) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  return h < 48 ? `${h}h ago` : `${Math.round(h / 24)}d ago`;
+};
+
+// ---------------------------------------------------------------- tree
+
+const branch = sh('git', ['rev-parse', '--abbrev-ref', 'HEAD']) || '?';
+const head = sh('git', ['rev-parse', '--short', 'HEAD']) || '?';
+const headFull = sh('git', ['rev-parse', 'HEAD']);
+const subject = sh('git', ['log', '-1', '--format=%s']);
+// Named, never counted-and-forgotten: this is a SHARED worktree, so an unexpected path here is
+// probably another session's work and must never be swept into a commit (`git add -A` is banned).
+const dirty = sh('git', ['status', '--porcelain'])
+  .split('\n')
+  .filter(Boolean)
+  .map((l) => l.slice(3));
+
+// ---------------------------------------------------------------- gate
+
+/** @type {any} */
+let gate = null;
+const gatePath = path.join(REPO, '.gate-state.json');
+if (existsSync(gatePath)) {
+  try {
+    gate = JSON.parse(readFileSync(gatePath, 'utf8'));
+  } catch {
+    gate = null;
+  }
+}
+
+// ---------------------------------------------------------------- launch gates
+
+/**
+ * Parse the go/no-go table in docs/LAUNCH-READINESS.md: `| N | name | status | notes |`.
+ * Only the first three columns are read -- the notes column is prose and belongs in the document.
+ */
+function launchGates() {
+  const p = path.join(REPO, 'docs/LAUNCH-READINESS.md');
+  if (!existsSync(p)) return { verdict: null, rows: [] };
+  const text = readFileSync(p, 'utf8');
+  const verdict = /\*\*VERDICT:\s*([A-Z-]+)/.exec(text)?.[1] ?? null;
+  const rows = [];
+  for (const line of text.split('\n')) {
+    const m = /^\|\s*(\d+)\s*\|([^|]+)\|([^|]+)\|/.exec(line);
+    if (!m) continue;
+    const clean = (s) => s.replace(/\*\*/g, '').replace(/`/g, '').replace(/\[([^\]]+)\]\([^)]*\)/g, '$1').trim();
+    rows.push({ n: Number(m[1]), name: clean(m[2]), status: clean(m[3]) });
+  }
+  // The document contains SEVERAL numbered tables -- the go/no-go gates (0..8) and the
+  // residual-risk register (1..11) among them. Take only the first contiguous run starting at 0
+  // and STOP at the first break, rather than accepting any row whose number happens to match the
+  // next index: that let residual rows 9/10/11 masquerade as launch gates 9/10/11.
+  const gateRows = [];
+  for (const r of rows) {
+    if (r.n === gateRows.length) gateRows.push(r);
+    else if (gateRows.length) break;
+  }
+  return { verdict, rows: gateRows };
+}
+
+const launch = launchGates();
+
+const gateColor = (s) => {
+  const u = s.toUpperCase();
+  if (u.startsWith('GO')) return C.g;
+  if (u.includes('STALE') || u.includes('CONDITIONAL')) return C.y;
+  if (u.includes('NO-GO')) return C.r;
+  return C.d;
+};
+
+// ---------------------------------------------------------------- deployments
+
+function deployments() {
+  const dir = path.join(REPO, 'contracts/config/deployments');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => {
+      try {
+        const j = JSON.parse(readFileSync(path.join(dir, f), 'utf8'));
+        const flat = {};
+        // The address book has nested shapes across generations; walk it rather than assuming one.
+        const walk = (o, prefix = '') => {
+          for (const [k, v] of Object.entries(o ?? {})) {
+            if (typeof v === 'string' && /^0x[0-9a-fA-F]{40}$/.test(v)) flat[prefix + k] = v;
+            else if (v && typeof v === 'object' && !Array.isArray(v)) walk(v, '');
+          }
+        };
+        walk(j);
+        return { network: f.replace(/\.json$/, ''), addresses: flat };
+      } catch {
+        return { network: f.replace(/\.json$/, ''), addresses: {} };
+      }
+    });
+}
+
+// ---------------------------------------------------------------- github
+
+let gh = null;
+if (!NO_GH) {
+  const prs = sh('gh', ['pr', 'list', '--state', 'open', '--json', 'number,title', '--limit', '20']);
+  const issues = sh('gh', ['issue', 'list', '--state', 'open', '--json', 'number,title', '--limit', '20']);
+  if (prs || issues) {
+    try {
+      gh = { prs: JSON.parse(prs || '[]'), issues: JSON.parse(issues || '[]') };
+    } catch {
+      gh = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------- render
+
+const short = (a) => `${a.slice(0, 6)}…${a.slice(-4)}`;
+const pad = (s, n) => (s.length >= n ? s : s + ' '.repeat(n - s.length));
+
+if (MD) say(`# Command center — ${new Date().toISOString().slice(0, 16).replace('T', ' ')}Z\n`);
+else say(`\n${C.b}${C.c}AGENT-GOVERNED VAULTS${C.x} ${C.d}command center · ${new Date().toISOString().slice(0, 16).replace('T', ' ')}Z${C.x}\n`);
+
+// --- tree
+if (MD) {
+  say(`## Tree\n`);
+  say(`\`${branch}\` @ \`${head}\` — ${subject}`);
+  say(dirty.length ? `\nDirty (${dirty.length}): ${dirty.map((f) => `\`${f}\``).join(', ')}` : `\nClean.`);
+  say('');
+} else {
+  say(`${C.b}TREE${C.x}      ${branch} @ ${head}  ${C.d}${subject.slice(0, 60)}${C.x}`);
+  if (dirty.length) {
+    say(`          ${C.y}${dirty.length} uncommitted${C.x}: ${dirty.slice(0, 6).join(', ')}${dirty.length > 6 ? ` +${dirty.length - 6}` : ''}`);
+    say(`          ${C.d}shared worktree — commit named paths only, never \`git add -A\`${C.x}`);
+  } else {
+    say(`          ${C.g}clean${C.x}`);
+  }
+}
+
+// --- gate
+if (!gate) {
+  const line = 'never run on this machine — `npm run gate`';
+  MD ? say(`## Gate\n\n${line}\n`) : say(`\n${C.b}GATE${C.x}      ${C.y}${line}${C.x}`);
+} else {
+  const sameCommit = gate.commit && headFull && gate.commit === headFull;
+  const verdictTxt = gate.passed ? 'PASSED' : 'FAILED';
+  const when = ago(Date.now() - Date.parse(gate.at));
+  const secs = `${(gate.totalMs / 1000).toFixed(1)}s`;
+  // The two ways a green gate lies: it ran on a different commit, or it ran on a dirty tree.
+  // Both are stated, because "gate passed" without them is the failure mode this board exists for.
+  const caveats = [
+    !sameCommit && 'ran on a DIFFERENT commit',
+    gate.treeDirty && 'ran against a dirty tree',
+    gate.mode?.quick && 'was --quick (no gas snapshot)',
+    gate.mode?.only && `was --only ${gate.mode.only.join(',')}`,
+  ].filter(Boolean);
+  const steps = (gate.steps ?? []).map((s) => `${s.id}:${s.state}`).join(' ');
+  if (MD) {
+    say(`## Gate\n`);
+    say(`**${verdictTxt}** in ${secs}, ${when}.`);
+    if (caveats.length) say(`\n> Does not certify this tree: ${caveats.join('; ')}.`);
+    say(`\n\`${steps}\`\n`);
+  } else {
+    say(`\n${C.b}GATE${C.x}      ${gate.passed ? C.g : C.r}${verdictTxt}${C.x} ${C.d}${secs} · ${when}${C.x}`);
+    if (caveats.length) say(`          ${C.y}does NOT certify this tree: ${caveats.join('; ')}${C.x}`);
+    else say(`          ${C.g}certifies this exact commit, clean tree${C.x}`);
+    say(`          ${C.d}${steps}${C.x}`);
+  }
+}
+
+// --- launch
+if (launch.rows.length) {
+  if (MD) {
+    say(`## Launch gates — verdict ${launch.verdict ?? '?'}\n`);
+    say('| # | Gate | Status |');
+    say('|---|------|--------|');
+    for (const r of launch.rows) say(`| ${r.n} | ${r.name} | ${r.status} |`);
+    say('');
+  } else {
+    say(`\n${C.b}LAUNCH${C.x}    ${launch.verdict === 'GO' ? C.g : C.r}${launch.verdict ?? '?'}${C.x} ${C.d}docs/LAUNCH-READINESS.md${C.x}`);
+    for (const r of launch.rows) {
+      say(`          ${C.d}${r.n}${C.x} ${pad(r.name.slice(0, 44), 45)} ${gateColor(r.status)}${r.status.slice(0, 42)}${C.x}`);
+    }
+  }
+}
+
+// --- deployments
+const deps = deployments();
+if (deps.length) {
+  if (MD) {
+    say(`## Deployed\n`);
+    for (const d of deps) {
+      say(`**${d.network}** — ` + Object.entries(d.addresses).map(([k, v]) => `${k} \`${v}\``).join(', '));
+    }
+    say('');
+  } else {
+    say(`\n${C.b}DEPLOYED${C.x}`);
+    for (const d of deps) {
+      say(`          ${C.c}${d.network}${C.x}`);
+      const es = Object.entries(d.addresses);
+      for (const [k, v] of es.slice(0, 8)) say(`            ${pad(k.slice(0, 22), 23)} ${C.d}${short(v)}${C.x}`);
+      if (es.length > 8) say(`            ${C.d}+${es.length - 8} more in contracts/config/deployments/${d.network}.json${C.x}`);
+    }
+  }
+}
+
+// --- github
+if (gh) {
+  const p = gh.prs.length ? gh.prs.map((x) => `#${x.number}`).join(' ') : 'none';
+  const i = gh.issues.length ? gh.issues.map((x) => `#${x.number}`).join(' ') : 'none';
+  if (MD) say(`## GitHub\n\n- Open PRs: ${p}\n- Open issues: ${i}\n`);
+  else {
+    say(`\n${C.b}GITHUB${C.x}    ${gh.prs.length} open PR(s): ${C.d}${p}${C.x}`);
+    say(`          ${gh.issues.length} open issue(s): ${C.d}${i}${C.x}`);
+  }
+} else if (!NO_GH) {
+  if (!MD) say(`\n${C.b}GITHUB${C.x}    ${C.d}unavailable (gh not installed / not authenticated / offline)${C.x}`);
+}
+
+// --- the map
+const NOW = path.join(REPO, 'docs/NOW.md');
+if (existsSync(NOW)) {
+  // NOW.md is the cold-start file: short, current, and the first thing to read. Echo its
+  // "Right now" section verbatim rather than summarizing it -- see the design rule at the top.
+  const text = readFileSync(NOW, 'utf8');
+  const sec = /##\s*Right now\s*\n([\s\S]*?)(?=\n##\s|\n*$)/i.exec(text)?.[1]?.trim();
+  if (sec) {
+    if (MD) say(`## Right now\n\n${sec}\n`);
+    else {
+      say(`\n${C.b}RIGHT NOW${C.x} ${C.d}docs/NOW.md${C.x}`);
+      for (const l of sec.split('\n').slice(0, 14)) say(`          ${l.replace(/\*\*/g, '').replace(/`/g, '')}`);
+    }
+  }
+}
+
+if (!MD) {
+  say(`\n${C.d}          full map: docs/NOW.md · docs/LAUNCH-READINESS.md · Obsidian › Agent-Governed Vaults${C.x}`);
+  say('');
+}
+
+console.log(out.join('\n'));


### PR DESCRIPTION
## Why

GitHub Actions minutes are exhausted until ~2026-09-01, so there is currently no way to "push and see". This adds the local equivalent — and it stays useful after CI returns, because a `forge fmt` violation found in 3 seconds locally beats the same violation found in a 6–7 minute round trip.

## `npm run gate` — mirrors `ci.yml` step for step

fmt → entrypoint syntax → build → ops-check exit code → backend → forge test → gas snapshot → EIP-170 sizes → advisory Slither. **~31s warm.**

The mirror is deliberately complete rather than a convenient subset. A gate that checks *less* than CI green-lights a PR that CI then fails — the exact round trip it exists to remove. So it also carries the two checks an informal "five commands" list omits:

- the **ops-check exit-code contract** — its exit code *is* the contract: `1`, not `0` (which silently disarms alerting) and not `2` (a crash);
- **`node --check`** over the six operational entrypoints, which have no unit tests by design and are exercised by hand against a live chain.

**Ordering is load-bearing** and commented as such: `forge build` must precede the backend suite, because `abis.test.mjs` skips itself when `contracts/out` is absent — running it first would turn the ABI drift guard into a false green.

Two deliberate divergences from CI, surfaced by `--list` and at runtime: `npm ci` is not run (it would reinstall `node_modules` every run to catch a failure class that only appears when the lockfile changes), and Slither is skipped with a notice when absent rather than failing — a gate that goes red because an optional Python tool is missing teaches people to ignore red.

## Three real Windows spawn bugs, fixed at the root

Building this surfaced three, all now covered by a documented shell policy:

- `shell:true` splits an absolute path at spaces, so `process.execPath` (`C:\Program Files\nodejs\node.exe`) ran as the command `C:\Program`.
- `cmd.exe` reinterprets metacharacters inside quoted arguments: the gas gate's `--nmt "testFuzz|c4EndToEnd"` became a **pipe** into a command named `c4EndToEnd`.
- `npm.cmd` cannot be spawned without a shell (CVE-2024-27980) and its path also contains a space, so it needs its own quoting.

The first two failed loudly. The dangerous version is silent: a mangled `--nmt` that still exits 0 means the gate is checking something other than what it claims. Bare names are now resolved once via `where`/`which` and spawned without a shell; the one `.cmd` case asserts its arguments are metacharacter-free rather than trusting quoting.

## `npm run cc` — status board

Derived entirely from sources that already exist: git, the last gate run, `contracts/config/deployments`, and the go/no-go table. It reports facts it can compute and points at the prose it cannot, so it cannot go stale on its own.

Critically, it states **the two ways a green gate lies** — the run was on a different commit, or against a dirty tree — because "gate passed" without those is the failure mode a status board exists to prevent.

## `docs/NOW.md` — cold-start file

What is in flight, what is blocked on a human, and the traps not visible in the code (the permanent ≥5% operator stake requirement, the shared worktree, the non-rebindable operator payout).

## `.claude/workflows/` — saved multi-agent patterns

The two patterns that have each been run and worked, invoked by name instead of re-authored from memory — re-authoring is where the structural choices that made them work get dropped. `docs/WORKFLOWS.md` records why each is shaped the way it is.

## Verification

Gate passes all 9 steps locally: forge **326/326**, backend **552 pass / 2 skip**, fmt / snapshot / sizes green, Slither advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)