### PR TITLE
docs: correct the stale RED claim in NOW.md, and add a cross-department protocol

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -26,14 +26,14 @@ work it describes.
 - **CI is unavailable** — GitHub Actions minutes exhausted 2026-08-29, back around 2026-09-01.
   `npm run gate` is the substitute and mirrors `ci.yml` step for step. Do not trust a red CI in this
   window without reproducing it locally: PR #71's "backend fail" was minutes exhaustion, not code.
-- **⚠ `protocol/main` is RED at the tip — `npm run gate` fails on `build`, and has since the oracle
-  retirement landed.** `contracts/test/retired/` has three unresolvable imports: `PythSource.sol`
-  and `UniswapV3TwapSource.sol` both import `../OracleAggregator.sol` (now `./`, since
-  `OracleAggregator.sol` moved into that same directory), and `OracleAggregator.sol` imports
-  `./interfaces/IOracleAggregator.sol` (the interface stayed in `src/interfaces/`). `build`, `test`,
-  `snapshot` and `sizes` therefore all fail; `fmt`, `syntax`, `opscheck` and `backend` still pass.
-  **No agent can meet the definition of done until this is fixed**, and CI could not catch it
-  because minutes are exhausted. Found 2026-08-30 by the gate-7 drill, which changed no code.
+- **`protocol/main` was RED for about an hour on 2026-08-30 and is now GREEN again** (repaired at
+  `4fc6ffbc`, `npm run gate` passes all 9 steps). Recorded because the CAUSE is a live hazard, not
+  because the breakage stands: the oracle retirement moved five files out of `contracts/src/`, and
+  another sprint branched from the SHARED worktree after the move but before the import paths were
+  rewritten — so main received the moves without the fixes and stopped compiling. Nobody's change
+  was wrong on its own; an intermediate state was captured mid-flight. The lesson is the one in
+  `docs/SWARM.md` section 8: agents that write must work in their OWN worktree, or a half-finished
+  edit becomes somebody else's base commit.
 - **Batch related changes into one PR.** A CI round trip is 6–7 minutes, so three PRs for three
   related fixes costs 20 minutes of waiting for nothing.
 

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -81,6 +81,50 @@ to economize — it exists precisely to catch what the implementer got wrong.
 
 ---
 
+## 0.7 Departments collaborate — check before you produce
+
+Departments are not silos. Two failures come from treating them as such: **double work** (two
+departments independently write the same analysis) and **information leakage** (one department
+ships a claim another department already knows is false).
+
+The second is the dangerous one. Marketing writing "zero capital cost to the operator" is not a
+copy error — Finance has the number, Development knows the contract enforces it, and Legal knows
+that claim is exactly the kind that attracts a regulator. A claim is only as good as the department
+best placed to check it.
+
+### Before you produce, read what already exists
+
+The Obsidian vault's `Business/` tree is the shared surface, and `npm run cc` lists every
+department's notes with how recently each changed. Read the neighbouring departments' output before
+writing yours. If another department has already answered your question, cite it — do not
+re-derive it, and do not quietly contradict it. If you believe they are wrong, say so explicitly
+and name the note, so the disagreement is visible rather than buried in two conflicting documents.
+
+### Who checks what
+
+Route an artifact through the departments that can actually falsify it:
+
+| Artifact | Must be checked by | For what |
+|---|---|---|
+| Anything public-facing | **Legal** | securities / CIS recharacterization, and every claim needing counsel sign-off |
+| Anything claiming a capability | **Development** | does the feature exist, on which network, and is it in the launch scope |
+| Anything with a number in it | **Finance** | is the number derived from the code, or asserted |
+| Anything promising a response | **Operations** | can a one-to-two person rotation actually honour it |
+| Anything naming a counterparty | **BD** | is the relationship real, and is the claim about them defensible |
+| Anything a user will read in-product | **Design** | is it legible under stress, and accessible |
+
+This is the same idea as the review pattern in section 3, applied across departments instead of
+within one: the producer does not get to be the only judge.
+
+### Say what you need, do not invent it
+
+When your work needs something another department owns — a number, a legal position, a statement
+about what the code does — **ask for it in your report rather than assuming it.** An assumed number
+that turns out wrong propagates into every document that cites it. Explicitly listing what you took
+from where makes the dependency visible and cheap to correct.
+
+---
+
 ## 1. The unit of work
 
 **One agent owns one module.** Not one feature spanning six files — one file, or one tightly-bounded


### PR DESCRIPTION
## `NOW.md` said `protocol/main` is RED

It was, for about an hour on 2026-08-30. It is green again — repaired at `4fc6ffbc`, with `npm run gate` passing all 9 steps.

That claim landed in the **cold-start file**, which is the worst possible place for a stale alarm: `NOW.md` is the first thing a fresh session reads, and `SWARM.md`'s own rule is that *a stale note is worse than a missing one, because it will be believed*.

The entry is **kept rather than deleted**, because the cause is a live hazard even though the breakage is not:

> The oracle retirement moved five files out of `contracts/src/`, and another sprint branched from the **shared worktree** after the move but before the import paths were rewritten — so main received the moves without the fixes and stopped compiling.

Neither change was wrong on its own; an intermediate state was captured mid-flight. That is precisely what section 8's own-worktree rule exists to prevent, so the entry now points at the lesson instead of raising a false alarm.

## `SWARM.md` section 0.7 — departments collaborate

Departments are not silos, and treating them as such produces two failures: **double work** (two departments independently writing the same analysis) and **information leakage** (one department shipping a claim another already knows is false).

The second is the dangerous one, and it is not hypothetical here. Marketing writing *"zero capital cost to the operator"* is not a copy error — Finance has the real number, Development knows the contract enforces the ≥5% stake, and Legal knows that claim is exactly the kind that attracts a regulator. **A claim is only as good as the department best placed to falsify it.**

The section fixes three things:

1. **Read before you produce.** The vault's `Business/` tree is the shared surface and `npm run cc` lists every department's notes with recency. Cite rather than re-derive; if you think another department is wrong, say so explicitly and name the note, so the disagreement is visible rather than buried in two conflicting documents.

2. **Route each artifact to whoever can falsify it.**

   | Artifact | Checked by | For what |
   |---|---|---|
   | Anything public-facing | Legal | recharacterization risk; claims needing counsel sign-off |
   | Anything claiming a capability | Development | does the feature exist, on which network, in launch scope |
   | Anything with a number | Finance | derived from code, or asserted |
   | Anything promising a response | Operations | can a 1–2 person rotation honour it |
   | Anything naming a counterparty | BD | is the relationship real and the claim defensible |
   | Anything a user reads in-product | Design | legible under stress, accessible |

3. **Ask, do not invent.** When your work needs something another department owns, request it in your report rather than assuming it. An assumed number that turns out wrong propagates into everything that cites it.

This is the review pattern from section 3 applied *across* departments rather than within one: the producer does not get to be the only judge.

## Verification

`npm run gate` passes. (Documentation-only change; the full battery was run on this tree at `4fc6ffbc`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)