### PR TITLE
docs: record the restore drill in NOW.md, and report that protocol/main is RED

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -26,6 +26,14 @@ work it describes.
 - **CI is unavailable** — GitHub Actions minutes exhausted 2026-08-29, back around 2026-09-01.
   `npm run gate` is the substitute and mirrors `ci.yml` step for step. Do not trust a red CI in this
   window without reproducing it locally: PR #71's "backend fail" was minutes exhaustion, not code.
+- **⚠ `protocol/main` is RED at the tip — `npm run gate` fails on `build`, and has since the oracle
+  retirement landed.** `contracts/test/retired/` has three unresolvable imports: `PythSource.sol`
+  and `UniswapV3TwapSource.sol` both import `../OracleAggregator.sol` (now `./`, since
+  `OracleAggregator.sol` moved into that same directory), and `OracleAggregator.sol` imports
+  `./interfaces/IOracleAggregator.sol` (the interface stayed in `src/interfaces/`). `build`, `test`,
+  `snapshot` and `sizes` therefore all fail; `fmt`, `syntax`, `opscheck` and `backend` still pass.
+  **No agent can meet the definition of done until this is fixed**, and CI could not catch it
+  because minutes are exhausted. Found 2026-08-30 by the gate-7 drill, which changed no code.
 - **Batch related changes into one PR.** A CI round trip is 6–7 minutes, so three PRs for three
   related fixes costs 20 minutes of waiting for nothing.
 
@@ -36,7 +44,10 @@ These need a funded key or a decision, and no amount of agent work advances them
 1. **Resume the smoke lifecycle** (needs the `deployer` keystore password) — unblocks launch gate 2.
 2. **Soak + canary re-run** on the pivoted tree — unblocks gates 3 and 6. Wired and ready:
    `scripts/soak/run-soak.ps1`.
-3. **Recorded restore drill** — gate 7. ~30 minutes, read-only, no keys needed.
+3. ~~**Recorded restore drill** — gate 7.~~ **DONE 2026-08-30** — `docs/RESTORE-DRILL.md`. The
+   restore genuinely works on both state files. Gate 7 stays CONDITIONAL for one reason: steps 1
+   and 6 of the runbook are `docker compose stop/start` and **there is no Docker on this machine**,
+   so they were substituted. **Closing the row now needs Docker, not a key.**
 4. **Launch parameter: `proposalThresholdBps = 500`.** Keep it or lower it — immutable per vault
    once shipped. See the trap below.
 

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -367,3 +367,51 @@ node --env-file=data-drill/drill.env packages/indexer/src/index-runner.mjs   # w
 `data-drill/` is deliberately **not committed** — it is a scratch state directory, and the
 artifacts are machine- and block-specific. Every command and every line of output it produced is
 quoted verbatim above.
+
+## 8. Gate status for this PR — and a blocker found on `protocol/main`
+
+This PR changes **two documentation files and no code**. `npm run gate` nonetheless **fails**, for a
+reason that predates it:
+
+```
+  pass             fmt        0.1s
+  pass             syntax     0.3s
+  FAIL             build      1.1s
+  pass             opscheck   0.1s
+  pass             backend    2.5s
+  FAIL             test       1.1s
+  FAIL             snapshot   1.1s
+  FAIL             sizes      1.1s
+  warn             slither    1.9s
+GATE FAILED on build (9.5s)
+```
+
+**Every step that does not depend on `forge build` passes.** The four failures are the same failure:
+
+```
+Error (6275): Source "test/OracleAggregator.sol" not found
+ --> test/retired/PythSource.sol:4:1
+```
+
+`contracts/test/retired/` carries three unresolvable imports after the oracle retirement moved these
+files: `PythSource.sol` and `UniswapV3TwapSource.sol` import `../OracleAggregator.sol` when
+`OracleAggregator.sol` is now their *sibling*, and `OracleAggregator.sol` imports
+`./interfaces/IOracleAggregator.sol` when that interface stayed in `src/interfaces/`.
+
+**This is not caused by this PR**, and the proof is mechanical — the branch's contracts tree is
+byte-identical to `protocol/main`:
+
+```bash
+$ git diff --stat protocol/main..HEAD -- contracts/     # empty
+$ git diff --name-only protocol/main..HEAD
+docs/LAUNCH-READINESS.md
+docs/NOW.md
+docs/RESTORE-DRILL.md
+```
+
+Left unfixed **deliberately**, per SWARM.md §4 ("if you spot something worth fixing that is outside
+your task, report it — do not fix it") and §9 (one PR per coherent change). Correcting three import
+paths inside a documentation PR is exactly the merge-surface expansion those rules exist to prevent.
+It is reported here, recorded in `docs/NOW.md`, and queued as its own task. **No agent can meet the
+definition of done until it lands**, and CI could not have caught it — Actions minutes are exhausted
+until ~2026-09-01.


### PR DESCRIPTION
Follow-up to #77, which merged from a stale base and so landed without this last commit. Docs only, no code.

## 1. `docs/NOW.md` — the drill is done

NOW.md's "Blocked on a human" item 3 still reads *"Recorded restore drill — gate 7. ~30 minutes, read-only, no keys needed."* That drill happened (#77, `docs/RESTORE-DRILL.md`) and **the restore genuinely works**. NOW.md asks to be updated in the same commit as the work it describes.

The substantive change for whoever picks gate 7 up next: **closing the row now needs Docker, not a key.** Steps 1 and 6 of the runbook are `docker compose stop/start`, there is no Docker on this machine, and they were substituted — 4 of 6 steps followed literally is not a green gate.

## 2. ⚠ `protocol/main` is RED at the tip

`npm run gate` fails on `build`, taking `test`, `snapshot` and `sizes` with it. `fmt`, `syntax`, `opscheck` and `backend` pass.

```
Error (6275): Source "test/OracleAggregator.sol" not found
 --> test/retired/PythSource.sol:4:1
```

`contracts/test/retired/` carries **three unresolvable imports** after the oracle retirement moved those files:

| File | Imports | Problem |
|---|---|---|
| `test/retired/PythSource.sol:4` | `../OracleAggregator.sol` | `OracleAggregator.sol` is now its **sibling** |
| `test/retired/UniswapV3TwapSource.sol:4` | `../OracleAggregator.sol` | same |
| `test/retired/OracleAggregator.sol:4` | `./interfaces/IOracleAggregator.sol` | interface stayed in `src/interfaces/` |

**No agent can meet SWARM.md §7's definition of done until this lands**, and CI could not have caught it — Actions minutes are exhausted until ~2026-09-01, so this merged red.

**Deliberately not fixed here**, per SWARM.md §4 (*report it — do not fix it*) and §9 (one PR per coherent change). It also deserves a prior question rather than a reflex path-fix: SWARM.md §5 says delete dead code rather than maintain it, and §6 forbids deleting audit evidence — so whoever owns it should decide between fixing the three paths, deleting `test/retired/` outright, or excluding it from compilation. Queued as its own task.

Recorded in `docs/NOW.md` under "Right now" and in `docs/RESTORE-DRILL.md` §8, both with the mechanical proof that the drill did not cause it:

```bash
$ git diff --stat protocol/main..HEAD -- contracts/     # empty
```

## Gate

Unchanged from main — same three-import failure, before and after. This branch touches two doc files:

```
  pass fmt · pass syntax · FAIL build · pass opscheck · pass backend
  FAIL test · FAIL snapshot · FAIL sizes · warn slither
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
