### PR TITLE
docs+tooling: write down how to source-verify a live deployment (ChainlinkOracle finding downgraded to a doc gap)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -276,3 +276,107 @@ Do **not** deploy to mainnet before: (a) an external audit consuming
 [AUDIT-HANDOFF.md](AUDIT-HANDOFF.md), (b) audit findings remediated + re-reviewed, (c) a
 staged-value guardrail period on testnet, (d) `capacityCapUsdc` set conservatively for the
 initial vaults.
+
+## 9. Source-verifying a LIVE deployment (read this before running `forge verify-contract`)
+
+**`HEAD` is not guaranteed to reproduce a historical deployment's bytecode — only the exact
+commit it was built from is.** `contracts/foundry.toml` sets no `bytecode_hash`, so solc's
+default `ipfs` metadata mode applies: every compiled contract's runtime bytecode ends with a CBOR
+trailer whose IPFS hash is a digest of the compiler's `sources` map, keyed by **source path**.
+Moving, renaming, or re-pathing *any* file in a contract's compiled dependency graph — including
+one it only imports indirectly, and including a file that has nothing to do with the contract's
+own logic — changes that trailer, even though not one opcode changed. Deployed bytecode is fixed
+forever; `HEAD` keeps moving. The two drift apart the first time a relevant path changes.
+
+**This already happened once, silently.** The 2026-08-29 retired-oracle prune
+(`chore/prune-retired-oracle-stack`) moved five files out of `contracts/src/` into
+`contracts/test/retired/` and rewrote `ChainlinkOracle.sol`'s import of one of them.
+`ChainlinkOracle.sol` itself did not move and its logic did not change, but its compiled metadata
+trailer did — found only because a reviewer went looking after the fact. Measured on 2026-09-01,
+against the live Base Sepolia deployment
+(`0x6371E14C0682882e75E8382caf0216545B1f43C6`, recorded in
+[`contracts/config/deployments/base-sepolia.json`](../contracts/config/deployments/base-sepolia.json)):
+
+- Building `ChainlinkOracle` at `protocol/main` and masking its two immutable slots (`usdc`,
+  `sequencerUptimeFeed` — the only non-deterministic bytes a fresh build can never match, since
+  they are baked in at construction, not compile time) still leaves a **32-byte divergence in the
+  trailing CBOR metadata** (the IPFS hash) against the deployed runtime code. Everything else —
+  every opcode, all 1,532 bytes of runtime length — is identical.
+- Building at the commit the deployment record pins as **`sourceCommit`** (`5934ef22` —
+  [`config/deployments/base-sepolia.json`](../contracts/config/deployments/base-sepolia.json))
+  reproduces the deployed runtime bytecode **byte-for-byte, including the trailer**. Zero bytes
+  differ, not even under masking.
+
+So the finding is a **documentation gap, not a code defect**: nothing on-chain is wrong, the
+deployed contract behaves exactly as its source says, and it can still be source-verified — the
+missing piece was ever writing down that verification must build at the pinned commit, not at
+whatever `main` happens to be when you get around to it.
+
+### The procedure
+
+1. **Read `sourceCommit` from the deployment record** for the chain you're verifying against
+   (`contracts/config/deployments/<chain>.json`). If the field is missing, stop — there is
+   nothing to pin to, and verifying against `HEAD` is a coin flip that happens to work until the
+   next file move.
+2. **Check out that commit into its own worktree**, so you never disturb whatever branch you're
+   actually working on (this is a shared worktree — see `docs/SWARM.md` §8):
+   ```bash
+   git worktree add ../verify-<chain>-<sourceCommit> <sourceCommit>
+   cd ../verify-<chain>-<sourceCommit>/contracts
+   forge build --skip test --skip script
+   ```
+3. **Recover the constructor arguments** the same way the deploy script did — from that SAME
+   commit's config file, not today's. For `ChainlinkOracle` on Base Sepolia,
+   `script/DeployTestnet.s.sol` builds them from `config/base-sepolia.json`'s `chainlinkOracle`
+   block (`assets[].asset` / `.feed` / `.heartbeatSeconds` / `.minPriceWad` / `.maxPriceWad`,
+   `usdcPin`, `sequencerUptimeFeed`), in that array order — read that script's `_deployOracle`
+   helper at the pinned commit if the shape has since changed. (As of
+   this writing the `chainlinkOracle` block's *values* are unchanged since `5934ef22` — only
+   explanatory notes were added — so today's committed config still reconstructs the right
+   arguments; that was checked, not assumed, and may not stay true forever.) Alternatively, skip
+   manual reconstruction and pass `--guess-constructor-args` (see `forge verify-contract --help`)
+   to have `forge` extract them from the on-chain creation transaction directly.
+4. **Verify from the pinned-commit worktree**, not your working tree, so the compiler sees that
+   commit's file layout:
+   ```bash
+   forge verify-contract --chain 84532 <address> \
+     src/oracle/ChainlinkOracle.sol:ChainlinkOracle \
+     --constructor-args <abi-encoded-args-or---guess-constructor-args> \
+     --etherscan-api-key "$ETHERSCAN_API_KEY" --watch
+   ```
+5. **Remove the scratch worktree** when done (`git worktree remove ../verify-<chain>-<sourceCommit>`).
+
+### What to expect from each verifier
+
+This repo has not run a real verification submission against either explorer as part of this
+finding (no API key was available; only the pinned-commit rebuild above was measured). What
+follows is documented, standard verifier behavior, not a repo-specific measurement — treat it as
+guidance, and expect the pinned-commit build to be the reliable path either way:
+
+- **A pinned-commit build should verify cleanly everywhere**, since the bytecode — trailer
+  included — matches exactly what step 2 above proved.
+- **Basescan/Etherscan-family explorers** generally require the submitted source to compile to
+  bytecode that matches the deployed contract; a metadata-only mismatch (built at `HEAD` instead
+  of the pinned commit) is the most common reason a "the source is definitely right" submission
+  still comes back unverified. If a `HEAD`-built submission is ever rejected only on the trailer,
+  that is this exact issue — rebuild at `sourceCommit` and resubmit.
+- **Sourcify** distinguishes a "full match" (bytecode identical including metadata) from a
+  "partial match" (identical except metadata) and accepts both as verified, labeling which one you
+  got — by protocol design, precisely to handle non-reproducible metadata hashes like this one. A
+  `HEAD`-built submission there may succeed as a partial match even without pinning; a
+  pinned-commit build should come back a full match. This was not tested against a live endpoint
+  for this finding — confirm before relying on it.
+
+### Keeping this reproducible: `node scripts/verify-deployment-reproducibility.mjs` (standalone, not wired into `npm run gate`)
+
+This checks, offline and without touching an RPC,
+that every `contracts/config/deployments/*.json`'s `sourceCommit` still resolves in local git
+history **and** is still reachable from `origin/protocol/main` — the one part of this procedure
+that can rot silently (a rebase or a pruned branch can make a previously-valid `sourceCommit`
+unreachable long after the deployment it describes is still live). It does **not** and cannot
+detect metadata drift itself — drift is expected any time `contracts/` changes under `ipfs` mode
+and is not, on its own, a defect. It is deliberately **not** one of `scripts/gate.mjs`'s 9 CI-mirroring
+steps (that file's own header states it must mirror `.github/workflows/ci.yml`, not add to it —
+wiring this in would mean editing both, and the check has nothing to do with whether the current
+diff is mergeable). Run it by hand before cutting a new deployment record, or whenever
+`contracts/src/` moves files around and a live deployment references the old layout.

--- a/docs/TESTNET-CHECKLIST.md
+++ b/docs/TESTNET-CHECKLIST.md
@@ -147,6 +147,16 @@ Then check on [sepolia.basescan.org](https://sepolia.basescan.org): each address
 “Contract Source Code Verified” badge, and `VaultFactory → Read` resolves `registry`,
 `governance`, `feeEngine`, `subVaultRegistry`.
 
+> **Re-verifying later, from a checkout that has since moved on, is a different procedure.** The
+> commands above work because they run from the same tree the deploy just broadcast from. Coming
+> back later — a new session, `main` has since moved — and running `forge verify-contract` against
+> `HEAD` is **not** guaranteed to reproduce the deployed bytecode: solc's default `ipfs` metadata
+> mode keys the trailing CBOR hash by source path, so any file move anywhere in the compiled
+> dependency graph changes it, even with zero logic changes. See
+> [DEPLOYMENT.md §9](DEPLOYMENT.md#9-source-verifying-a-live-deployment-read-this-before-running-forge-verify-contract)
+> for the pinned-commit procedure and the measurement that found this against the live
+> `ChainlinkOracle` deployment above.
+
 ## 6. Troubleshooting
 
 - **RPC 503 / “no backend healthy”** — the default `sepolia.base.org` endpoint is flaky; use

--- a/scripts/lib/deployment-reproducibility.mjs
+++ b/scripts/lib/deployment-reproducibility.mjs
@@ -1,0 +1,86 @@
+// @ts-check
+/**
+ * Pure logic behind `scripts/verify-deployment-reproducibility.mjs`, split out so it is testable
+ * without a real git repository. See that script's header for the full "why" — in short: solc's
+ * default `ipfs` metadata mode keys the CBOR trailer by source path, so HEAD is not guaranteed to
+ * reproduce a historical deployment's bytecode after files move; only the exact `sourceCommit`
+ * pinned in the deployment record is. This module checks that the pinned commit still resolves
+ * and is still reachable from the shared mainline — the one thing that silently rots.
+ *
+ * @typedef {object} DeploymentRecord
+ * @property {string} [chainName]
+ * @property {string} [sourceCommit]
+ *
+ * @typedef {object} CheckResult
+ * @property {string} chainName
+ * @property {string} sourceCommit   '(none)' when unset
+ * @property {boolean} resolves
+ * @property {boolean|null} isAncestor   null = not checked (no mainline ref, or does not resolve)
+ * @property {boolean} hardFail
+ */
+
+/**
+ * @param {DeploymentRecord} cfg
+ * @param {{
+ *   gitResolves: (commit: string) => boolean,
+ *   gitIsAncestor: (commit: string) => boolean,
+ *   haveMainline: boolean,
+ *   fallbackChainName: string,
+ * }} deps
+ * @returns {CheckResult}
+ */
+export function checkDeploymentRecord(cfg, deps) {
+  const chainName = cfg.chainName ?? deps.fallbackChainName;
+  const sourceCommit = cfg.sourceCommit;
+
+  if (!sourceCommit) {
+    // Nothing pinned yet -- a content problem with the record, not a reproducibility-of-what's-
+    // pinned problem, so this is skipped rather than failed.
+    return {chainName, sourceCommit: '(none)', resolves: false, isAncestor: null, hardFail: false};
+  }
+
+  const resolves = deps.gitResolves(sourceCommit);
+  if (!resolves) {
+    return {chainName, sourceCommit, resolves: false, isAncestor: null, hardFail: true};
+  }
+
+  if (!deps.haveMainline) {
+    return {chainName, sourceCommit, resolves: true, isAncestor: null, hardFail: false};
+  }
+
+  const isAncestor = deps.gitIsAncestor(sourceCommit);
+  return {chainName, sourceCommit, resolves: true, isAncestor, hardFail: !isAncestor};
+}
+
+/**
+ * @param {CheckResult[]} results
+ * @returns {boolean} true if any record hard-failed
+ */
+export function anyHardFail(results) {
+  return results.some((r) => r.hardFail);
+}
+
+/**
+ * @param {CheckResult} r
+ * @returns {string}
+ */
+export function formatResultLine(r) {
+  if (r.sourceCommit === '(none)') {
+    return `  SKIP  ${r.chainName}: no sourceCommit recorded`;
+  }
+  if (!r.resolves) {
+    return (
+      `  FAIL  ${r.chainName}: sourceCommit ${r.sourceCommit} does not resolve in local git ` +
+      `history -- this deployment can no longer be reproduced or source-verified from this checkout.`
+    );
+  }
+  if (r.isAncestor === false) {
+    return (
+      `  FAIL  ${r.chainName}: sourceCommit ${r.sourceCommit} resolves locally but is NOT an ` +
+      `ancestor of the mainline -- it depends on a ref that can be pruned or force-pushed away. ` +
+      `Re-record a commit that is on the shared mainline.`
+    );
+  }
+  const ancestorNote = r.isAncestor === true ? ', ancestor of the mainline' : '';
+  return `  OK    ${r.chainName}: sourceCommit ${r.sourceCommit} resolves${ancestorNote}`;
+}

--- a/scripts/test/deployment-reproducibility.test.mjs
+++ b/scripts/test/deployment-reproducibility.test.mjs
@@ -1,0 +1,131 @@
+// @ts-check
+/**
+ * Pure-logic tests for scripts/lib/deployment-reproducibility.mjs -- the "why" is in that
+ * module's header. No real git repo is touched; `gitResolves`/`gitIsAncestor` are stubbed so the
+ * suite exercises every branch of the verdict, not whatever this checkout's history happens to
+ * contain right now.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  checkDeploymentRecord,
+  anyHardFail,
+  formatResultLine,
+} from '../lib/deployment-reproducibility.mjs';
+
+test('no sourceCommit recorded -> SKIP, not a hard failure', () => {
+  const r = checkDeploymentRecord(
+    {chainName: 'base-mainnet'},
+    {
+      gitResolves: () => {
+        throw new Error('must not be called');
+      },
+      gitIsAncestor: () => {
+        throw new Error('must not be called');
+      },
+      haveMainline: true,
+      fallbackChainName: 'base-mainnet',
+    }
+  );
+  assert.equal(r.sourceCommit, '(none)');
+  assert.equal(r.resolves, false);
+  assert.equal(r.isAncestor, null);
+  assert.equal(r.hardFail, false);
+  assert.match(formatResultLine(r), /^  SKIP/);
+});
+
+test('sourceCommit does not resolve locally -> hard FAIL, ancestry never checked', () => {
+  let ancestorCalled = false;
+  const r = checkDeploymentRecord(
+    {chainName: 'base-sepolia', sourceCommit: 'deadbeef'},
+    {
+      gitResolves: () => false,
+      gitIsAncestor: () => {
+        ancestorCalled = true;
+        return true;
+      },
+      haveMainline: true,
+      fallbackChainName: 'base-sepolia',
+    }
+  );
+  assert.equal(r.resolves, false);
+  assert.equal(r.isAncestor, null);
+  assert.equal(r.hardFail, true);
+  assert.equal(ancestorCalled, false, 'a commit that does not resolve must not be checked for ancestry');
+  assert.match(formatResultLine(r), /^  FAIL.*does not resolve/);
+});
+
+test('sourceCommit resolves but is not an ancestor of the mainline -> hard FAIL', () => {
+  const r = checkDeploymentRecord(
+    {chainName: 'base-sepolia', sourceCommit: '5934ef22'},
+    {
+      gitResolves: () => true,
+      gitIsAncestor: () => false,
+      haveMainline: true,
+      fallbackChainName: 'base-sepolia',
+    }
+  );
+  assert.equal(r.resolves, true);
+  assert.equal(r.isAncestor, false);
+  assert.equal(r.hardFail, true);
+  assert.match(formatResultLine(r), /^ {2}FAIL.*NOT an ancestor/);
+});
+
+test('sourceCommit resolves and is an ancestor of the mainline -> OK, no failure', () => {
+  const r = checkDeploymentRecord(
+    {chainName: 'base-sepolia', sourceCommit: '5934ef22'},
+    {
+      gitResolves: () => true,
+      gitIsAncestor: () => true,
+      haveMainline: true,
+      fallbackChainName: 'base-sepolia',
+    }
+  );
+  assert.equal(r.resolves, true);
+  assert.equal(r.isAncestor, true);
+  assert.equal(r.hardFail, false);
+  assert.match(formatResultLine(r), /^  OK .*ancestor of the mainline/);
+});
+
+test('no mainline ref available -> ancestry not checked, resolution alone is enforced', () => {
+  let ancestorCalled = false;
+  const r = checkDeploymentRecord(
+    {chainName: 'base-sepolia', sourceCommit: '5934ef22'},
+    {
+      gitResolves: () => true,
+      gitIsAncestor: () => {
+        ancestorCalled = true;
+        return true;
+      },
+      haveMainline: false,
+      fallbackChainName: 'base-sepolia',
+    }
+  );
+  assert.equal(r.resolves, true);
+  assert.equal(r.isAncestor, null);
+  assert.equal(r.hardFail, false, 'missing mainline ref must be advisory, not a failure');
+  assert.equal(ancestorCalled, false);
+  assert.match(formatResultLine(r), /^  OK /);
+  assert.doesNotMatch(formatResultLine(r), /ancestor of the mainline/);
+});
+
+test('chainName falls back to the filename stem when the record omits it', () => {
+  const r = checkDeploymentRecord(
+    {sourceCommit: '5934ef22'},
+    {
+      gitResolves: () => true,
+      gitIsAncestor: () => true,
+      haveMainline: true,
+      fallbackChainName: 'base-sepolia',
+    }
+  );
+  assert.equal(r.chainName, 'base-sepolia');
+});
+
+test('anyHardFail is true if any record hard-failed, false otherwise', () => {
+  const ok = {chainName: 'a', sourceCommit: 'x', resolves: true, isAncestor: true, hardFail: false};
+  const bad = {chainName: 'b', sourceCommit: 'y', resolves: false, isAncestor: null, hardFail: true};
+  assert.equal(anyHardFail([ok]), false);
+  assert.equal(anyHardFail([ok, bad]), true);
+  assert.equal(anyHardFail([]), false);
+});

--- a/scripts/verify-deployment-reproducibility.mjs
+++ b/scripts/verify-deployment-reproducibility.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Verify that every recorded on-chain deployment can still be SOURCE-VERIFIED: the
+ * `sourceCommit` pinned in each `contracts/config/deployments/*.json` must still resolve in
+ * this repo's git history, and must be reachable from the shared mainline
+ * (`origin/protocol/main`) rather than only from a local or ephemeral ref that a `git gc`,
+ * a rebase, or a force-push could make unreachable.
+ *
+ * WHY THIS EXISTS. `contracts/foundry.toml` sets no `bytecode_hash`, so solc's default `ipfs`
+ * metadata mode applies, and the CBOR metadata trailer embeds an IPFS hash of the compiled
+ * `sources` map, which is keyed by SOURCE PATH. Moving or renaming any file in a contract's
+ * compiled dependency graph changes that trailer without changing a single opcode. Measured
+ * 2026-09-01: on `protocol/main`, `ChainlinkOracle`'s compiled runtime bytecode diverges from
+ * the deployed Base Sepolia bytecode (`0x6371E14C0682882e75E8382caf0216545B1f43C6`) in exactly
+ * the 32-byte CBOR metadata hash — every other byte, including all four immutable-address
+ * slots once masked, is identical. Building at the commit recorded as `sourceCommit` in the
+ * deployment record (`5934ef22`) reproduces the deployed bytecode byte-for-byte, trailer
+ * included. So HEAD reproducing a historical deployment is NOT guaranteed and must not be
+ * assumed — only the exact pinned commit is guaranteed to. See docs/DEPLOYMENT.md's "Source
+ * verification" section for the full reproduction procedure this script exists to protect.
+ *
+ * WHAT THIS SCRIPT DOES NOT DO. It does not rebuild anything and it does not touch an RPC. It
+ * cannot and does not detect metadata drift itself — that is EXPECTED any time `contracts/`
+ * changes under `ipfs` mode, and is not a defect. All it checks is whether the documented
+ * reproduction recipe ("check out `sourceCommit`, build, verify") still has a commit to check
+ * out. That is cheap, offline, and the one thing that actually rots silently: a `sourceCommit`
+ * can be lost to a rebase or a pruned branch long after the deployment it describes is still
+ * live and needs re-verifying.
+ *
+ * Exit 0 = every deployment record's `sourceCommit` resolves locally AND is an ancestor of
+ *          `origin/protocol/main` (or ancestry could not be checked because no such ref is
+ *          configured here — reported as an advisory NOTE, never a failure, since a shallow
+ *          clone or a sandboxed CI checkout may not carry it).
+ * Exit 1 = a `sourceCommit` does not resolve in local git history at all (unrecoverable), or it
+ *          resolves but is NOT an ancestor of `origin/protocol/main` (recoverable only by
+ *          re-recording a commit that IS on the shared mainline).
+ *
+ * Env: DEPLOYMENT_MAINLINE_REF (default origin/protocol/main)
+ * Run: node scripts/verify-deployment-reproducibility.mjs [--json]
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkDeploymentRecord, anyHardFail, formatResultLine } from './lib/deployment-reproducibility.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEPLOYMENTS_DIR = path.join(ROOT, 'contracts', 'config', 'deployments');
+const MAINLINE_REF = process.env.DEPLOYMENT_MAINLINE_REF ?? 'origin/protocol/main';
+const JSON_OUT = process.argv.includes('--json');
+
+/** @param {string[]} args */
+function gitOk(args) {
+  try {
+    execFileSync('git', args, {cwd: ROOT, stdio: 'ignore'});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findDeploymentFiles() {
+  if (!fs.existsSync(DEPLOYMENTS_DIR)) return [];
+  return fs
+    .readdirSync(DEPLOYMENTS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => path.join(DEPLOYMENTS_DIR, f))
+    .sort();
+}
+
+const files = findDeploymentFiles();
+const haveMainline = gitOk(['rev-parse', '--verify', '--quiet', `${MAINLINE_REF}^{commit}`]);
+
+const results = files.map((file) => {
+  const cfg = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return checkDeploymentRecord(cfg, {
+    gitResolves: (commit) => gitOk(['cat-file', '-e', `${commit}^{commit}`]),
+    gitIsAncestor: (commit) => gitOk(['merge-base', '--is-ancestor', commit, MAINLINE_REF]),
+    haveMainline,
+    fallbackChainName: path.basename(file, '.json'),
+  });
+});
+
+const hardFail = anyHardFail(results);
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({mainlineRef: MAINLINE_REF, haveMainline, results}, null, 2));
+} else {
+  console.log(`verify-deployment-reproducibility: checking ${files.length} deployment record(s)`);
+  if (!haveMainline) {
+    console.log(
+      `  NOTE: ${MAINLINE_REF} is not resolvable here (no remote configured / not fetched). ` +
+        `Ancestry cannot be checked -- resolution-in-local-history is still enforced.`
+    );
+  }
+  for (const r of results) console.log(formatResultLine(r));
+}
+
+process.exit(hardFail ? 1 : 0);


### PR DESCRIPTION
## Summary

Dev15-SourceVerify: the oracle-prune reviewers reported that the live Base Sepolia `ChainlinkOracle` can no longer be source-verified from `protocol/main`, because `foundry.toml`'s default `ipfs` `bytecode_hash` keys the CBOR metadata trailer by source path, and the prune moved five files -- changing the trailer even though `ChainlinkOracle`'s own logic never changed.

**Measured, not assumed:**
- Building `ChainlinkOracle` at `protocol/main` and masking its two immutable slots (`usdc`, `sequencerUptimeFeed`) against the deployed bytecode at `0x6371E14C0682882e75E8382caf0216545B1f43C6` (Base Sepolia, read via `eth_getCode`, no key) diverges in **exactly the 32-byte IPFS hash** in the trailer -- every other byte of the 1,532-byte runtime, including all four immutable-slot ranges once masked, is identical.
- Building at the commit the deployment record already pins as `sourceCommit` (`5934ef22`) reproduces the deployed bytecode **byte-for-byte, trailer included** -- zero bytes differ.

**Conclusion: this is a documentation gap, not a code defect.** Nothing on-chain is wrong, and the deployment was always reproducible -- the recipe to do it just was not written down anywhere. Also confirmed: `5934ef22` is an ancestor of `origin/protocol/main` (won't be orphaned by a rebase today), and `contracts/foundry.toml` is unchanged since that commit.

## What changed

- **`docs/DEPLOYMENT.md` §9 (new)**: the pinned-commit source-verification procedure (check out `sourceCommit` into a scratch `git worktree`, reconstruct constructor args from that commit's own config, `forge verify-contract` from that tree), the measurement above, and honestly-hedged notes on Basescan vs. Sourcify metadata-match behavior (not empirically tested here -- no API key available).
- **`docs/TESTNET-CHECKLIST.md` §5**: a pointer to §9 for anyone re-verifying later rather than immediately after a deploy broadcast.
- **`scripts/verify-deployment-reproducibility.mjs`** (+ `scripts/lib/deployment-reproducibility.mjs`, +7 tests in `scripts/test/deployment-reproducibility.test.mjs`): a fully offline, no-RPC check that every deployment record's `sourceCommit` still resolves in git history and is still reachable from `origin/protocol/main` -- the one part of this procedure that can rot silently (a rebase or a pruned branch). It does **not** and cannot detect metadata drift itself (expected under `ipfs` mode, not a defect). Deliberately **not** wired into `scripts/gate.mjs`'s 9 CI-mirroring steps -- that file's header states it must mirror `ci.yml`, not add to it, and this check has nothing to do with mergeability.

## The framed decision (not made here, per SWARM §10 -- launch parameter, permanent on mainnet)

`bytecode_hash` in `foundry.toml` was deliberately left untouched. Options, priced:

| Option | Buys | Costs / forecloses |
|---|---|---|
| **Keep `ipfs`, pin verification to `sourceCommit`** (what this PR documents) | Zero contract-behavior change; standard tooling default; metadata hash still useful (IPFS-addressable source, when pinned) | Verification is a two-step procedure forever, not `forge verify-contract` off `HEAD` |
| **`none`** | HEAD always reproduces every past deployment -- no pinning procedure needed, ever | Permanently drops the metadata pointer from every mainnet contract; can't be undone post-deploy (immutable bytecode) |
| **`bzzr1`** | Nothing over `ipfs` -- same path-keyed `sources` map, same failure mode, a deader ecosystem (Swarm) | Same cost as `ipfs`, no benefit |
| **Add a gate step comparing deployed bytecode to a build** | Would catch drift the day it happens, automatically | Needs RPC (network-dependent, against SWARM §10's offline requirement for gate steps) or a manually-recorded expected hash; still doesn't remove the need to pin for verification |

My recommendation: **keep `ipfs` and rely on the pinned-commit procedure this PR writes down.** The measurement here shows pinning works perfectly today, `none` buys convenience at a permanent, irreversible cost on contracts that don't change once deployed anyway (so the "reproduce from HEAD" convenience mostly matters during active pre-launch iteration, exactly when pinning is cheapest to do), and no option removes the need for *some* discipline around verification. **Mainnet has no deployment yet, so this choice is free today and permanent the moment `Deploy.s.sol` broadcasts to Base mainnet** -- it should be made deliberately before then, not defaulted into.

## Test plan

- [x] `npm run gate` -- PASSED, all 9 steps (280.8s), 1 pre-existing advisory Slither warning
- [x] `npm run test:backend` -- 773 tests, 771 pass, 0 fail (2 pre-existing environment skips), including the 7 new tests
- [x] No `contracts/src/` touched -- no EIP-170 or gas-snapshot movement
- [x] Re-fetched `origin/protocol/main` immediately before opening this PR; branch is up to date (`HEAD == origin/protocol/main`)
- [x] No key, no funded account, no `--broadcast` -- every chain read (`eth_getCode` via public RPC) was free and keyless

🤖 Generated with [Claude Code](https://claude.com/claude-code)
