### PR TITLE
canary: watch feed identity - the two construction-time proofs the oracle can never re-run

### DIFF
--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -24,7 +24,7 @@ RPC_URL=… OPERATOR_REGISTRY_ADDRESS=… STATE_PATH=./data/indexer-state.json n
 | `VAULTS` | | — | explicit comma-separated vault list, to run without an indexer |
 | `OPERATOR_REGISTRY_ADDRESS` | | — | enables the fee-routing signal |
 | `EXTRA_OPERATOR_ADDRESSES` | | — | extra operator addresses to treat as prohibited fee destinations |
-| `CANARY_STATE_PATH` | | `./data/canary-state.json` | transition state, so a restart does not re-page |
+| `CANARY_STATE_PATH` | | `./data/canary-state.json` | transition state, so a restart does not re-page. Also holds the aggregator identities `feed-identity` pins on first sight; see §3(g) |
 | `ALERT_WEBHOOK_URL` | | — | POST one JSON body per transition |
 | `CANARY_POLL_INTERVAL_MS` | | `30000` | sweep cadence (named apart from the indexer's `POLL_INTERVAL_MS` — compose feeds both one `.env`, and a sweep is heavier than an indexer poll) |
 | `CONFIRMATIONS` | | `5` | blocks to lag head, matching the indexer |
@@ -165,10 +165,13 @@ source to fail over to: the heartbeat, the band, the feed and the vault's oracle
 them, during a grace tail included. For a sequencer grace tail, `detail.resumesAtSec` is the one
 honest ETA this protocol can ever publish, because it is a contract constant.
 
-**Two things it still does not watch**, both filed as gaps rather than silently absent: the feed's
-*identity* (`aggregator()` / `description()` / `decimals()` swapping behind the proxy — a Chainlink
-deprecation looks like ordinary staleness only *after* the point of no return), and a USDC depeg,
+**One thing it still does not watch**, filed as a gap rather than silently absent: a USDC depeg,
 which by design freezes nothing at all because the pin is never stale.
+
+The feed's *identity* — `decimals()` / `description()` / `aggregator()` moving behind the proxy —
+**is** watched, but by a different signal, because it is a different question. This one asks whether
+the price is FRESH; identity asks whether it is RIGHT, and a mis-scaled feed is not stale, not
+frozen and not out of band. See **(g) `feed-identity`** below.
 
 #### The retired oracle (`OracleAggregator`)
 
@@ -333,6 +336,86 @@ operator outside the claim flow is a value-extraction finding: reconcile against
 `FeesClaimed` on the FeeEngine for the same period, and treat the vault as compromised until the
 transfers are explained.
 
+### (g) `feed-identity` — is it still the same feed, and still scaled the way the oracle assumed?
+
+**What it measures.** Per basket asset, every sweep: the live `decimals()` and `description()` of the
+Chainlink proxy behind that asset, and which aggregator is currently behind it (`aggregator()`,
+`phaseId()`).
+
+**The gap it closes.** `ChainlinkOracle`'s constructor proves three things about every feed it lists
+— that the feed describes itself as USD-quoted (`_requireUsdQuote`), that it reports 8 decimals, and
+that `scale = 10**(18 - decimals)` is therefore correct — and then caches the result in an immutable
+`feedOf` entry and never looks again. Chainlink meanwhile swaps the aggregator behind an
+`EACAggregatorProxy` as routine operation, and the proxy forwards `decimals()` and `description()` to
+whichever aggregator is current. So the contract's construction-time proofs can silently stop being
+true on a contract that cannot re-check them. This signal re-checks them.
+
+**Nothing else in the canary can see this.** A mis-scaled feed is not stale, not frozen and not out
+of band, so signal (a) reads OK — the price is served, it is just wrong. And `nav-backing` recomputes
+NAV through the same `oracle.priceWad(asset)` the vault uses, so a uniform mis-scale cancels exactly
+on both sides of its comparison and that signal stays silent through the whole event.
+
+**Ground truth, and why there is no configuration here.** The comparison that matters for decimals is
+**live-vs-cached, not live-vs-config** — and the cached value is observable on-chain: `feedOf(asset)`
+is a public mapping getter and `scale` *is* `10**(18 - decimals)` as cached at construction. So the
+check is
+
+```
+10n ** (18n - BigInt(feed.decimals())) === feedOf(asset).scale
+```
+
+with **both sides read from the chain**. No pin, no env var, no config file, nothing that can go
+stale, and correct on the very first sweep after a cold start — which matters, because a swap that
+happened while the canary was down must still be caught when it comes back. The denomination leg is
+the same shape: it re-runs the constructor's own `_requireUsdQuote` predicate (ends in `USD` as a
+whole word, separator and all) against the description the proxy reports now.
+
+Only the **identity** leg needs a remembered value, and it is the leg that carries no harm on its
+own. It is pinned on first sight into `CANARY_STATE_PATH`. Rejected alternatives:
+
+| Where the pin could come from | Rejected because |
+|---|---|
+| `contracts/config/*.json`'s `aggregatorPin` | `.dockerignore` excludes `contracts/` from the runtime image, so the canary cannot read it — the same finding that shaped `ORACLE_FEED_CADENCE_SECONDS` |
+| a new env var, told like the cadence map | It must be hand-edited after every routine Chainlink swap or the signal alerts forever. A standing alert that needs a config deploy to silence is the strongest possible muting pressure, and it buys nothing the harm legs do not already cover pin-free |
+| first sight, in the canary's own state | **Chosen.** No config surface, no maintenance. Residual, stated in the signal's own message: a swap during canary downtime is adopted silently and never narrated — `scripts/verify-chainlink-oracle.mjs` compares against the config's git-tracked `aggregatorPin`, which is the half that survives a restart |
+
+**Severity, and why the two findings are not calibrated the same.** A Chainlink aggregator swap is
+routine and legitimate — `phaseId` exists to count them. A `decimals()` change is not routine and is
+the one that silently mis-scales every price. So:
+
+| Finding | Status | Behaviour |
+|---|---|---|
+| decimals no longer match the cached `scale` (including a value > 18, which no `scale` can express) | **ALERT** | **Latches.** The oracle's config is immutable, so there is no operator action that repairs it — the vault stays not-OK until it is evacuated or the oracle replaced |
+| the description no longer ends in `USD` as a whole word | **ALERT** | **Latches**, same reason |
+| the aggregator behind the proxy changed, decimals and denomination still check out | **ALERT** | **Clears itself next sweep**, because the runner re-pins. A notification ("go read Chainlink's announcement"), not a standing incident |
+
+The self-clear is the calibration, not a softening. Latching a benign swap would park a permanent
+not-OK row in the heartbeat summary and in `ops-check` with no action that clears it — which is the
+muting pressure `ORACLE_MIN_MARGIN` and `ORACLE_STALENESS_WARN_PCT` were both calibrated against. And
+alerting at all is safe here for a reason the flat staleness bar could not claim: an aggregator is
+swapped on the order of **once or twice a year**, not dozens of times a day.
+
+Critically the self-clear is **gated on the harm legs**: the swap alert only clears because decimals
+and denomination passed against the *new* aggregator on the same sweep. A swap that also moves
+decimals leaves the harm leg alerting and the vault not-OK. Two adjacent tests in
+`test/feed-identity.test.mjs` pin that conjunction.
+
+**Conviction rules for the identity leg** mirror `scripts/verify-chainlink-oracle.mjs` rather than
+inventing a second argument: `phaseId` increments on every swap so it convicts on its own; a changed
+`aggregator()` convicts only when both sides are readable, because an `aggregator()` read coming back
+empty is network noise, not evidence (observed against a live proxy on 2026-08-30).
+
+**When it fires.** There is no on-chain remedy — `feedOf` is immutable. For a decimals or
+denomination finding, treat every price served since the change as wrong (`detail` carries the
+cached scale, the live decimals and the factor the price is off by) and follow the de-listing /
+evacuation path, not the freeze path: the vault is not frozen, it is *transacting at a wrong price*,
+which is worse. For a swap notice, verify it against Chainlink's announcement — that is the moment a
+deprecation is still recoverable, because on-chain a deprecation looks like ordinary staleness only
+*after* the response window has closed.
+
+**Silent on a retired-oracle deployment**, and deliberately so: `OracleAggregator` has no Chainlink
+proxy anywhere, so feed identity is not a capability that exists to be blind about there.
+
 ---
 
 ## 4. Signals that cannot run
@@ -347,6 +430,7 @@ vault. The cases:
 | `… reverts StaleOracle` (NAV, exit liveness) | the oracle breaker is tripped | signal (a) is paging for the real cause; coverage resumes when the breaker clears |
 | `sequencer gate not configured … sequencerUptimeFeed is address(0)` | the oracle has no uptime feed | correct off a sequencer L2 (Base Sepolia leaves it `address(0)` by design, so expect exactly one line per vault on testnet). **On Base mainnet it means the deployment shipped with no sequencer guard at all** |
 | `no vaults to watch` | empty watch set | set `VAULTS`, or point `STATE_PATH` at a snapshot that has seen a `VaultCreated` |
+| `feed identity cannot be checked … feedOf() lists no feed for it` | the asset is unlisted, or it is the oracle's pinned USDC leg | if unlisted, signal (a) is already paging (`priceWad` reverts permanently); if it is the pin, there is no aggregator behind it and nothing to drift |
 
 An empty watch set is reported loudly rather than read as a clean bill of health.
 
@@ -358,6 +442,16 @@ re-assert on a backoff until fixed:
 | `ORACLE DETECTOR BLIND … answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig()` | the vault's oracle is a flavor this canary does not know | the canary needs a new oracle implementation before this vault is monitored at all — do not treat the vault as healthy |
 | `vault … is unreadable` | wrong address, wrong chain, or the RPC is failing | check `RPC_URL`/`CHAIN_ID` and the address. **Every** signal for that vault is suspended |
 | `… check ERRORED on vault … and measured nothing` | the signal threw (usually an RPC fault) | read the error in `detail`; the vault is unmonitored for that signal until it clears |
+| `FEED IDENTITY DETECTOR BLIND … did not answer description() / decimals()` | the proxy stopped answering the two reads the harm checks compare against | the asset is unmonitored for aggregator-swap drift. A feed that has stopped answering the calls `ChainlinkOracle`'s own constructor made has itself changed shape — check it against Chainlink's feed registry |
+| `FEED IDENTITY DETECTOR BLIND … answered neither aggregator() nor phaseId()` | the feed is not an `EACAggregatorProxy`, or both reads are failing | the harm checks (decimals, denomination) **did** run and passed; it is the swap *notice* that is blind |
+
+**These three damp against RPC noise, and none of the others do.** Every blind branch in
+`feed-identity` is triggered by an `eth_call` coming back empty, and one empty return is noise while
+three consecutive is the feed — so they carry `minConsecutive: 3` and only escalate on the third
+sweep. The exception is the very first sighting of an asset, which reports immediately: a monitor
+that has never once succeeded must not be indistinguishable from silence. `oracle-freshness` needs no
+such damping, because its blind branch is structural (an oracle answering an ABI it does not have),
+not a transient read.
 
 **Event scan gaps.** If the canary is down long enough that the backlog exceeds
 `MAX_LOG_SPAN_BLOCKS`, it scans the most recent window and moves on — the older blocks are never
@@ -381,7 +475,10 @@ signals have the hole. Raise `MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
   not OK.
 - **Restarts do not re-page.** Transition state persists to `CANARY_STATE_PATH` (atomic
   write-temp-then-rename, same discipline as the indexer snapshot). Delete that file to force a fresh
-  report of everything currently wrong.
+  report of everything currently wrong. That file also holds the aggregator identities `feed-identity`
+  pinned on first sight, so deleting it re-pins from whatever is live and a swap that happened while
+  the canary was down is never narrated. The decimals and denomination checks in that signal need no
+  pin and are unaffected. `node packages/canary/src/canary-runner.mjs verify` prints the pin count.
 - **A paging outage is not a monitoring outage.** A webhook that throws, times out, or returns 500 is
   logged and stepped over; the sweep continues.
 - **One broken vault does not blind the others.** A signal that errors becomes a DEGRADED result for
@@ -392,19 +489,24 @@ signals have the hole. Raise `MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
   fresh pages — but if you are standing the canary up after a vault has been live for a while, set
   `LOG_LOOKBACK_BLOCKS` to cover the gap for the first run. The level signals (a–d) read current
   state and are complete from the first sweep regardless.
-- **Sizing.** A sweep is `O(vaults × basket assets)` reads against a `ChainlinkOracle` (roughly three
-  per asset — `feedOf`, `priceWad`, `latestRoundData` — plus four fixed per vault), and
-  `O(vaults × basket assets × oracle sources)` against the retired aggregator. The default 30s
+- **Sizing.** A sweep is `O(vaults × basket assets)` reads against a `ChainlinkOracle` (roughly eight
+  per asset — `feedOf`, `priceWad`, `latestRoundData` for signal (a), then a second `feedOf` plus
+  `description`, `decimals`, `aggregator`, `phaseId` for signal (g), which are issued in one batch —
+  plus four fixed per vault). The two oracle signals deliberately do **not** share their `feedOf`
+  read: each is a pure function of the reader, which is what lets every one of them be tested against
+  a plain mock, and one duplicate `eth_call` per asset is a cheaper price than coupling them. Against
+  the retired aggregator a sweep is
+  `O(vaults × basket assets × oracle sources)`, and signal (g) does not run at all. The default 30s
   cadence is comfortable for a handful of vaults on a normal RPC; raise `CANARY_POLL_INTERVAL_MS`
   before raising your rate limit.
 
 ## 6. Tests
 
-`npm run test:backend` includes `packages/canary/test/*.test.mjs` — 175 tests, every one with a
+`npm run test:backend` includes `packages/canary/test/*.test.mjs` — 226 tests, every one with a
 mocked client. **No live RPC in CI.** Both a healthy and an alerting fixture exist for every signal,
 and for both oracle flavors.
 
-Three guards worth knowing about:
+Four guards worth knowing about:
 
 - `test/abis.test.mjs` recomputes every embedded 4-byte selector with viem and cross-checks the
   watched events, the views, and the gate errors against the **compiled** `VaultCore` ABI. A stale
@@ -415,6 +517,12 @@ Three guards worth knowing about:
   *not* on it (the flavor probe depends on that absence). **This guard is the direct answer to how
   the pivot broke this signal:** the oracle table was previously checked only against itself, so
   nothing in CI could see that the signal was calling functions the deployed contract does not have.
+- The same file cross-checks `feed-identity`'s two **harm** legs (`decimals()`, `description()`)
+  against the compiled `IAggregatorV3` / `IAggregatorV3Description` — the interfaces
+  `ChainlinkOracle`'s own constructor reads them through. `aggregator()` and `phaseId()` belong to
+  Chainlink's `EACAggregatorProxy`, which is not in this tree, so they are **not** pinned that way and
+  the test says so rather than pretending; their runtime failure is covered instead, by a
+  DETECTOR BROKEN result.
 - `test/reader.test.mjs` asserts the chain reader exposes no send/sign/write surface, and
   `test/abis.test.mjs` asserts the ABI table declares no non-`view` function. The read-only claim is
   enforced, not just documented.

--- a/packages/canary/README.md
+++ b/packages/canary/README.md
@@ -36,6 +36,7 @@ its own `CANARY_STATE_PATH`.
 | `src/sinks.mjs` | console + optional webhook; a sink failure never propagates |
 | `src/signals/*.mjs` | one file per signal, each a pure function over an injected reader |
 | `src/signals/oracle-health.mjs` | signal (a) against the LIVE `ChainlinkOracle`, plus the flavor probe that dispatches to it or to the retired `oracle-freshness.mjs` |
+| `src/signals/feed-identity.mjs` | signal (g): the feed's live `decimals()` against the oracle's CACHED `scale`, its `description()` against the constructor's own USD predicate, and the aggregator behind the proxy. The one signal that owns persistent state (`feedIdentity` in the canary state file) |
 
 ## Design notes
 
@@ -51,8 +52,11 @@ reports DEGRADED — never a false OK.
 render as DETECTOR BROKEN and are re-asserted on a doubling backoff instead of being reported once.
 Report-once is right for a problem in the system; for a problem in the monitor it manufactures
 confidence, which is how the pre-pivot oracle signal stayed dead for a whole deployment after one
-startup line. Only three things set the flag: an oracle answering neither known ABI, an unreadable
-vault, and a signal that threw.
+startup line. Things that set the flag: an oracle answering neither known ABI, an unreadable vault, a
+signal that threw, and every branch of `feed-identity` that could not read the feed. That last group
+is the only one that damps — each is an `eth_call` coming back empty, so they carry
+`minConsecutive: 3` (one empty return is RPC noise, three consecutive is the feed), except on a first
+sighting, which reports at once because a monitor that has never succeeded must not look like silence.
 
 **One root cause, one page.** A tripped oracle breaker makes `navWad()` and `requestExit` revert too.
 Those two attribute their `StaleOracle` reverts to the oracle signal and go DEGRADED, so the operator
@@ -64,6 +68,6 @@ gets one alert instead of three.
 node --test packages/canary/test/*.test.mjs
 ```
 
-175 tests, all mocked. `test/helpers.mjs` carries the shared fixtures: `healthyVault()` (retired
+226 tests, all mocked. `test/helpers.mjs` carries the shared fixtures: `healthyVault()` (retired
 multi-source oracle) and `chainlinkVault()` (the live single-feed one) are healthy on every signal,
 so each test perturbs exactly one thing and proves the signal reacts to that and nothing else.

--- a/packages/canary/src/abis.mjs
+++ b/packages/canary/src/abis.mjs
@@ -110,6 +110,31 @@ export const AGGREGATOR_V3_VIEWS = Object.freeze([
   ]),
 ]);
 
+/**
+ * The feed's OWN self-description — the surface `signals/feed-identity.mjs` re-checks every sweep.
+ *
+ * `ChainlinkOracle` reads `description()` and `decimals()` exactly ONCE, in its constructor, and
+ * caches `scale = 10**(18 - decimals)` in an immutable `feedOf` entry. Chainlink swaps the
+ * aggregator behind an `EACAggregatorProxy` as routine operation, and the proxy forwards all four
+ * of these to whichever aggregator is current — so every one of them can move after construction
+ * while the oracle keeps using what it cached. That gap is G2.
+ *
+ * `decimals()` and `description()` are the HARM legs: a change to either silently mis-scales or
+ * re-denominates every price the vault computes. `aggregator()` and `phaseId()` are the IDENTITY
+ * legs, which only say that a swap happened. `phaseId` increments on every swap, so it convicts on
+ * its own; `aggregator` names the new implementation for the alert line.
+ *
+ * Only `decimals()` and `description()` are cross-checkable against a contract in this tree — the
+ * other two belong to Chainlink's `EACAggregatorProxy`, which we do not compile. test/abis.test.mjs
+ * pins what can be pinned and says so about the rest.
+ */
+export const CHAINLINK_FEED_IDENTITY_VIEWS = Object.freeze([
+  view('decimals', [], ['uint8']),
+  view('description', [], ['string']),
+  view('aggregator', [], ['address']),
+  view('phaseId', [], ['uint16']),
+]);
+
 /** IPriceSource — polled per source to count how many are fresh right now. */
 export const PRICE_SOURCE_VIEWS = Object.freeze([
   view('latestPrice', [], [

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -22,7 +22,12 @@
  *   OPERATOR_REGISTRY_ADDRESS  enables the fee-routing signal (skipped without it)
  *   EXTRA_OPERATOR_ADDRESSES   comma-separated extra operator addresses to treat as prohibited
  *   ALERT_WEBHOOK_URL          POST one JSON body per transition
- *   CANARY_STATE_PATH (./data/canary-state.json)  transition state, so a restart does not re-page
+ *   CANARY_STATE_PATH (./data/canary-state.json)  transition state, so a restart does not re-page.
+ *                              It also holds the aggregator identities `feed-identity` pinned on
+ *                              first sight. Deleting it re-pins from whatever is live, so a swap
+ *                              that happened while the canary was down is not narrated — the
+ *                              decimals and denomination checks in that signal need no pin and
+ *                              cover the harm either way.
  *   CHAIN_ID (8453)  CHAIN_NAME (base)  CONFIRMATIONS (5)
  *   CANARY_POLL_INTERVAL_MS (30000)  sweep cadence. Named apart from the indexer's
  *                              POLL_INTERVAL_MS because docker-compose feeds both services one
@@ -69,6 +74,7 @@ import { createConsoleSink, createWebhookSink, emitAll } from './sinks.mjs';
 import { VAULT_VIEWS } from './abis.mjs';
 import { skipped, detectorBroken, shortAddr } from './signal.mjs';
 import { checkOracleSignals } from './signals/oracle-health.mjs';
+import { checkFeedIdentity, applyIdentityObservations } from './signals/feed-identity.mjs';
 import { checkNavBacking } from './signals/nav-backing.mjs';
 import { checkShareConservation } from './signals/share-conservation.mjs';
 import { checkExitLiveness } from './signals/exit-liveness.mjs';
@@ -164,9 +170,12 @@ export function resolveCanaryConfig(env) {
  * @param {string[]} ctx.vaults
  * @param {ReturnType<typeof resolveCanaryConfig>} ctx.cfg
  * @param {{fromBlock:number, toBlock:number, nowSec:number}} ctx.window
+ * @param {Record<string, any>} [ctx.identityPins] remembered aggregator identities, from the canary
+ *        state file. Read-only in here; the caller folds this sweep's observations back in with
+ *        `applyIdentityObservations` and persists the result.
  * @returns {Promise<import('./signal.mjs').SignalResult[]>}
  */
-export async function collectSignals({ reader, state, vaults, cfg, window }) {
+export async function collectSignals({ reader, state, vaults, cfg, window, identityPins = {} }) {
   const out = [];
   const { fromBlock, toBlock, nowSec } = window;
 
@@ -230,6 +239,13 @@ export async function collectSignals({ reader, state, vaults, cfg, window }) {
       cadenceByAsset: cfg.oracleFeedCadenceSeconds,
     }));
 
+    // The other half of the oracle: not "is the price fresh" but "is it still the same feed, and
+    // is it still scaled the way the immutable config assumed". Silent on a retired-aggregator
+    // deployment, where no Chainlink proxy exists to drift.
+    await run('feed-identity', () => checkFeedIdentity({
+      reader, vault, oracle: meta.oracle, assets: meta.assets, pins: identityPins,
+    }));
+
     await run('nav-backing', () => checkNavBacking({
       reader, vault, atBlock: toBlock, thresholdBps: cfg.navDivergenceBps,
     }));
@@ -285,6 +301,8 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
   const persisted = await loadCanaryState(cfg.canaryStatePath);
   const tracker = createTransitionTracker({ initial: persisted.transitions });
   let lastScannedBlock = persisted.lastScannedBlock ?? null;
+  // Defaulted, not assumed: a state file written before this key existed is a legitimate input.
+  let identityPins = persisted.feedIdentity ?? {};
   let poll = 0;
 
   const stateWriter = createCanaryStateWriter({
@@ -342,11 +360,15 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
     }
 
     const results = await collectSignals({
-      reader, state, vaults, cfg,
+      reader, state, vaults, cfg, identityPins,
       window: { fromBlock: windowFrom, toBlock, nowSec },
     });
 
     const transitions = tracker.observe(results, { poll, timestamp: now().toISOString() });
+    // AFTER the transition is computed, never before: the alert for a swap is the comparison
+    // against the OLD pin, and re-pinning first would compare the new identity against itself and
+    // report nothing. Re-pinning here is also what makes a benign swap self-clear next sweep.
+    identityPins = applyIdentityObservations(identityPins, results);
     await emitAll(sinks, transitions, { onError: errLine });
 
     lastScannedBlock = toBlock;
@@ -356,8 +378,8 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
 
   /** Persist what the tracker knows right now. Called after every sweep, and on shutdown. */
   async function flush() {
-    await stateWriter.save({ transitions: tracker.snapshot(), lastScannedBlock });
-    return { tracked: tracker.size, lastScannedBlock };
+    await stateWriter.save({ transitions: tracker.snapshot(), lastScannedBlock, feedIdentity: identityPins });
+    return { tracked: tracker.size, lastScannedBlock, feedsPinned: Object.keys(identityPins).length };
   }
 
   const ac = new AbortController();

--- a/packages/canary/src/signals/feed-identity.mjs
+++ b/packages/canary/src/signals/feed-identity.mjs
@@ -1,0 +1,377 @@
+// @ts-check
+/**
+ * Signal (g) — FEED IDENTITY. The on-chain half of G2 (OPS-3, aggregator-swap drift).
+ *
+ * WHAT THIS EXISTS FOR. `ChainlinkOracle`'s constructor proves three things about every feed it
+ * lists — that the feed describes itself as USD-quoted (`_requireUsdQuote`), that it reports 8
+ * decimals, and that `10**(18 - decimals)` is therefore the right `scale` — and then caches the
+ * result in an IMMUTABLE `feedOf` entry and never looks again. Chainlink meanwhile swaps the
+ * aggregator behind an `EACAggregatorProxy` as routine operation, and the proxy forwards
+ * `decimals()` / `description()` to whichever aggregator is current. So the contract's three
+ * construction-time proofs can silently stop being true, on a contract that cannot re-check them.
+ *
+ * This signal is the thing that re-checks them, every sweep. It is not a second staleness detector:
+ * `oracle-freshness` owns the freeze, and a mis-scaled feed is not frozen — it prices perfectly,
+ * just wrongly, which is exactly why nothing else in the canary can see it. `nav-backing` recomputes
+ * NAV through the same `oracle.priceWad(asset)`, so a uniform mis-scale cancels on both sides of its
+ * comparison and that signal stays silent through the whole event.
+ *
+ * ── GROUND TRUTH, AND WHY THERE IS ALMOST NO CONFIGURATION HERE ─────────────────────────────────
+ *
+ * The comparison that matters for the decimals leg is LIVE-vs-CACHED, not live-vs-config, and the
+ * cached value IS observable on-chain: `feedOf(asset)` is a public mapping getter and `scale` is
+ * literally `10**(18 - feedDecimals)` as cached at construction. So the check is
+ *
+ *     10n ** (18n - BigInt(feed.decimals())) === feedOf(asset).scale
+ *
+ * with BOTH sides read from the chain. No pin, no env var, no config file, nothing that can go
+ * stale, nothing to maintain, and it is correct on the very first sweep after a cold start — which
+ * matters, because a swap that happens while the canary is down must still be caught when it comes
+ * back. The denomination leg is the same shape: it re-runs the constructor's own `_requireUsdQuote`
+ * predicate against the description the proxy reports now.
+ *
+ * Only the IDENTITY leg — "which aggregator is behind the proxy" — needs a remembered value, and it
+ * is the leg that carries no harm on its own. Its pin is observed on first sight and kept in the
+ * canary's own state file (see `applyIdentityObservations` at the bottom, and canary-runner.mjs).
+ * Rejected alternatives, and their failure modes, are recorded in docs/CANARY.md §3(g).
+ *
+ * ── SEVERITY, AND THE CALIBRATION TRAP THIS PACKAGE HAS BEEN BITTEN BY TWICE ────────────────────
+ *
+ * A Chainlink aggregator swap is ROUTINE AND LEGITIMATE — `phaseId` exists to count them. A
+ * `decimals()` change is not routine and is the one that silently mis-scales every price. Those two
+ * facts must not produce the same behaviour, so they do not:
+ *
+ *   - a HARM finding (decimals/scale, or a description that stopped quoting USD) ALERTS and
+ *     LATCHES. There is no operator action that repairs it — the oracle's config is immutable — so
+ *     the vault stays not-OK until it is evacuated or the oracle is replaced. It must never
+ *     self-clear.
+ *   - a benign IDENTITY change ALERTS EXACTLY ONCE and then clears, because the runner re-pins to
+ *     the observed identity and the next sweep matches. It is a notification ("go read Chainlink's
+ *     announcement"), not a standing incident.
+ *
+ * The self-clear is not a softening, it is the calibration. Latching a benign swap would park a
+ * permanent not-OK row in `tracker.unhealthy()`, in the heartbeat summary and in `ops-check`, with
+ * no action that clears it — which IS the muting pressure `ORACLE_MIN_MARGIN` and
+ * `ORACLE_STALENESS_WARN_PCT` were both calibrated against. The transition line itself is emitted
+ * durably either way; that is how every alert in this package reaches a human.
+ *
+ * And the alert level is safe for the identity leg for a reason the flat staleness bar could not
+ * claim: a Chainlink feed's aggregator is swapped on the order of once or twice a YEAR, not dozens
+ * of times a day. Rarity is what makes "page and let a human check the announcement" the right
+ * calibration here and the wrong one there.
+ *
+ * Critically, the self-clear is GATED on the harm legs: the identity alert only clears because the
+ * decimals and denomination checks passed on the same sweep. A swap that also moves decimals leaves
+ * the harm leg alerting, and the vault stays not-OK. That conjunction is pinned by two adjacent
+ * tests in test/feed-identity.test.mjs.
+ *
+ * ── A CHECK THAT CANNOT RUN IS NEVER SILENT ────────────────────────────────────────────────────
+ *
+ * Every branch below that cannot measure returns `detectorBroken`, which the transition tracker
+ * re-asserts on a doubling backoff. The one departure from `oracle-health.mjs` is
+ * `minConsecutive: UNREADABLE_SWEEPS`: every blind branch here is triggered by an eth_call coming
+ * back empty, and PR #92 recorded observing exactly that against `aggregator()` on 2026-08-30 —
+ * a single empty return is RPC noise, three consecutive is the feed. oracle-health needs no such
+ * damping because its blind branch is structural (an oracle answering an ABI it does not have),
+ * not a transient read.
+ *
+ * Fans out one result per (vault, asset), keyed by asset, like `oracle-freshness`.
+ */
+
+import { CHAINLINK_ORACLE_VIEWS, CHAINLINK_FEED_IDENTITY_VIEWS, ORACLE_VIEWS } from '../abis.mjs';
+import { ok, alert, skipped, detectorBroken, signalId, shortAddr } from '../signal.mjs';
+
+/**
+ * Its OWN signal name, deliberately not `oracle-freshness`. Two reasons: this is a different
+ * detector answering a different question (is the price RIGHT, not is the price FRESH), and the
+ * soak's `series-analysis.mjs` keys the freeze verdict off every transition id starting
+ * `oracle-freshness|`, so folding these rows in there would put identity noise inside the drill's
+ * freeze evidence.
+ */
+export const SIGNAL = 'feed-identity';
+
+/** Consecutive unreadable sweeps before a blind leg is escalated. See the header. */
+export const UNREADABLE_SWEEPS = 3;
+
+const ZERO = '0x0000000000000000000000000000000000000000';
+const isZero = (a) => typeof a !== 'string' || /^0x0{40}$/i.test(a);
+const eqAddr = (a, b) => typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+
+/**
+ * `ChainlinkOracle` caches `scale = 10**(18 - decimals)` in a `uint64`. Anything that cannot be
+ * expressed that way could never have been cached, so it is a mismatch by construction rather than
+ * an arithmetic problem to work around.
+ *
+ * This function exists mostly to stop `10n ** BigInt(18 - d)` from throwing a RangeError on a
+ * negative exponent: a swapped aggregator reporting 18 decimals is PRECISELY the drift this signal
+ * is for, and letting it throw would convert the named ALERT into the runner's generic "signal
+ * ERRORED" detectorBroken — a real freeze reported as a monitoring fault.
+ *
+ * @param {unknown} d
+ * @returns {bigint|null} null when no cacheable scale exists for `d`
+ */
+export function scaleForDecimals(d) {
+  const n = typeof d === 'bigint' ? Number(d) : Number(d);
+  if (!Number.isInteger(n) || n < 0 || n > 18) return null;
+  return 10n ** BigInt(18 - n);
+}
+
+/**
+ * `ChainlinkOracle._requireUsdQuote`, mirrored: the description must end in `USD` as a whole word,
+ * i.e. the last three characters are `USD` and the one before them is a pair separator (`' '` or
+ * `'/'`). The separator is what stops `"ETH / PYUSD"` — an ETH price quoted in a USD-ish TOKEN —
+ * from passing on a bare suffix match.
+ *
+ * Chainlink feed descriptions are ASCII, so comparing JS code units matches the contract's byte
+ * comparison. A description that is not ASCII fails the suffix test anyway.
+ *
+ * @param {unknown} description
+ */
+export function isUsdQuoted(description) {
+  if (typeof description !== 'string' || description.length < 4) return false;
+  if (description.slice(-3) !== 'USD') return false;
+  const sep = description[description.length - 4];
+  return sep === ' ' || sep === '/';
+}
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {string} ctx.oracle
+ * @param {string[]} ctx.assets
+ * @param {Record<string, {feed?:string|null, aggregator?:string|null, phaseId?:string|null}>} [ctx.pins]
+ *        remembered identities, keyed by this signal's transition id. Read-only here: the runner
+ *        owns the write, via `applyIdentityObservations`.
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkFeedIdentity({ reader, vault, oracle, assets, pins = {} }) {
+  if (!Array.isArray(assets) || assets.length === 0) return [];
+
+  // The SAME flavor probe `oracle-health.mjs` uses, in the same order, deliberately: two signals
+  // that disagreed about which oracle is deployed would be worse than either being wrong.
+  const seq = await reader.tryRead(oracle, CHAINLINK_ORACLE_VIEWS, 'sequencerUptimeFeed', []);
+  if (!seq.ok) {
+    const legacy = await reader.tryRead(oracle, ORACLE_VIEWS, 'assetConfig', [assets[0]]);
+    if (legacy.ok) {
+      // A CONFIRMED retired `OracleAggregator`. There is no Chainlink proxy anywhere in that
+      // regime, so feed identity is not a thing that exists to be blind about — its sources are
+      // fixed addresses in an immutable config. Nothing to report is the honest answer, not a
+      // suppressed one.
+      return [];
+    }
+    // Neither ABI. This IS a blind detector, and it is reported here as well as under
+    // `oracle-freshness`: that signal's line says the vault is unmonitored for the staleness
+    // FREEZE, which is a different capability from the one this signal provides.
+    return [detectorBroken({
+      signal: SIGNAL, vault, key: 'flavor',
+      message: `FEED IDENTITY DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig(), so no feed can be located to check. This vault is UNMONITORED for aggregator-swap drift, not clean`,
+      detail: {
+        vault, oracle, minConsecutive: UNREADABLE_SWEEPS,
+        chainlinkProbeError: seq.error ?? null, legacyProbeError: legacy.error ?? null,
+      },
+    })];
+  }
+
+  const out = [];
+  for (const asset of assets) {
+    out.push(await assetIdentity({ reader, vault, oracle, asset, pins }));
+  }
+  return out;
+}
+
+/** @returns {Promise<import('../signal.mjs').SignalResult>} */
+async function assetIdentity({ reader, vault, oracle, asset, pins }) {
+  const base = { signal: SIGNAL, vault, key: asset };
+  const id = signalId(SIGNAL, vault, asset);
+  const pin = pins?.[id] ?? null;
+  const blind = (message, detail) => detectorBroken({
+    ...base, message, detail: { vault, oracle, asset, minConsecutive: UNREADABLE_SWEEPS, ...detail },
+  });
+
+  const cfgRead = await reader.tryRead(oracle, CHAINLINK_ORACLE_VIEWS, 'feedOf', [asset]);
+  if (!cfgRead.ok) {
+    return blind(
+      `FEED IDENTITY DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} reverts (${cfgRead.error}) even though the oracle answered as a ChainlinkOracle, so the cached scale this check compares against cannot be read. This asset is UNMONITORED for aggregator-swap drift, not clean`,
+      { error: cfgRead.error ?? null },
+    );
+  }
+  const cfg = normalizeFeedConfig(cfgRead.value);
+
+  if (isZero(cfg.feed)) {
+    // A KNOWN state, not a blind one: either the asset is unlisted — in which case
+    // `oracle-freshness` is already paging, because priceWad reverts permanently — or it is the
+    // oracle's pinned USDC leg, which has no feed and therefore no identity to drift. Reported
+    // once, never escalated, exactly like the other "another signal owns this" skips.
+    return skipped({
+      ...base,
+      message: `feed identity cannot be checked for ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() lists no feed for it. Either the asset is unlisted — in which case oracle-freshness is paging, since priceWad reverts permanently — or it is the oracle's pinned USDC leg, which has no aggregator behind it`,
+      detail: { vault, oracle, asset, listed: false, attributedTo: 'oracle-freshness' },
+    });
+  }
+
+  // One round trip for the four proxy reads. tryRead never throws, so a partial failure is data.
+  const [desc, dec, agg, phase] = await Promise.all([
+    reader.tryRead(cfg.feed, CHAINLINK_FEED_IDENTITY_VIEWS, 'description', []),
+    reader.tryRead(cfg.feed, CHAINLINK_FEED_IDENTITY_VIEWS, 'decimals', []),
+    reader.tryRead(cfg.feed, CHAINLINK_FEED_IDENTITY_VIEWS, 'aggregator', []),
+    reader.tryRead(cfg.feed, CHAINLINK_FEED_IDENTITY_VIEWS, 'phaseId', []),
+  ]);
+
+  const observedIdentity = {
+    feed: cfg.feed,
+    aggregator: agg.ok && typeof agg.value === 'string' ? agg.value : null,
+    phaseId: phase.ok && phase.value != null ? String(phase.value) : null,
+  };
+  const detail = {
+    vault, oracle, asset,
+    feed: cfg.feed,
+    cachedScale: cfg.scale.toString(),
+    liveDecimals: dec.ok ? Number(dec.value) : null,
+    liveDescription: desc.ok ? String(desc.value) : null,
+    pinnedAggregator: pin?.aggregator ?? null,
+    pinnedPhaseId: pin?.phaseId ?? null,
+    observedIdentity,
+  };
+
+  // HARM LEGS FIRST, in the constructor's own order (`_requireUsdQuote`, then `decimals`). Order
+  // decides which cause a responder chases — the Dev11 lesson, applied here too.
+  if (!desc.ok || !dec.ok) {
+    return blind(
+      `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} did not answer ${!desc.ok ? 'description()' : ''}${!desc.ok && !dec.ok ? ' or ' : ''}${!dec.ok ? 'decimals()' : ''} (${(desc.error ?? dec.error) || 'no error text'}), so neither the denomination nor the cached-scale check could run. This asset is UNMONITORED for aggregator-swap drift, not clean`,
+      { ...detail, descriptionError: desc.error ?? null, decimalsError: dec.error ?? null },
+    );
+  }
+
+  const description = String(desc.value);
+  if (!isUsdQuoted(description)) {
+    return alert({
+      ...base,
+      message: `FEED DENOMINATION DRIFT for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} now describes itself as ${JSON.stringify(description)}, which is NOT USD-quoted. ChainlinkOracle proved this feed was USD-quoted once, at construction, and its config is immutable — every price it has served since the change is denominated in something else, and NAV, deposits and exits are all wrong rather than frozen. Verify against Chainlink's announcement and treat the vault as mispriced`,
+      measured: JSON.stringify(description), threshold: 'a description ending in "USD" as a whole word',
+      detail: { ...detail, usdQuoted: false, harm: 'denomination' },
+    });
+  }
+
+  const liveDecimals = Number(dec.value);
+  const expectedScale = scaleForDecimals(liveDecimals);
+  if (expectedScale == null || expectedScale !== cfg.scale) {
+    const factor = expectedScale == null ? null : ratio(expectedScale, cfg.scale);
+    return alert({
+      ...base,
+      message: `FEED DECIMALS DRIFT for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} now reports ${liveDecimals} decimals, but the oracle cached scale ${cfg.scale}${expectedScale == null ? ' and no cacheable scale exists for that many decimals (scale is 10**(18-decimals), which requires decimals <= 18)' : ` when the correct scale for ${liveDecimals} decimals is ${expectedScale}`}. Every price this asset has served since the change is mis-scaled${factor ? ` by ${factor}` : ''} — the vault is NOT frozen, it is silently WRONG, and nothing else in the canary can see it because nav-backing recomputes through the same priceWad. The oracle's config is immutable: this cannot be repaired, only evacuated`,
+      measured: `decimals ${liveDecimals}`,
+      threshold: `the cached scale ${cfg.scale} (decimals ${scaleToDecimals(cfg.scale) ?? '?'})`,
+      detail: { ...detail, expectedScale: expectedScale == null ? null : expectedScale.toString(), harm: 'decimals' },
+    });
+  }
+
+  // IDENTITY LEG. Harm-free by itself, and only reached once both harm legs have passed.
+  if (!agg.ok && !phase.ok) {
+    return blind(
+      `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} answered neither aggregator() nor phaseId() (${(agg.error ?? phase.error) || 'no error text'}), so an aggregator swap cannot be observed at all. The denomination and cached-scale checks DID pass this sweep — the harm checks are running; it is the swap NOTICE that is blind`,
+      { ...detail, aggregatorError: agg.error ?? null, phaseIdError: phase.error ?? null },
+    );
+  }
+
+  const swap = convictSwap(pin, observedIdentity);
+  if (swap) {
+    return alert({
+      ...base,
+      message: `AGGREGATOR SWAPPED behind the feed for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${swap}. This is LEGITIMATE routine Chainlink operation and there is nothing to fix on-chain — but it is the only event that can invalidate the oracle's cached scale, so verify it against Chainlink's announcement (a deprecation is announced off-chain and looks like ordinary staleness only AFTER the response window closes). The denomination and cached-scale checks passed against the NEW aggregator on this same sweep, which is what says the swap was harmless; this alert clears itself next sweep`,
+      measured: `aggregator ${observedIdentity.aggregator ?? 'unreadable'} / phaseId ${observedIdentity.phaseId ?? 'unreadable'}`,
+      threshold: `aggregator ${pin?.aggregator ?? 'unpinned'} / phaseId ${pin?.phaseId ?? 'unpinned'}`,
+      detail: { ...detail, swapped: true, harm: null },
+    });
+  }
+
+  const partial = observedIdentity.aggregator == null || observedIdentity.phaseId == null;
+  return ok({
+    ...base,
+    message: pin
+      ? `feed identity unchanged for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${liveDecimals} decimals matching the cached scale ${cfg.scale}, ${JSON.stringify(description)} still USD-quoted, aggregator ${observedIdentity.aggregator ?? 'unreadable this sweep'} phaseId ${observedIdentity.phaseId ?? 'unreadable this sweep'}`
+      : `feed identity PINNED for ${shortAddr(asset)} on vault ${shortAddr(vault)} on first sight: aggregator ${observedIdentity.aggregator ?? 'unreadable'} phaseId ${observedIdentity.phaseId ?? 'unreadable'}, ${liveDecimals} decimals matching the cached scale ${cfg.scale}. A swap that happened BEFORE this pin is invisible to the identity leg — the decimals and denomination checks above do not depend on it and cover the harm regardless; scripts/verify-chainlink-oracle.mjs compares against the config's own aggregatorPin, which is the half that survives a canary restart`,
+    measured: `decimals ${liveDecimals}`, threshold: `the cached scale ${cfg.scale}`,
+    detail: { ...detail, pinned: pin != null, identityPartial: partial },
+  });
+}
+
+/**
+ * Decide whether the observed identity CONVICTS a swap against the pin, mirroring the argument in
+ * `scripts/verify-chainlink-oracle.mjs` rather than inventing a second one.
+ *
+ * `phaseId` increments on every swap and is a single word, so it convicts on its own. A changed
+ * `aggregator()` convicts only when both sides are actually readable — a read that came back empty
+ * is not evidence of a swap, and PR #92 recorded observing exactly that burst on 2026-08-30.
+ *
+ * @returns {string|null} the human clause for the alert line, or null for "no swap evidenced"
+ */
+function convictSwap(pin, observed) {
+  if (!pin) return null; // nothing pinned yet: first sight is not a change
+  if (pin.phaseId != null && observed.phaseId != null && String(pin.phaseId) !== String(observed.phaseId)) {
+    return `phaseId moved ${pin.phaseId} -> ${observed.phaseId}${observed.aggregator && pin.aggregator && !eqAddr(pin.aggregator, observed.aggregator) ? ` and aggregator() moved ${pin.aggregator} -> ${observed.aggregator}` : ''}`;
+  }
+  if (pin.aggregator && observed.aggregator && !eqAddr(pin.aggregator, observed.aggregator)) {
+    return `aggregator() moved ${pin.aggregator} -> ${observed.aggregator} (phaseId ${observed.phaseId ?? 'unreadable'})`;
+  }
+  if (pin.feed && observed.feed && !eqAddr(pin.feed, observed.feed)) {
+    // The oracle's config is immutable, so this should be unreachable — which is exactly why it is
+    // worth saying out loud if it ever happens: it would mean the vault's oracle itself changed.
+    return `the ORACLE now lists a different feed for this asset: ${pin.feed} -> ${observed.feed}`;
+  }
+  return null;
+}
+
+/**
+ * Fold this sweep's observations into the remembered identities. Pure; the runner calls it and
+ * persists the result to the canary state file.
+ *
+ * FIELD-BY-FIELD, and NEVER writing an absent value over a present one. That rule is Dev12's
+ * recorded bug stated as a guard: a pinned leg emitting a zero from an empty struct "would have
+ * overwritten a real heartbeat with zero — absent is the honest value". Here the equivalent
+ * mistake would erase the anchor with a null on the one sweep an `aggregator()` read came back
+ * empty, and the next real swap would then go unnarrated.
+ *
+ * @param {Record<string, any>} pins
+ * @param {import('../signal.mjs').SignalResult[]} results
+ * @returns {Record<string, any>} a new map; `pins` is not mutated
+ */
+export function applyIdentityObservations(pins, results) {
+  const next = { ...(pins ?? {}) };
+  for (const r of results ?? []) {
+    if (r?.signal !== SIGNAL) continue;
+    const obs = r.detail?.observedIdentity;
+    if (!obs) continue; // a blind or skipped leg observed nothing; keep whatever is pinned
+    const merged = { ...(next[r.id] ?? {}) };
+    for (const field of ['feed', 'aggregator', 'phaseId']) {
+      if (obs[field] != null) merged[field] = obs[field];
+    }
+    if (merged.feed == null && merged.aggregator == null && merged.phaseId == null) continue;
+    next[r.id] = merged;
+  }
+  return next;
+}
+
+/** `feedOf` is a mapping-to-struct getter, flattened to (feed, heartbeat, scale, min, max). */
+function normalizeFeedConfig(v) {
+  const [feed, , scale] = Array.isArray(v) ? v : [v?.feed, v?.heartbeat, v?.scale];
+  return { feed: typeof feed === 'string' ? feed : ZERO, scale: BigInt(scale ?? 0) };
+}
+
+/** Invert `10**(18 - d)` for the alert line, or null when the cached scale is not a power of ten. */
+function scaleToDecimals(scale) {
+  for (let d = 0; d <= 18; d += 1) if (10n ** BigInt(18 - d) === scale) return d;
+  return null;
+}
+
+/**
+ * How wrong the PRICE is, not how wrong the scale is — that is the number an operator reading one
+ * line at 3am has to act on. `priceWad = answer * cachedScale`, so the price is off by exactly
+ * `cachedScale / correctScale`.
+ */
+function ratio(expected, cached) {
+  if (cached === 0n || expected === 0n) return null;
+  if (cached > expected) return `${cached / expected}x too HIGH`;
+  if (expected > cached) return `${expected / cached}x too LOW`;
+  return null;
+}

--- a/packages/canary/src/state-file.mjs
+++ b/packages/canary/src/state-file.mjs
@@ -14,7 +14,16 @@
 import { readFile } from 'node:fs/promises';
 import { createRotatingWriter, listBackups } from '../../oplog/src/durable.mjs';
 
-export const emptyCanaryState = () => ({ transitions: {}, lastScannedBlock: null });
+/**
+ * `feedIdentity` is the aggregator identity `signals/feed-identity.mjs` observed on first sight,
+ * keyed by that signal's transition id. It is the ONLY remembered value in the canary that is not a
+ * status: everything else that signal checks (the feed's live `decimals()` against the oracle's
+ * cached `scale`, and the USD denomination) is read from the chain on both sides and needs no
+ * memory. A state file written before this key existed simply has no pins, and the identity leg
+ * re-pins on first sight — see the caveat that carries in the signal's own "PINNED on first sight"
+ * message.
+ */
+export const emptyCanaryState = () => ({ transitions: {}, lastScannedBlock: null, feedIdentity: {} });
 
 /** Atomic writer with the backup ring. `save(obj)` replaces the old inline temp-then-rename. */
 export function createCanaryStateWriter({ path, backups = 0, backupIntervalMs = 0, now }) {
@@ -50,7 +59,7 @@ export function summariseTransitions(transitions) {
  * The question after an incident is "what did it already know, and how far had it scanned?".
  */
 export async function verifyCanaryState(path, { keep = 5 } = {}) {
-  const report = { path, ok: false, exists: false, error: null, lastScannedBlock: null, summary: null, backups: [] };
+  const report = { path, ok: false, exists: false, error: null, lastScannedBlock: null, summary: null, feedsPinned: 0, backups: [] };
   for (const b of await listBackups(path, keep)) {
     const row = { ...b, ok: false, lastScannedBlock: null, tracked: null, error: null };
     try {
@@ -78,6 +87,7 @@ export async function verifyCanaryState(path, { keep = 5 } = {}) {
     const obj = JSON.parse(raw);
     report.lastScannedBlock = obj.lastScannedBlock ?? null;
     report.summary = summariseTransitions(obj.transitions);
+    report.feedsPinned = Object.keys(obj.feedIdentity ?? {}).length;
     report.ok = true;
   } catch (err) {
     report.error = String(err?.message ?? err);
@@ -96,6 +106,10 @@ export function formatCanaryStateReport(report) {
     lines.push(`  cursor      lastScannedBlock=${report.lastScannedBlock ?? 'null (cold start)'}`);
     lines.push(`  signals     ${s.tracked} tracked — ${Object.entries(s.byStatus).map(([k, v]) => `${k}=${v}`).join(' ') || 'none'}`);
     for (const n of s.notOk) lines.push(`    NOT OK    ${n.id} (${n.status} since poll ${n.since})`);
+    // 0 pinned after a live run is worth seeing: it means the feed-identity signal has never
+    // reached a Chainlink feed, so an aggregator swap would not be narrated (the decimals and
+    // denomination checks still run — they need no pin).
+    lines.push(`  feed pins   ${report.feedsPinned} aggregator identit${report.feedsPinned === 1 ? 'y' : 'ies'} remembered`);
     lines.push(`  file        ${report.bytes} bytes`);
   }
   if (report.backups.length === 0) {

--- a/packages/canary/test/abis.test.mjs
+++ b/packages/canary/test/abis.test.mjs
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
   REQUEST_EXIT_SELECTOR, EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS,
-  VAULT_VIEWS, ORACLE_VIEWS, CHAINLINK_ORACLE_VIEWS, AGGREGATOR_V3_VIEWS,
+  VAULT_VIEWS, ORACLE_VIEWS, CHAINLINK_ORACLE_VIEWS, AGGREGATOR_V3_VIEWS, CHAINLINK_FEED_IDENTITY_VIEWS,
   VAULT_WATCH_EVENTS, ERC20_TRANSFER_EVENT, EXIT_SETTLED_EVENT,
   signatureOf,
 } from '../src/abis.mjs';
@@ -39,6 +39,12 @@ const oracleAbi = oracleBuilt ? JSON.parse(readFileSync(oracleAbiPath, 'utf8')).
 const feedAbiPath = join(OUT, 'IAggregatorV3.sol/IAggregatorV3.json');
 const feedBuilt = existsSync(feedAbiPath);
 const feedAbi = feedBuilt ? JSON.parse(readFileSync(feedAbiPath, 'utf8')).abi ?? [] : [];
+
+// `description()` is declared as its own interface inside ChainlinkOracle.sol, because the
+// constructor reaches it by raw staticcall rather than through IAggregatorV3.
+const descAbiPath = join(OUT, 'ChainlinkOracle.sol/IAggregatorV3Description.json');
+const descBuilt = existsSync(descAbiPath);
+const descAbi = descBuilt ? JSON.parse(readFileSync(descAbiPath, 'utf8')).abi ?? [] : [];
 
 /** Every embedded selector, mapped to the Solidity signature it must equal. */
 const EXPECTED = {
@@ -81,7 +87,7 @@ test('StaleOracle is NOT filed as a gate — it must never read as a healthy exi
 });
 
 test('the ABI table declares no state-changing function — the canary is read-only by construction', () => {
-  for (const frag of [...VAULT_VIEWS, ...ORACLE_VIEWS, ...CHAINLINK_ORACLE_VIEWS, ...AGGREGATOR_V3_VIEWS]) {
+  for (const frag of [...VAULT_VIEWS, ...ORACLE_VIEWS, ...CHAINLINK_ORACLE_VIEWS, ...AGGREGATOR_V3_VIEWS, ...CHAINLINK_FEED_IDENTITY_VIEWS]) {
     assert.equal(frag.stateMutability, 'view', `${frag.name} is not a view function`);
   }
 });
@@ -203,4 +209,45 @@ test('the Chainlink feed tuple matches the compiled IAggregatorV3 — field ORDE
       `${sig} field NAMES drifted — startedAt and updatedAt are adjacent uint256s and are not interchangeable`,
     );
   }
+});
+
+/**
+ * The feed-identity table, split by what can actually be pinned.
+ *
+ * `decimals()` and `description()` are the HARM legs, and both are read by `ChainlinkOracle`'s own
+ * constructor — `decimals()` through `IAggregatorV3`, `description()` through the
+ * `IAggregatorV3Description` interface declared alongside it for the raw staticcall. Those two are
+ * cross-checked against the compiled contracts here for the same reason the ChainlinkOracle table
+ * is: a signal reading a selector the target does not implement goes blind, and this file is the
+ * only place that can notice at build time.
+ *
+ * `aggregator()` and `phaseId()` are NOT checkable this way and are not pretended otherwise: they
+ * belong to Chainlink's `EACAggregatorProxy`, which is not in this tree and is not ours to compile.
+ * Their runtime failure is covered instead — `signals/feed-identity.mjs` reports a feed answering
+ * neither as DETECTOR BROKEN, and test/feed-identity.test.mjs pins that.
+ */
+test('the feed-identity HARM legs exist on the compiled contracts the oracle itself reads them through', { skip: (!feedBuilt || !descBuilt) && 'contracts/out absent — run `cd contracts && forge build`' }, () => {
+  const declared = new Map(
+    [...feedAbi, ...descAbi].filter((i) => i.type === 'function').map((i) => [canonical(i), i]),
+  );
+  for (const name of ['decimals', 'description']) {
+    const frag = CHAINLINK_FEED_IDENTITY_VIEWS.find((f) => f.name === name);
+    const sig = signatureOf(frag);
+    const onChain = declared.get(sig);
+    assert.ok(onChain, `${sig} is not on IAggregatorV3/IAggregatorV3Description — the harm leg would read a reverting selector and go blind`);
+    assert.equal(onChain.stateMutability, 'view');
+    assert.deepEqual(
+      onChain.outputs.map((o) => o.type), frag.outputs.map((o) => o.type),
+      `${sig} return shape drifted — feed-identity would mis-decode the value it compares against the cached scale`,
+    );
+  }
+});
+
+test('the feed-identity IDENTITY legs are the EACAggregatorProxy signatures, and are recorded as unpinnable', () => {
+  // Self-referential on purpose, and labelled as such: there is no compiled EACAggregatorProxy in
+  // this repo to check against. The assertion is here so a rename is at least deliberate.
+  assert.deepEqual(
+    CHAINLINK_FEED_IDENTITY_VIEWS.map(signatureOf).sort(),
+    ['aggregator()', 'decimals()', 'description()', 'phaseId()'],
+  );
 });

--- a/packages/canary/test/feed-identity.test.mjs
+++ b/packages/canary/test/feed-identity.test.mjs
@@ -1,0 +1,378 @@
+// @ts-check
+/**
+ * Signal (g) — FEED IDENTITY, the on-chain half of G2 (OPS-3, aggregator-swap drift).
+ *
+ * These tests are the executable statement of the one thing `ChainlinkOracle` proves at
+ * construction and can never re-prove: that the feed behind each asset still reports the decimals
+ * the immutable `scale` was cached from, and still quotes in USD. Every case perturbs exactly one
+ * of those and asserts the canary says so.
+ *
+ * Two of them are load-bearing as a PAIR and are written adjacent, in order, under
+ * "the severity calibration": a benign aggregator swap alerts once and clears itself, and a swap
+ * that ALSO moves decimals alerts and stays alerting. The self-clear is only safe because it is
+ * gated on the harm legs passing, and a future retune that breaks that gate must fail here rather
+ * than quietly turning a mis-scale into a one-line notice.
+ *
+ * All mocked. No live RPC anywhere.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  checkFeedIdentity, applyIdentityObservations, scaleForDecimals, isUsdQuoted, UNREADABLE_SWEEPS,
+} from '../src/signals/feed-identity.mjs';
+import { createTransitionTracker } from '../src/transitions.mjs';
+import {
+  mockReader, healthyVault, chainlinkVault,
+  VAULT, ORACLE, ASSET, FEED, AGGREGATOR, AGGREGATOR_2, ZERO_ADDR,
+} from './helpers.mjs';
+
+const NOW = 1_700_000_000;
+
+const readerFor = (opts = {}) => mockReader({ contracts: chainlinkVault({ nowSec: NOW, ...opts }), nowSec: NOW });
+const run = (reader, pins = {}) => checkFeedIdentity({ reader, vault: VAULT, oracle: ORACLE, assets: [ASSET], pins });
+const one = async (opts = {}, pins = {}) => (await run(readerFor(opts), pins))[0];
+
+/** The pin a healthy first sweep leaves behind. */
+const PINNED = { [`feed-identity|${VAULT}|${ASSET}`]: { feed: FEED, aggregator: AGGREGATOR, phaseId: '4' } };
+
+// ── pure helpers: the two predicates the contract owns, mirrored ──────────────
+
+test('scaleForDecimals mirrors the cached scale formula, and refuses what could never be cached', () => {
+  assert.equal(scaleForDecimals(8), 10_000_000_000n, '8 decimals is the Chainlink USD convention');
+  assert.equal(scaleForDecimals(18), 1n);
+  assert.equal(scaleForDecimals(0), 1_000000000000000000n);
+  // ChainlinkOracle computes 10**(18 - d) in a uint8 subtraction, so d > 18 reverts at
+  // construction and can never be the cached value. In JS the same expression is a RangeError, so
+  // this MUST be null rather than a throw — see the alert path test below.
+  assert.equal(scaleForDecimals(19), null);
+  assert.equal(scaleForDecimals(20), null);
+  assert.equal(scaleForDecimals(-1), null);
+  assert.equal(scaleForDecimals(8.5), null);
+  assert.equal(scaleForDecimals('eight'), null);
+});
+
+test('isUsdQuoted is ChainlinkOracle._requireUsdQuote, separator rule included', () => {
+  assert.equal(isUsdQuoted('ETH / USD'), true);
+  assert.equal(isUsdQuoted('BTC/USD'), true);
+  assert.equal(isUsdQuoted('CBETH / ETH'), false);
+  // The separator requirement is the whole point: a USD-ISH TOKEN is not USD.
+  assert.equal(isUsdQuoted('ETH / PYUSD'), false);
+  assert.equal(isUsdQuoted('USD'), false);
+  assert.equal(isUsdQuoted(null), false);
+});
+
+// ── flavor dispatch ──────────────────────────────────────────────────────────
+
+test('a ChainlinkOracle deployment is checked, and a healthy feed pins itself on first sight', async () => {
+  const results = await run(readerFor());
+  assert.equal(results.length, 1);
+  const r = results[0];
+  assert.equal(r.status, 'ok');
+  assert.equal(r.signal, 'feed-identity', 'its own signal name, not oracle-freshness');
+  assert.equal(r.detail.cachedScale, '10000000000');
+  assert.equal(r.detail.liveDecimals, 8);
+  assert.equal(r.detail.observedIdentity.aggregator, AGGREGATOR);
+  assert.equal(r.detail.observedIdentity.phaseId, '4');
+  assert.match(r.message, /PINNED for .* on first sight/);
+  assert.match(r.message, /A swap that happened BEFORE this pin is invisible/, 'the residual is stated, not hidden');
+});
+
+test('a retired-aggregator deployment produces NOTHING — there is no proxy there to drift', async () => {
+  // Not a suppressed skip: the retired OracleAggregator has fixed source addresses in an immutable
+  // config, so "feed identity" is not a capability that exists to be blind about.
+  const reader = mockReader({ contracts: healthyVault(), nowSec: NOW });
+  assert.deepEqual(await run(reader), []);
+});
+
+test('an oracle answering NEITHER ABI is a BROKEN DETECTOR here too, not a quiet nothing', async () => {
+  // oracle-freshness reports the same vault as blind for the staleness FREEZE. That is a different
+  // capability from this one, so this signal says its own piece rather than assuming coverage.
+  const reader = mockReader({
+    contracts: { ...healthyVault(), [ORACLE.toLowerCase()]: { priceWad: () => 3_000000000000000000n } },
+    nowSec: NOW,
+  });
+  const [r] = await run(reader);
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.key, 'flavor');
+  assert.match(r.message, /UNMONITORED for aggregator-swap drift, not clean/);
+});
+
+test('no basket assets means no results at all, rather than a fabricated clean bill', async () => {
+  assert.deepEqual(
+    await checkFeedIdentity({ reader: readerFor(), vault: VAULT, oracle: ORACLE, assets: [] }),
+    [],
+  );
+});
+
+test('an asset with no feed listed is a KNOWN skip attributed elsewhere, never a broken detector', async () => {
+  // feedOf returns the zero struct for anything that is not ASSET.
+  const results = await checkFeedIdentity({
+    reader: readerFor(), vault: VAULT, oracle: ORACLE, assets: [`0x${'7'.repeat(40)}`],
+  });
+  assert.equal(results[0].status, 'skipped');
+  assert.equal(results[0].detail.detectorBroken, undefined, 'oracle-freshness is already paging for this');
+  assert.equal(results[0].detail.attributedTo, 'oracle-freshness');
+});
+
+// ── the harm leg that needs no pin: live decimals vs the oracle's CACHED scale ──
+
+test('the decimals check is LIVE vs CACHED, both read from the chain — no pin, no config', async () => {
+  // The comparison that matters is against `feedOf().scale`, which IS the value the contract uses,
+  // not against a convention or a config file. Prove the check keys off the cached scale by moving
+  // the cached scale and leaving the feed alone.
+  const r = await one({ scale: 1_000_000n }); // as if the oracle had been deployed against 12 decimals
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.harm, 'decimals');
+  assert.equal(r.detail.cachedScale, '1000000');
+  assert.equal(r.detail.liveDecimals, 8);
+});
+
+test('an aggregator swapped to FEWER decimals ALERTs, and the line says how wrong the price is', async () => {
+  const r = await one({ feedDecimals: 6 }); // correct scale 1e12, cached 1e10 → prices 100x too low
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.harm, 'decimals');
+  assert.equal(r.detail.expectedScale, '1000000000000');
+  assert.match(r.message, /100x too LOW/);
+  assert.match(r.message, /NOT frozen, it is silently WRONG/);
+  assert.match(r.message, /nav-backing recomputes through the same priceWad/, 'why nothing else sees it');
+});
+
+test('an aggregator swapped to 18 decimals ALERTs — the Chainlink-precedent drift, prices 1e10 too high', async () => {
+  const r = await one({ feedDecimals: 18 });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.expectedScale, '1');
+  assert.match(r.message, /10000000000x too HIGH/);
+});
+
+test('decimals ABOVE 18 is a named ALERT, not a RangeError swallowed into a generic broken detector', async () => {
+  // 10n ** BigInt(18 - 20) throws. If it escaped, the runner would convert a real mis-scale into
+  // "this signal ERRORED" — a live mispricing reported as a monitoring fault.
+  const r = await one({ feedDecimals: 20 });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.harm, 'decimals');
+  assert.equal(r.detail.expectedScale, null);
+  assert.match(r.message, /no cacheable scale exists/);
+});
+
+test('a feed that still reports 8 decimals against a 1e10 cached scale is OK — no false positive', async () => {
+  const r = await one({ feedDecimals: 8 });
+  assert.equal(r.status, 'ok');
+});
+
+// ── the other pin-free harm leg: denomination ────────────────────────────────
+
+test('a feed that stops quoting USD ALERTs — the constructor proved this once and cannot re-prove it', async () => {
+  const r = await one({ feedDescription: 'CBETH / ETH' });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.harm, 'denomination');
+  assert.match(r.message, /NOT USD-quoted/);
+});
+
+test('a USD-ish TOKEN quote does not pass on a bare suffix match', async () => {
+  const r = await one({ feedDescription: 'ETH / PYUSD' });
+  assert.equal(r.status, 'alert');
+  assert.equal(r.detail.harm, 'denomination');
+});
+
+test('a renamed but still USD-quoted feed is NOT an alert — the predicate is denomination, not identity', async () => {
+  const r = await one({ feedDescription: 'Ethereum / USD' });
+  assert.equal(r.status, 'ok');
+});
+
+test('the harm legs run in the CONSTRUCTOR order: denomination is named before decimals', async () => {
+  // ChainlinkOracle runs _requireUsdQuote then reads decimals(). Mirroring the order decides which
+  // cause a responder chases when both are true.
+  const r = await one({ feedDescription: 'CBETH / ETH', feedDecimals: 6 });
+  assert.equal(r.detail.harm, 'denomination');
+});
+
+// ── the severity calibration: the two cases that must NOT behave the same ─────
+//
+// A Chainlink aggregator swap is routine and legitimate; a decimals change is not. The pair below
+// is the pinned statement of that difference, and it is a CONJUNCTION: the benign swap only clears
+// itself because the harm legs passed on the same sweep.
+
+test('a BENIGN aggregator swap alerts EXACTLY ONCE and then clears itself — routine, not a standing incident', async () => {
+  const tracker = createTransitionTracker();
+  let pins = {};
+  let poll = 0;
+  const sweep = async (opts) => {
+    const results = await run(readerFor(opts), pins);
+    const transitions = tracker.observe(results, { poll: (poll += 1) });
+    pins = applyIdentityObservations(pins, results);
+    return transitions;
+  };
+
+  assert.deepEqual(await sweep({}), [], 'first sight pins silently');
+  const swapped = await sweep({ feedAggregator: AGGREGATOR_2, feedPhaseId: 5 });
+  assert.equal(swapped.length, 1);
+  assert.equal(swapped[0].to, 'alert');
+  assert.match(swapped[0].line, /AGGREGATOR SWAPPED/);
+  assert.match(swapped[0].line, /LEGITIMATE routine Chainlink operation/);
+  assert.match(swapped[0].line, /verify it against Chainlink's announcement/);
+
+  const after = await sweep({ feedAggregator: AGGREGATOR_2, feedPhaseId: 5 });
+  assert.equal(after.length, 1);
+  assert.equal(after[0].to, 'ok', 'the re-pin clears it: there is no operator action that resolves a swap');
+  assert.deepEqual(await sweep({ feedAggregator: AGGREGATOR_2, feedPhaseId: 5 }), [], 'and then it is silent');
+});
+
+test('a swap that ALSO moves decimals alerts and STAYS alerting — the self-clear is gated on the harm legs', async () => {
+  const tracker = createTransitionTracker();
+  let pins = {};
+  let poll = 0;
+  const sweep = async (opts) => {
+    const results = await run(readerFor(opts), pins);
+    const transitions = tracker.observe(results, { poll: (poll += 1) });
+    pins = applyIdentityObservations(pins, results);
+    return transitions;
+  };
+
+  assert.deepEqual(await sweep({}), []);
+  const bad = { feedAggregator: AGGREGATOR_2, feedPhaseId: 5, feedDecimals: 6 };
+  const first = await sweep(bad);
+  assert.equal(first.length, 1);
+  assert.equal(first[0].to, 'alert');
+  assert.match(first[0].line, /FEED DECIMALS DRIFT/, 'the harm outranks the swap notice');
+
+  // The pin is refreshed exactly as in the benign case — and it must NOT be what silences this.
+  assert.deepEqual(await sweep(bad), [], 'no RECOVERED line: the vault is still mispriced');
+  assert.deepEqual(await sweep(bad), []);
+  assert.equal(tracker.unhealthy().length, 1, 'it stays not-OK until the oracle is replaced');
+});
+
+// ── the identity leg on its own ──────────────────────────────────────────────
+
+test('phaseId convicts a swap on its own, even when aggregator() does not answer', async () => {
+  const r = await one({ feedPhaseId: 5, feedAggregatorReverts: true }, PINNED);
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /phaseId moved 4 -> 5/);
+});
+
+test('an unreadable aggregator() alone does NOT convict — an empty return is not evidence of a swap', async () => {
+  // PR #92 recorded observing exactly this burst against a live proxy on 2026-08-30. Convicting on
+  // it would page on network noise.
+  const r = await one({ feedAggregatorReverts: true }, PINNED);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.detail.identityPartial, true);
+});
+
+test('a changed aggregator() convicts when phaseId is unreadable but both addresses are', async () => {
+  const r = await one({ feedAggregator: AGGREGATOR_2, feedPhaseIdReverts: true }, PINNED);
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /aggregator\(\) moved/);
+});
+
+test('a first sighting with no pin is never a swap', async () => {
+  const r = await one({ feedAggregator: AGGREGATOR_2, feedPhaseId: 9 }, {});
+  assert.equal(r.status, 'ok');
+});
+
+// ── a check that cannot run is never silent ──────────────────────────────────
+
+test('an unreadable decimals() is a BROKEN DETECTOR — the harm check could not run', async () => {
+  const r = await one({ feedDecimalsReverts: true });
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.detail.minConsecutive, UNREADABLE_SWEEPS);
+  assert.match(r.message, /UNMONITORED for aggregator-swap drift, not clean/);
+});
+
+test('an unreadable description() is a BROKEN DETECTOR for the same reason', async () => {
+  const r = await one({ feedDescriptionReverts: true });
+  assert.equal(r.detail.detectorBroken, true);
+  assert.match(r.message, /description\(\)/);
+});
+
+test('an unreadable feedOf() is a BROKEN DETECTOR: the cached scale is the thing being compared against', async () => {
+  const reader = mockReader({
+    contracts: {
+      ...chainlinkVault({ nowSec: NOW }),
+      [ORACLE.toLowerCase()]: {
+        sequencerUptimeFeed: () => ZERO_ADDR,
+        feedOf: () => ({ revert: '0xdeadbeef' }),
+      },
+    },
+    nowSec: NOW,
+  });
+  const [r] = await run(reader);
+  assert.equal(r.detail.detectorBroken, true);
+  assert.match(r.message, /feedOf\(\) on .* reverts/);
+});
+
+test('a blind IDENTITY leg is still loud, and the line says the harm checks DID run', async () => {
+  const r = await one({ feedAggregatorReverts: true, feedPhaseIdReverts: true });
+  assert.equal(r.detail.detectorBroken, true);
+  assert.match(r.message, /answered neither aggregator\(\) nor phaseId\(\)/);
+  assert.match(r.message, /denomination and cached-scale checks DID pass this sweep/);
+});
+
+test('an established detector is DAMPED against one flaky sweep, but three consecutive escalate', async () => {
+  const tracker = createTransitionTracker();
+  let poll = 0;
+  const sweep = async (opts) => tracker.observe(await run(readerFor(opts)), { poll: (poll += 1) });
+
+  assert.deepEqual(await sweep({}), [], 'healthy: silent');
+  assert.deepEqual(await sweep({ feedDecimalsReverts: true }), [], 'one empty return is RPC noise');
+  assert.deepEqual(await sweep({ feedDecimalsReverts: true }), []);
+  const escalated = await sweep({ feedDecimalsReverts: true });
+  assert.equal(escalated.length, 1);
+  assert.match(escalated[0].line, /DETECTOR BROKEN/);
+  // Recovery is not damped: an ok result carries no minConsecutive, so coverage resumes at once.
+  const recovered = await sweep({});
+  assert.equal(recovered.length, 1);
+  assert.equal(recovered[0].to, 'ok');
+});
+
+test('a FIRST sighting that cannot be read reports immediately — never observed must not look like silence', async () => {
+  // Deliberate, and asymmetric with the damping above: the tracker never applies minConsecutive to
+  // an id it has not seen before. A monitor that has never once succeeded must say so on sweep one,
+  // even at the cost of a line that clears next sweep.
+  const tracker = createTransitionTracker();
+  const first = tracker.observe(await run(readerFor({ feedDecimalsReverts: true })), { poll: 1 });
+  assert.equal(first.length, 1);
+  assert.match(first[0].line, /DETECTOR BROKEN/);
+});
+
+// ── the pin store ────────────────────────────────────────────────────────────
+
+test('applyIdentityObservations never writes an absent value over a present one', async () => {
+  // Dev12's recorded bug, as a guard: overwriting a real anchor with a null from one empty read
+  // would make the NEXT real swap unnarratable.
+  const results = await run(readerFor({ feedAggregatorReverts: true }), PINNED);
+  const next = applyIdentityObservations(PINNED, results);
+  const rec = next[`feed-identity|${VAULT}|${ASSET}`];
+  assert.equal(rec.aggregator, AGGREGATOR, 'the pinned aggregator survived an unreadable sweep');
+  assert.equal(rec.phaseId, '4');
+});
+
+test('a leg that never reached the feed pins nothing, and the input map is not mutated', async () => {
+  // feedOf reverting means no feed address was even resolved: there is nothing to remember, and
+  // writing a placeholder would be the same class of mistake as overwriting with a null.
+  const before = {};
+  const reader = mockReader({
+    contracts: {
+      ...chainlinkVault({ nowSec: NOW }),
+      [ORACLE.toLowerCase()]: { sequencerUptimeFeed: () => ZERO_ADDR, feedOf: () => ({ revert: '0xdeadbeef' }) },
+    },
+    nowSec: NOW,
+  });
+  assert.deepEqual(applyIdentityObservations(before, await run(reader, before)), {});
+  assert.deepEqual(before, {}, 'pure: the caller owns the write');
+});
+
+test('an identity read that DID succeed is pinned even when a harm leg was blind', async () => {
+  // The legs are independent: `aggregator()`/`phaseId()` answering is a complete, valid observation
+  // whether or not `decimals()` answered on the same sweep. Discarding it would mean a swap during
+  // a decimals-blind window went untracked — and that window is exactly when one is most likely.
+  const results = await run(readerFor({ feedDecimalsReverts: true }), {});
+  assert.equal(results[0].detail.detectorBroken, true, 'still loudly blind on the harm leg');
+  const rec = applyIdentityObservations({}, results)[`feed-identity|${VAULT}|${ASSET}`];
+  assert.equal(rec.aggregator, AGGREGATOR);
+});
+
+test('applyIdentityObservations ignores results from every other signal', () => {
+  const foreign = [{ id: 'oracle-freshness|v|a', signal: 'oracle-freshness', detail: { observedIdentity: { aggregator: AGGREGATOR } } }];
+  assert.deepEqual(applyIdentityObservations({}, foreign), {});
+});

--- a/packages/canary/test/helpers.mjs
+++ b/packages/canary/test/helpers.mjs
@@ -32,6 +32,10 @@ export const FEED = `0x${'fe'.repeat(18)}0001`;
 export const SEQ_FEED = `0x${'5e'.repeat(18)}0002`;
 export const ZERO_ADDR = `0x${'0'.repeat(40)}`;
 
+/** The aggregator currently behind FEED, and the one Chainlink swaps in. */
+export const AGGREGATOR = `0x${'a9'.repeat(18)}0003`;
+export const AGGREGATOR_2 = `0x${'a9'.repeat(18)}0004`;
+
 /** 8-decimal feed answer of $3.00 — × the 1e10 scale it is the 3e18 the NAV fixture expects. */
 export const FEED_ANSWER_3USD = 300_000_000n;
 export const FEED_SCALE_8DP = 10_000_000_000n;
@@ -197,6 +201,17 @@ export function chainlinkVault({
   maxPriceWad = 0n,
   feed = FEED,
   feedReverts = false,
+  // The proxy's self-description, which `signals/feed-identity.mjs` re-checks every sweep. The
+  // defaults are the healthy launch shape: 8 decimals (so 10**(18-8) == the 1e10 default `scale`),
+  // a USD-quoted description, and a stable aggregator/phaseId pair.
+  feedDecimals = 8,
+  feedDescription = 'ETH / USD',
+  feedAggregator = AGGREGATOR,
+  feedPhaseId = 4,
+  feedDecimalsReverts = false,
+  feedDescriptionReverts = false,
+  feedAggregatorReverts = false,
+  feedPhaseIdReverts = false,
   priceWadReverts = false,
   priceWadRevertData = '0xa2671f4b', // StaleOracle(address)
   usdcPin = ZERO_ADDR,
@@ -226,8 +241,13 @@ export function chainlinkVault({
   };
 
   const stamp = BigInt(nowSec - ageSec);
+  const RV = { revert: '0xdeadbeef' };
   contracts[lc(feed)] = {
-    latestRoundData: () => (feedReverts ? { revert: '0xdeadbeef' } : [1n, answer, stamp, stamp, 1n]),
+    latestRoundData: () => (feedReverts ? RV : [1n, answer, stamp, stamp, 1n]),
+    decimals: () => (feedDecimalsReverts ? RV : feedDecimals),
+    description: () => (feedDescriptionReverts ? RV : feedDescription),
+    aggregator: () => (feedAggregatorReverts ? RV : feedAggregator),
+    phaseId: () => (feedPhaseIdReverts ? RV : feedPhaseId),
   };
 
   if (lc(sequencerUptimeFeed) !== lc(ZERO_ADDR)) {

--- a/packages/canary/test/runner.test.mjs
+++ b/packages/canary/test/runner.test.mjs
@@ -11,13 +11,14 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { rm, mkdtemp, readFile } from 'node:fs/promises';
+import { rm, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { resolveCanaryConfig, collectSignals, buildCanary } from '../src/canary-runner.mjs';
 import { saveSnapshot } from '../../indexer/src/store.mjs';
 import { emptyState } from '../../indexer/src/projections.mjs';
 import {
   mockReader, healthyVault, healthyState, chainlinkVault, log,
   VAULT, USDC, ORACLE, ASSET, REGISTRY, MEMBER, CREATOR, OPERATOR, SRC1, SRC2, SRC3, SEQ_FEED,
+  AGGREGATOR, AGGREGATOR_2,
 } from './helpers.mjs';
 
 const NOW = 1_700_000_000;
@@ -438,4 +439,105 @@ test('a full sweep derives the early-warning bar from ORACLE_FEED_CADENCE_SECOND
   assert.match(r.message, /AGEING/);
   assert.equal(r.detail.warnBarSource, 'derived');
   assert.equal(r.detail.warnAtSec, 2400);
+});
+
+// ── feed identity (signal g) is wired into the sweep ─────────────────────────
+
+test('a healthy PIVOTED sweep runs SEVEN signals — feed-identity included, and silent', async () => {
+  const results = await collectSignals({
+    reader: mockReader({ contracts: pivotedFixture(), nowSec: NOW }),
+    state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  assert.deepEqual(results.filter((r) => r.status !== 'ok').map((r) => r.message), []);
+  assert.deepEqual(
+    [...new Set(results.map((r) => r.signal))].sort(),
+    ['exit-liveness', 'fee-routing', 'feed-identity', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
+  );
+});
+
+test('a RETIRED-oracle sweep still runs exactly six signals — feed-identity has nothing to watch there', async () => {
+  const results = await collectSignals({
+    reader: mockReader({ contracts: healthyFixture(), nowSec: NOW }),
+    state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  assert.ok(!results.some((r) => r.signal === 'feed-identity'), 'no Chainlink proxy exists to drift');
+});
+
+test('a mis-scaled feed pages from feed-identity while every other signal reads healthy', async () => {
+  // The whole point of the signal: the vault is NOT frozen. priceWad answers, so oracle-freshness
+  // is OK, and nav-backing recomputes through that same priceWad so its two sides still agree.
+  const results = await collectSignals({
+    reader: mockReader({ contracts: pivotedFixture({ feedDecimals: 6 }), nowSec: NOW }),
+    state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const alerts = results.filter((r) => r.status === 'alert');
+  assert.equal(alerts.length, 1, 'exactly one page for one root cause');
+  assert.equal(alerts[0].signal, 'feed-identity');
+  assert.match(alerts[0].message, /FEED DECIMALS DRIFT/);
+  assert.equal(results.find((r) => r.signal === 'oracle-freshness' && r.key === ASSET).status, 'ok');
+  assert.equal(results.find((r) => r.signal === 'nav-backing').status, 'ok');
+});
+
+test('the aggregator pin survives a restart through the canary state file, so a swap pages once and only once', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const canaryStatePath = join(dir, 'canary-state.json');
+    const mkCfg = () => resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: canaryStatePath, OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+    });
+    const wire = async (contracts, out, err) => {
+      const canary = await buildCanary(mkCfg(), { log: (m) => out.push(m), error: (m) => err.push(m), client: {} });
+      canary.reader.headBlock = async () => 1000;
+      canary.reader.chainNow = async () => NOW;
+      const mock = mockReader({ contracts, nowSec: NOW });
+      Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+      return canary;
+    };
+
+    const out = [], err = [];
+    const first = await wire(pivotedFixture(), out, err);
+    assert.deepEqual((await first.runOnce()).transitions, [], 'first sight pins silently');
+    await first.stop();
+    const pinned = JSON.parse(await readFile(canaryStatePath, 'utf8')).feedIdentity;
+    assert.equal(Object.keys(pinned).length, 1);
+    assert.equal(pinned[`feed-identity|${VAULT}|${ASSET}`].aggregator, AGGREGATOR);
+
+    // A fresh process against a SWAPPED aggregator — the pin has to come off disk, or the swap is
+    // invisible and every restart silently re-pins to whatever is live.
+    const swapped = pivotedFixture({ feedAggregator: AGGREGATOR_2, feedPhaseId: 5 });
+    const second = await wire(swapped, out, err);
+    const t = (await second.runOnce()).transitions;
+    assert.equal(t.length, 1);
+    assert.match(t[0].line, /AGGREGATOR SWAPPED/);
+    // Same process, same fixture: the re-pin clears it rather than parking a permanent not-OK row.
+    assert.equal((await second.runOnce()).transitions[0].to, 'ok');
+    assert.deepEqual((await second.runOnce()).transitions, []);
+    await second.stop();
+    assert.equal(
+      JSON.parse(await readFile(canaryStatePath, 'utf8')).feedIdentity[`feed-identity|${VAULT}|${ASSET}`].phaseId,
+      '5',
+    );
+  });
+});
+
+test('a canary state file written BEFORE feedIdentity existed loads and re-pins, rather than throwing', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const canaryStatePath = join(dir, 'canary-state.json');
+    await writeFile(canaryStatePath, JSON.stringify({ transitions: {}, lastScannedBlock: 990 }), 'utf8');
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: canaryStatePath, OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+    });
+    const canary = await buildCanary(cfg, { log: () => {}, error: () => {}, client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: pivotedFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    assert.deepEqual((await canary.runOnce()).transitions, []);
+    const flushed = await canary.flush();
+    assert.equal(flushed.feedsPinned, 1);
+  });
 });

--- a/packages/canary/test/state-file.test.mjs
+++ b/packages/canary/test/state-file.test.mjs
@@ -29,6 +29,42 @@ test('write then load round-trips, and an absent file is a cold start not an err
   }
 });
 
+test('the empty state carries a feed-identity pin map, and a file written before it existed still loads', async () => {
+  assert.deepEqual(emptyCanaryState().feedIdentity, {});
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    // The exact legacy shape: no `feedIdentity` key at all. It must be a cold pin store, not a
+    // crash — and not a reason to refuse the transition history that IS in the file.
+    await writeFile(p, JSON.stringify(STATE(42, { 'nav-backing|0xabc': { status: 'alert', since: 3 } })), 'utf8');
+    const back = await loadCanaryState(p);
+    assert.equal(back.feedIdentity, undefined, 'absent, and the runner defaults it');
+    assert.equal(back.transitions['nav-backing|0xabc'].status, 'alert');
+    const r = await verifyCanaryState(p);
+    assert.equal(r.ok, true);
+    assert.equal(r.feedsPinned, 0);
+    assert.match(formatCanaryStateReport(r), /feed pins {3}0 aggregator identities remembered/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify counts the remembered aggregator identities, so "never pinned" is visible after an incident', async () => {
+  const dir = await tmp();
+  const p = join(dir, 'canary-state.json');
+  try {
+    await createCanaryStateWriter({ path: p, backups: 0 }).save({
+      ...STATE(7, {}),
+      feedIdentity: { 'feed-identity|0xaaa|0xbbb': { feed: '0xfeed', aggregator: '0xagg', phaseId: '4' } },
+    });
+    const r = await verifyCanaryState(p);
+    assert.equal(r.feedsPinned, 1);
+    assert.match(formatCanaryStateReport(r), /feed pins {3}1 aggregator identity remembered/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('summariseTransitions counts by status and lists what is not OK', () => {
   const s = summariseTransitions({
     a: { status: 'ok', since: 1 },


### PR DESCRIPTION
Closes the **on-chain half of G2** (OPS-3, aggregator-swap drift) — the gap the Monitoring Gap
Analysis ranks as the least-prepared incident and *"the only one where advance detection converts
directly into recoverable member capital"*, recorded as **undetected: weeks**.

Two things had landed against it — #92's `aggregatorPin` + `verify-chainlink-oracle.mjs --strict`,
and its `docs/INCIDENTS.md` §1a runbook entry — and both are the **off-chain** half. Nothing
continuous watched it: the verifier only runs when a human runs it.

## The finding that made this cheap: the cached value is observable on-chain

`ChainlinkOracle`'s constructor proves three things about every feed it lists — that it describes
itself as USD-quoted (`_requireUsdQuote`), that it reports 8 decimals, and that
`scale = 10**(18 - decimals)` is therefore right — then caches the result in an **immutable**
`feedOf` entry and never looks again. Chainlink swaps the aggregator behind an `EACAggregatorProxy`
as routine operation, and the proxy forwards `decimals()` / `description()` to whichever aggregator
is current. So the contract's proofs can silently stop being true, on a contract that cannot
re-check them.

The comparison that matters is **live-vs-cached, not live-vs-config** — and **both sides are
on-chain**. `feedOf(asset)` is a public mapping getter, and its `scale` field *is*
`10**(18 - feedDecimals)` as cached at construction:

```js
10n ** (18n - BigInt(feed.decimals())) === feedOf(asset).scale
```

**No pin, no env var, no config file, nothing that can go stale, and correct on the very first
sweep after a cold start** — which is the property that matters, because a swap that happened while
the canary was down must still be caught when it comes back. This is strictly stronger than #92's
`decimals() == 8` check, which compares against Chainlink's *convention* rather than against the
number the deployed oracle actually multiplies by. The denomination leg is the same shape: it
re-runs `_requireUsdQuote`'s own predicate against what the proxy reports now.

## What is now detected, and why nothing else could see it

Per basket asset, every sweep (`packages/canary/src/signals/feed-identity.mjs`):

1. live `decimals()` no longer implies the cached `scale` (including a value > 18, which no `scale`
   can express) → **ALERT**
2. `description()` no longer ends in `USD` as a whole word (separator rule included, so
   `"ETH / PYUSD"` still fails) → **ALERT**
3. the aggregator behind the proxy changed (`phaseId` / `aggregator`) → **ALERT, self-clearing**

**(1) and (2) are invisible to every other signal.** A mis-scaled feed is not stale, not frozen and
not out of band, so `oracle-freshness` reads OK — the price is served, it is just wrong. And
`nav-backing` recomputes NAV through the same `oracle.priceWad(asset)` the vault uses, so a uniform
mis-scale **cancels exactly on both sides of its comparison** and it stays silent through the whole
event. The vault is not frozen; it is transacting at a wrong price, which is worse. A test asserts
exactly this: a mis-scaled feed pages from `feed-identity` while `oracle-freshness` and
`nav-backing` both read healthy.

## Severity: the two findings are deliberately not calibrated the same

A swap is **routine and legitimate** — `phaseId` exists to count them. A `decimals()` change is not.

| Finding | Status | Behaviour |
|---|---|---|
| decimals vs cached scale | ALERT | **latches** — `feedOf` is immutable, no operator action repairs it |
| description no longer USD | ALERT | **latches**, same reason |
| aggregator swapped, harm legs clean | ALERT | **clears itself next sweep**, because the runner re-pins |

**The self-clear is the calibration, not a softening.** Latching a benign swap parks a permanent
not-OK row in `tracker.unhealthy()`, the heartbeat summary and `ops-check`, with nothing that clears
it — which IS the muting pressure `ORACLE_MIN_MARGIN` and `ORACLE_STALENESS_WARN_PCT` were both
calibrated against. The transition line is emitted durably either way.

**Alerting at all is safe here for a reason the flat staleness bar could not claim: frequency.** An
aggregator is swapped once or twice a *year* per feed, not dozens of times a day. The #89/#85
argument was about a bar firing on correct behaviour every heartbeat cycle; it does not transfer.

**The self-clear is GATED on the harm legs** — it only clears because decimals and denomination
passed against the *new* aggregator on the same sweep. Two adjacent tests pin that conjunction, in
order: a benign swap ALERTs once then RECOVERs; a swap that also moves decimals ALERTs and **stays**
alerting after the identical re-pin.

## The pin, and what was rejected

Only the identity leg needs memory, and it carries no harm on its own. Pinned **on first sight**
into `CANARY_STATE_PATH` (new `feedIdentity` key; a file written before it existed loads fine).

- **Rejected — the config's `aggregatorPin`:** `.dockerignore` excludes `contracts/` from the
  runtime image, so the canary cannot read it. Same finding that shaped
  `ORACLE_FEED_CADENCE_SECONDS`.
- **Rejected — a new env var:** hand-edited after every routine swap or it alerts forever. A
  standing alert needing a config deploy to silence is the strongest muting pressure there is, and
  it buys little, because **the harm legs do not depend on the pin at all**.
- **Chosen — first sight, in the canary's own state.** No config surface, no maintenance.

**Residual, stated in the signal's own message:** a benign swap during canary downtime is adopted
silently on restart and never narrated. #92's git-tracked pin is the half that survives a restart
("is this the aggregator we deployed against, ever"); this is the half that watches continuously.
Complementary, not redundant.

## Structure

Every branch that cannot measure is `DETECTOR BROKEN` and re-asserted on the doubling backoff. One
departure from `oracle-health.mjs`, argued in the file: all of them carry `minConsecutive: 3`,
because each is triggered by an `eth_call` coming back empty and one empty return is RPC noise while
three consecutive is the feed (#92 recorded observing exactly that burst against a live proxy on
2026-08-30). `oracle-health` needs no damping — its blind branch is structural, not a transient
read. **A first sighting reports immediately**, because the tracker never applies `minConsecutive`
to an id it has not seen: a monitor that has never once succeeded must not be indistinguishable
from silence. Both are pinned by adjacent tests.

Signal name is `feed-identity`, deliberately **not** `oracle-freshness`:
`scripts/soak/series-analysis.mjs` keys its freeze verdict off every id starting
`oracle-freshness|`, and identity rows do not belong inside the drill's freeze evidence.

Silent on a retired-aggregator deployment — no Chainlink proxy exists there to drift.

## Two defects caught in self-review

1. **`10n ** BigInt(18 - d)` throws a `RangeError` for `d > 18`** — and an aggregator reporting 18
   or 20 decimals is *precisely* the drift this signal is for. An escaping throw would have been
   converted by `collectSignals`'s wrapper into a generic "signal ERRORED" detector-broken: a live
   mispricing reported as a monitoring fault. Guarded and tested.
2. **The pin merge had to refuse incomplete observations** — Dev12's recorded bug verbatim,
   *"absent is the honest value"*. One sweep where `aggregator()` came back empty would have
   overwritten the anchor with a null and made the next real swap unnarratable. It now merges field
   by field and never writes an absent value over a present one.

## Gate

```
  pass             fmt        0.0s
  pass             syntax     0.2s
  pass             build      268.9s
  pass             opscheck   0.0s
  pass             backend    2.5s
  pass             test       9.7s
  pass             snapshot   9.2s
  pass             sizes      0.7s
  warn             slither    10.7s
GATE PASSED (302.2s) 1 advisory warning(s)
```

1 pre-existing advisory Slither warning, unchanged. **Zero `contracts/src/` bytes touched**
(`git diff --stat -- contracts/` is empty), so **no EIP-170 movement and no gas-snapshot
regeneration** — the `snapshot` and `sizes` steps passing untouched is the evidence.

`packages/canary` **185 → 226 tests (+41)**, none deleted, skipped or loosened. (The 8 cases that
previously reported *skipped* now run, because `contracts/out` was built — they are the
compiled-ABI cross-checks.)

## Docs, including ones I could not fix

Fixed: `docs/CANARY.md` §3(a) ended with *"Two things it still does not watch"*, naming feed
identity first — false as of this PR, so rewritten rather than left to be believed. New §3(g). §4
gains the new lines and states the damping rule. §5 corrects the sizing estimate. §6's test count
was already stale at 175 against 185 and is now 226.

Also fixed, and caught only by grepping for the **bare** signal names rather than the pipe-prefixed
transition keys: `packages/canary/README.md` — the package's own code map — listed six signals, said
"only three things set the DETECTOR BROKEN flag", and claimed 175 tests. Same class of drift, in the
file a future agent reads first. `scripts/status.mjs` (`npm run cc`) and `docs/NOW.md` were checked
in the same pass and enumerate no signals.

**Not fixed, and owned by #92, which is open** — reported rather than edited (SWARM §1/§4):

- #92's commit message says it rewrote `docs/DEPLOYMENT.md` to *"name the gap that actually remains:
  feed IDENTITY … and is not built."* **That sentence is false as of this PR, and `merge-tree` will
  show no conflict** — the identical failure mode #92's own adversarial review caught on #89.
- #92's new `docs/INCIDENTS.md` §1a and `docs/LAUNCH-READINESS.md` row 14 (neither exists on
  `protocol/main` yet) should gain a line saying the canary now watches this continuously.
- `docs/DEPLOYMENT.md` §7's signal table on `main` lists six signals and does not know about the
  seventh — and **two other files point at it as the canonical list**: `docs/CANARY.md`'s own opening
  line and `docs/RUNTIME.md:44` both say the canary is the runnable form of "the signal table in
  DEPLOYMENT.md §6", so those pointers go stale with it.

**Whichever of #92 and this lands second must reconcile those places by hand.**

**One behaviour worth knowing before the first live incident, and not a defect:** a *totally* dead
feed contract — one reverting `decimals()` and `description()` as well as `latestRoundData()` —
produces a `feed-identity` DETECTOR BROKEN line **alongside** the `oracle-freshness` freeze ALERT.
Two lines, one root cause. Honest (the identity detector genuinely cannot run) and damped by
`minConsecutive: 3`, but not in the fixtures — `feedReverts` only kills `latestRoundData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
