### PR TITLE
docs(SWARM): correct the stale gas-snapshot regeneration command

### DIFF
--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -204,7 +204,7 @@ across ~60,000 tests. That is the standard here.
 A task is done when **all** of these hold:
 
 1. `npm run gate` passes from the repo root. It mirrors CI step for step (~31s warm).
-2. If gas legitimately changed: regenerated via `cd contracts && forge snapshot --nmt "testFuzz"`,
+2. If gas legitimately changed: regenerated via `cd contracts && forge snapshot --nmt "testFuzz|testFork"`,
    and **said so explicitly** in the report.
 3. If `src/` changed: EIP-170 margin measured before and after, and reported as numbers.
 4. Work is committed on your own branch, in your own worktree.


### PR DESCRIPTION
`SWARM.md`'s definition of done told agents to regenerate with `forge snapshot --nmt "testFuzz"`. Both `.github/workflows/ci.yml` and `scripts/gate.mjs` say `--nmt "testFuzz|testFork"`. The contract predates the fork tests and was not updated when they landed.

**This has already cost something.** An agent followed `SWARM.md`, reported it as "exactly as SWARM specifies", and wrote eleven `ChainlinkOracleSequencerForkTest:testFork_*` rows into `.gas-snapshot` at `gas: 0`. Those are artifacts of an RPC-less run, not measurements.

Nothing catches them: the gate's `--check` filter excludes `testFork`, so a false record sits pinned in the very file that guards gas regressions. The next maintainer who regenerates with the documented command emits an eleven-line deletion diff unrelated to their change — which SWARM §7 then obliges them to explain.

Worse in the other direction: a maintainer with `BASE_MAINNET_RPC_URL` set who copies the old command writes **live-Base-mainnet-dependent** gas numbers into the snapshot, and those move on every run.

Found by an adversarial reviewer in the Slither triage workflow, which noticed the two documented commands disagreed and correctly identified this file as the wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)