### PR TITLE
feat(indexer): index exit-queue, escrow, fee and governance events (data-analytics build list 1-3)

### DIFF
--- a/packages/indexer/src/abis.mjs
+++ b/packages/indexer/src/abis.mjs
@@ -108,7 +108,18 @@ export function allEventFragments() {
   return Object.values(CONTRACT_ABIS).flat();
 }
 
+/**
+ * The canonical type string for one ABI input, expanding a `tuple` (struct) to its parenthesized
+ * component list — `tuple` alone would let e.g. a reordered or retyped `GovConfig` field pass the
+ * drift test silently, since every struct's bare JSON `type` is just the string "tuple".
+ * @param {{type:string, components?:Array<{type:string, components?:any}>}} input
+ */
+export function typeOf(input) {
+  if (input.type === 'tuple' && input.components) return `(${input.components.map(typeOf).join(',')})`;
+  return input.type;
+}
+
 /** Canonical `name(type,type,...)` signature for an event fragment (for drift comparison). */
 export function eventSignature(fragment) {
-  return `${fragment.name}(${fragment.inputs.map((i) => i.type).join(',')})`;
+  return `${fragment.name}(${fragment.inputs.map(typeOf).join(',')})`;
 }

--- a/packages/indexer/src/abis.mjs
+++ b/packages/indexer/src/abis.mjs
@@ -12,16 +12,22 @@
  * signature change breaks that test instead of silently producing wrong logs at runtime.
  *
  * Grouped by the on-chain source that emits them:
- *   - `factory`, `operatorRegistry`, `subvaultRegistry`, `governance` are SINGLETONS (one address).
+ *   - `factory`, `operatorRegistry`, `subvaultRegistry`, `governance`, `feeEngine` are SINGLETONS
+ *     (one address each — see config in index-runner.mjs / rpc.mjs).
  *   - `vault` events are emitted by every VaultCore instance — a dynamic address set the runner
  *     discovers from VaultCreated logs (see rpc.mjs).
+ *   - `adapter` events (`SwapExecuted`) are emitted by every execution-adapter instance — a dynamic
+ *     address set discovered from VaultCore's own `RebalanceExecuted(adapter, orderCount)`, the
+ *     same "learn an address from an event, then poll it" shape as vault discovery, one hop deeper
+ *     (adapters are per-vault allowlisted at vault construction, not announced by a singleton).
  */
 
-/** @typedef {{type:'event', name:string, anonymous:boolean, inputs:Array<{name:string,type:string,indexed:boolean}>}} AbiEvent */
+/** @typedef {{type:'event', name:string, anonymous:boolean, inputs:Array<{name:string,type:string,indexed:boolean}|{name:string,type:'tuple',indexed:boolean,components:Array<{name:string,type:string}>}>}} AbiEvent */
 
 const ev = (name, inputs) => ({ type: 'event', name, anonymous: false, inputs });
 const addr = (name, indexed = false) => ({ name, type: 'address', indexed });
 const u256 = (name, indexed = false) => ({ name, type: 'uint256', indexed });
+const bytes32 = (name, indexed = false) => ({ name, type: 'bytes32', indexed });
 
 /** @type {Record<string, AbiEvent[]>} */
 export const CONTRACT_ABIS = Object.freeze({
@@ -41,11 +47,28 @@ export const CONTRACT_ABIS = Object.freeze({
     ev('ChildRegistered', [addr('parent', true), addr('child', true), u256('depth')]),
   ],
   governance: [
+    // GovConfig, verbatim from Governance.sol's struct (uint32 commitDuration, revealDuration,
+    // timelockDuration, executionWindow; uint16 quorumBps, proposalThresholdBps,
+    // concentrationCapBps; uint32 proposalCooldown). Non-indexed struct arg — viem decodes tuples.
+    ev('VaultRegistered', [addr('vault', true), {
+      name: 'config', type: 'tuple', indexed: false,
+      components: [
+        { name: 'commitDuration', type: 'uint32' },
+        { name: 'revealDuration', type: 'uint32' },
+        { name: 'timelockDuration', type: 'uint32' },
+        { name: 'executionWindow', type: 'uint32' },
+        { name: 'quorumBps', type: 'uint16' },
+        { name: 'proposalThresholdBps', type: 'uint16' },
+        { name: 'concentrationCapBps', type: 'uint16' },
+        { name: 'proposalCooldown', type: 'uint32' },
+      ],
+    }]),
     ev('Proposed', [
       u256('pid', true), addr('vault', true),
       { name: 'ptype', type: 'uint8', indexed: false }, addr('proposer', true),
       { name: 'actionHash', type: 'bytes32', indexed: false },
     ]),
+    ev('Committed', [u256('pid', true), addr('voter', true)]),
     ev('Revealed', [u256('pid', true), addr('voter', true), { name: 'support', type: 'bool', indexed: false }, u256('weight')]),
     ev('DefaultApplied', [u256('pid', true), addr('member', true), { name: 'support', type: 'bool', indexed: false }, u256('weight')]),
     ev('DelegatedRevealed', [u256('pid', true), addr('delegator', true), addr('delegate', true), u256('weight')]),
@@ -53,16 +76,32 @@ export const CONTRACT_ABIS = Object.freeze({
     ev('Executed', [u256('pid', true)]),
     ev('ProposalExpired', [u256('pid', true)]),
   ],
+  feeEngine: [
+    ev('FeeAssessed', [addr('vault', true), addr('member', true), u256('netGain'), u256('fee')]),
+    ev('FeeCredited', [u256('opId', true), addr('token', true), u256('amount')]),
+    ev('FeesClaimed', [addr('operator', true), addr('token', true), u256('amount')]),
+  ],
   vault: [
     ev('DepositActivated', [addr('member', true), u256('amountUsdc'), u256('sharesMinted')]),
     ev('DepositPending', [addr('member', true), u256('amountUsdc'), { name: 'availableAt', type: 'uint64', indexed: false }]),
     ev('PendingCancelled', [addr('member', true), u256('amountUsdc')]),
+    ev('ExitQueued', [addr('member', true), u256('shares')]),
     ev('ExitSettled', [addr('member', true), u256('sharesBurned'), u256('usdcPaid'), u256('exitFeeBps'), u256('perfFeeUsdc')]),
+    ev('SliceEscrowed', [addr('member', true), addr('asset', true), u256('amount')]),
+    ev('EscrowClaimed', [addr('member', true), addr('asset', true), u256('amount')]),
+    ev('ModuleCallFailed', [bytes32('module', true), addr('member', true)]),
+    ev('RebalanceExecuted', [addr('adapter', true), u256('orderCount')]),
+  ],
+  // Dynamic address set — discovered from `RebalanceExecuted.adapter`, not a singleton or a
+  // factory-announced set. See rpc.mjs's adapter-discovery loop and projections.mjs's
+  // `state.adapters`.
+  adapter: [
+    ev('SwapExecuted', [addr('vault', true), addr('tokenIn'), addr('tokenOut'), u256('amountIn'), u256('amountOut')]),
   ],
 });
 
-/** Which config label supplies each singleton contract's address. `vault` is dynamic (not here). */
-export const SINGLETON_LABELS = Object.freeze(['factory', 'operatorRegistry', 'subvaultRegistry', 'governance']);
+/** Which config label supplies each singleton contract's address. `vault` and `adapter` are dynamic (not here). */
+export const SINGLETON_LABELS = Object.freeze(['factory', 'operatorRegistry', 'subvaultRegistry', 'governance', 'feeEngine']);
 
 /** Every event fragment, flattened — used by the drift test and by callers that want a union. */
 export function allEventFragments() {

--- a/packages/indexer/src/index-runner.mjs
+++ b/packages/indexer/src/index-runner.mjs
@@ -11,6 +11,9 @@
  *   SUBVAULT_REGISTRY_ADDRESS  SubVaultRegistry
  *   GOVERNANCE_ADDRESS         Governance
  * Optional env:
+ *   FEE_ENGINE_ADDRESS  FeeEngine — enables FeeAssessed/FeeCredited/FeesClaimed indexing when set;
+ *                        omitted deployments simply skip that singleton group (SINGLETON_LABELS
+ *                        loop in rpc.mjs already treats every label as optional).
  *   CHAIN_ID (8453)  CHAIN_NAME (base)  START_BLOCK (0)  STATE_PATH (./data/indexer-state.json)
  *   CONFIRMATIONS (5)  BATCH_BLOCKS (2000)  POLL_INTERVAL_MS (12000)
  *   SNAPSHOT_BACKUPS (3)  SNAPSHOT_BACKUP_INTERVAL_MS (300000)
@@ -52,6 +55,11 @@ export function resolveIndexerConfig(env) {
   for (const [label, a] of Object.entries(addresses)) {
     if (!isAddr(a)) throw new Error(`indexer: ${label} is not a 20-byte address: ${a}`);
   }
+  // Optional: unset means "don't index FeeEngine events yet", not a config error.
+  if (env.FEE_ENGINE_ADDRESS) {
+    if (!isAddr(env.FEE_ENGINE_ADDRESS)) throw new Error(`indexer: feeEngine is not a 20-byte address: ${env.FEE_ENGINE_ADDRESS}`);
+    addresses.feeEngine = env.FEE_ENGINE_ADDRESS;
+  }
   const statePath = env.STATE_PATH || './data/indexer-state.json';
   const pollIntervalMs = num('POLL_INTERVAL_MS', 12_000);
   return {
@@ -80,14 +88,16 @@ export function resolveIndexerConfig(env) {
 export async function buildIndexer(cfg, { log, logger = loggerFromEnv('indexer'), client } = {}) {
   const line = log ?? logger.text('indexer.progress');
 
-  // Load once to discover already-known vaults, so VaultCore events keep indexing across restarts.
+  // Load once to discover already-known vaults (and adapters), so VaultCore / adapter events keep
+  // indexing across restarts without re-seeing their discovery event.
   const resumed = await loadSnapshot(cfg.statePath);
   const knownVaults = [...resumed.vaults.keys()];
+  const knownAdapters = [...resumed.adapters];
 
   const source = createChainSource({
     client, // tests inject a fake viem client; production builds one from rpcUrl
     rpcUrl: cfg.rpcUrl, chainId: cfg.chainId, chainName: cfg.chainName,
-    addresses: cfg.addresses, knownVaults,
+    addresses: cfg.addresses, knownVaults, knownAdapters,
   });
 
   const writer = createSnapshotWriter({

--- a/packages/indexer/src/projections.mjs
+++ b/packages/indexer/src/projections.mjs
@@ -26,6 +26,8 @@
  * @property {bigint} capacityCapUsdc
  * @property {string|null} parent        // sub-vault parent, or null for a root
  * @property {number} depth
+ * @property {number} exitQueuedCount    // ExitQueued occurrences (Mode-F entries)
+ * @property {number} exitSettledCount   // ExitSettled occurrences (all settled exits, Mode-F + Mode-I)
  */
 
 /**
@@ -59,7 +61,34 @@ export const HANDLED_EVENTS = Object.freeze([
   'RealizationRecorded', 'FeeRecorded', 'DepositPending', 'PendingCancelled',
   'DepositActivated', 'ExitSettled', 'Proposed', 'Revealed', 'DefaultApplied',
   'DelegatedRevealed', 'Finalized', 'Executed', 'ProposalExpired',
+  // Mode-F exit queue, in-kind escrow, module-call failures and rebalance execution counts
+  // (data-analytics build-order #1 — packages/indexer/src/abis.mjs is the source of these).
+  'ExitQueued', 'SliceEscrowed', 'EscrowClaimed', 'ModuleCallFailed', 'RebalanceExecuted',
+  // FeeEngine per-token fee accrual + Governance quorum context / reveal drop-off (build-order #2).
+  'FeeAssessed', 'FeeCredited', 'FeesClaimed', 'VaultRegistered', 'Committed',
+  // Execution-adapter fills (build-order #3).
+  'SwapExecuted',
 ]);
+
+/**
+ * Events tracked only as a count + last-seen marker (§ build-order #1/#2/#3): no bespoke reducer
+ * exists for these yet (that is the bigger Postgres-substrate work in the vault note's build order
+ * items 4+). Folding them here at least means they are not silently dropped — `state.eventStats`
+ * answers "has this event ever fired, how many times, as of which block" for every one of them.
+ */
+const STAT_ONLY_EVENTS = Object.freeze([
+  'ExitQueued', 'SliceEscrowed', 'EscrowClaimed', 'ModuleCallFailed', 'RebalanceExecuted',
+  'FeeAssessed', 'FeeCredited', 'FeesClaimed', 'VaultRegistered', 'Committed', 'SwapExecuted',
+]);
+const STAT_ONLY_EVENT_SET = new Set(STAT_ONLY_EVENTS);
+
+function bumpEventStat(state, e) {
+  const s = state.eventStats.get(e.name) ?? { count: 0, lastBlock: 0, lastLogIndex: -1 };
+  s.count += 1;
+  s.lastBlock = e.blockNumber;
+  s.lastLogIndex = e.logIndex;
+  state.eventStats.set(e.name, s);
+}
 
 export function emptyState() {
   return {
@@ -68,6 +97,9 @@ export function emptyState() {
     /** @type {Map<string, Map<string, bigint>>} */ shares: new Map(), // vault -> member -> shares
     /** @type {Map<number, ProposalState>} */ proposals: new Map(), // pid -> proposal
     /** @type {Map<string, number>} */ activeProposal: new Map(), // vault -> pid (0 = none)
+    /** @type {Map<string, {count:number, lastBlock:number, lastLogIndex:number}>} */
+    eventStats: new Map(), // event name -> occurrence count + last-seen cursor (STAT_ONLY_EVENTS)
+    /** @type {Set<string>} */ adapters: new Set(), // execution-adapter addresses, learned from RebalanceExecuted
     lastBlock: 0,
     lastLogIndex: -1,
   };
@@ -92,6 +124,8 @@ function ensureVault(state, vault) {
       capacityCapUsdc: 0n,
       parent: null,
       depth: 0,
+      exitQueuedCount: 0,
+      exitSettledCount: 0,
     };
     state.vaults.set(vault, v);
   }
@@ -127,6 +161,7 @@ function creditShares(state, vault, member, delta) {
  */
 export function apply(state, e) {
   const a = e.args ?? {};
+  if (STAT_ONLY_EVENT_SET.has(e.name)) bumpEventStat(state, e);
   switch (e.name) {
     case 'VaultCreated': {
       const v = ensureVault(state, e.args.vault);
@@ -191,8 +226,17 @@ export function apply(state, e) {
       // idle tracking is approximate off events; authoritative NAV comes from a chain read.
       break;
     }
+    case 'ExitQueued':
+      ensureVault(state, e.vault).exitQueuedCount += 1;
+      break;
     case 'ExitSettled':
+      ensureVault(state, e.vault).exitSettledCount += 1;
       creditShares(state, e.vault, a.member, -big(a.sharesBurned));
+      break;
+    case 'RebalanceExecuted':
+      // Learns the adapter's address so the chain source can poll it for SwapExecuted the same
+      // way it learns a vault's address from VaultCreated (see rpc.mjs).
+      if (a.adapter) state.adapters.add(a.adapter);
       break;
     case 'Proposed': {
       const pid = Number(a.pid);
@@ -314,6 +358,25 @@ export function listVaults(state) {
     capacityCapUsdc: v.capacityCapUsdc,
     attested: v.operatorId !== 0, // operatorId 0 = unattested (scam-quarantine signal)
   }));
+}
+
+/**
+ * Approximate Mode-F exit rate for a vault: `ExitQueued` occurrences over `ExitSettled`
+ * occurrences (counts, not value — matches the vault note's "exits, NOT value" framing).
+ *
+ * This is a first-order signal, not the exact per-member discriminator from the data-analytics
+ * build note (§3.6): the precise rule is "an ExitSettled is Mode-F iff that (vault, member) has an
+ * ExitQueued with no intervening ExitSettled," which needs a per-member exit ledger (the
+ * `exit_event` table in the note's build order item 4+, on the Postgres substrate). Two counts
+ * over the vault's whole history is the natural small addition available from the existing
+ * scalar-fold shape; it will over- or under-count relative to the exact ledger whenever queued
+ * exits settle out of order across members. Returns null when the vault is unknown or has no
+ * settled exits yet (undefined rate, not zero).
+ */
+export function modeFExitRate(state, vault) {
+  const v = state.vaults.get(vault);
+  if (!v || v.exitSettledCount === 0) return null;
+  return v.exitQueuedCount / v.exitSettledCount;
 }
 
 /** A member's share position in a vault (0 if none). */

--- a/packages/indexer/src/projections.mjs
+++ b/packages/indexer/src/projections.mjs
@@ -361,8 +361,12 @@ export function listVaults(state) {
 }
 
 /**
- * Approximate Mode-F exit rate for a vault: `ExitQueued` occurrences over `ExitSettled`
- * occurrences (counts, not value — matches the vault note's "exits, NOT value" framing).
+ * Approximate Mode-F exit rate for a vault, in integer basis points of `ExitQueued` occurrences
+ * over `ExitSettled` occurrences (counts, not value — matches the vault note's "exits, NOT value"
+ * framing and its own field name, `mode_f_exit_rate_bps`, §4.2). Bps rather than a float ratio to
+ * match the repo's existing convention for a counts-over-counts fraction (see `shareOfVaultBps` in
+ * `memberPosition`, right below) and because §4.4's public-field lint permits `_bps` only for
+ * exactly this shape.
  *
  * This is a first-order signal, not the exact per-member discriminator from the data-analytics
  * build note (§3.6): the precise rule is "an ExitSettled is Mode-F iff that (vault, member) has an
@@ -370,13 +374,19 @@ export function listVaults(state) {
  * `exit_event` table in the note's build order item 4+, on the Postgres substrate). Two counts
  * over the vault's whole history is the natural small addition available from the existing
  * scalar-fold shape; it will over- or under-count relative to the exact ledger whenever queued
- * exits settle out of order across members. Returns null when the vault is unknown or has no
- * settled exits yet (undefined rate, not zero).
+ * exits settle out of order across members.
+ *
+ * Can legitimately exceed 10000 bps (100%) when more exits have been queued than have settled —
+ * e.g. 3 queued, 1 settled, a stranded-queue situation (§3.6) — since it divides two independent
+ * lifetime counters, not a partition of one total. That is a real signal (a backlog of unsettled
+ * Mode-F exits), not a bug; do not clamp it.
+ *
+ * Returns null when the vault is unknown or has no settled exits yet (undefined rate, not zero).
  */
-export function modeFExitRate(state, vault) {
+export function modeFExitRateBps(state, vault) {
   const v = state.vaults.get(vault);
   if (!v || v.exitSettledCount === 0) return null;
-  return v.exitQueuedCount / v.exitSettledCount;
+  return Math.round((v.exitQueuedCount * 10000) / v.exitSettledCount);
 }
 
 /** A member's share position in a vault (0 if none). */

--- a/packages/indexer/src/rpc.mjs
+++ b/packages/indexer/src/rpc.mjs
@@ -24,13 +24,15 @@ const lc = (a) => (typeof a === 'string' ? a.toLowerCase() : a);
  * @param {string} [cfg.rpcUrl]         HTTP RPC endpoint (required when no client is injected)
  * @param {number} [cfg.chainId]        chain id for the viem client (e.g. 8453 Base, 84532 Base Sepolia)
  * @param {string} [cfg.chainName]
- * @param {{factory?:string, operatorRegistry?:string, subvaultRegistry?:string, governance?:string}} cfg.addresses
- * @param {Iterable<string>} [cfg.knownVaults]  vault addresses already known (seed from resumed state)
+ * @param {{factory?:string, operatorRegistry?:string, subvaultRegistry?:string, governance?:string, feeEngine?:string}} cfg.addresses
+ * @param {Iterable<string>} [cfg.knownVaults]    vault addresses already known (seed from resumed state)
+ * @param {Iterable<string>} [cfg.knownAdapters]  execution-adapter addresses already known (seed from resumed state)
  */
-export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 'base', addresses, knownVaults = [] }) {
+export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 'base', addresses, knownVaults = [], knownAdapters = [] }) {
   const addr = {};
   for (const label of SINGLETON_LABELS) if (addresses?.[label]) addr[label] = lc(addresses[label]);
   const vaults = new Set([...knownVaults].filter((v) => ADDRESS_RE.test(v)).map(lc));
+  const adapters = new Set([...knownAdapters].filter((a) => ADDRESS_RE.test(a)).map(lc));
 
   let _client = client ?? null;
   async function getClient() {
@@ -65,7 +67,9 @@ export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 
   /**
    * NORMALIZED events for [from, to], globally sorted by (blockNumber, logIndex). Discovers new
    * vaults from VaultCreated in this same range before polling VaultCore events, so a vault
-   * created and used within one batch is captured.
+   * created and used within one batch is captured. Adapters are discovered one hop further in:
+   * from each VaultCore's own RebalanceExecuted(adapter, orderCount), so an adapter used for the
+   * first time in this same range still has its SwapExecuted fills picked up in this batch.
    * @returns {Promise<import('./projections.mjs').Event[]>}
    */
   async function fetchEvents(from, to) {
@@ -83,7 +87,15 @@ export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 
 
     if (vaults.size > 0) {
       const vaultEvts = await logsFor(c, [...vaults], CONTRACT_ABIS.vault, from, to);
+      for (const e of vaultEvts) {
+        if (e.name === 'RebalanceExecuted' && ADDRESS_RE.test(e.args?.adapter)) adapters.add(lc(e.args.adapter));
+      }
       out.push(...vaultEvts);
+    }
+
+    if (adapters.size > 0) {
+      const adapterEvts = await logsFor(c, [...adapters], CONTRACT_ABIS.adapter, from, to);
+      out.push(...adapterEvts);
     }
 
     return sortEvents(out);
@@ -94,5 +106,7 @@ export function createChainSource({ client, rpcUrl, chainId = 8453, chainName = 
     fetchEvents,
     /** The live known-vault set (grows as VaultCreated logs are seen). */
     get knownVaults() { return new Set(vaults); },
+    /** The live known-adapter set (grows as RebalanceExecuted logs are seen). */
+    get knownAdapters() { return new Set(adapters); },
   };
 }

--- a/packages/indexer/src/store.mjs
+++ b/packages/indexer/src/store.mjs
@@ -43,6 +43,8 @@ export function serializeState(state) {
     shares: mapEntries(state.shares, (book) => mapEntries(book, (b) => b.toString())),
     proposals: mapEntries(state.proposals, prop),
     activeProposal: mapEntries(state.activeProposal),
+    eventStats: mapEntries(state.eventStats),
+    adapters: [...state.adapters],
   };
 }
 
@@ -80,6 +82,10 @@ export function deserializeState(obj) {
     });
   }
   for (const [k, pid] of obj.activeProposal) s.activeProposal.set(k, pid);
+  // Both absent on a snapshot written before these fields existed — default to empty rather than
+  // throwing, so an older snapshot still resumes cleanly (only these two collections were added).
+  for (const [k, stat] of obj.eventStats ?? []) s.eventStats.set(k, stat);
+  for (const a of obj.adapters ?? []) s.adapters.add(a);
   return s;
 }
 
@@ -179,6 +185,7 @@ export function countState(state) {
     shareBooks: state.shares.size,
     holders,
     activeProposals: state.activeProposal.size,
+    adapters: state.adapters.size,
   };
 }
 
@@ -209,7 +216,7 @@ export function formatSnapshotReport(report) {
     const c = report.counts;
     lines.push(`snapshot ${report.path}: OK`);
     lines.push(`  cursor      lastBlock=${report.lastBlock} lastLogIndex=${report.lastLogIndex} → resumes from block ${report.resumeFrom}`);
-    lines.push(`  counts      vaults=${c.vaults} operators=${c.operators} proposals=${c.proposals} shareBooks=${c.shareBooks} holders=${c.holders} activeProposals=${c.activeProposals}`);
+    lines.push(`  counts      vaults=${c.vaults} operators=${c.operators} proposals=${c.proposals} shareBooks=${c.shareBooks} holders=${c.holders} activeProposals=${c.activeProposals} adapters=${c.adapters}`);
     lines.push(`  file        ${report.bytes} bytes, written ${report.mtime} (${report.ageSec}s ago)`);
   }
   if (report.backups.length === 0) {

--- a/packages/indexer/test/abis.test.mjs
+++ b/packages/indexer/test/abis.test.mjs
@@ -26,6 +26,9 @@ function compiledEventSignatures() {
     'OperatorRegistry.sol/OperatorRegistry.json',
     'SubVaultRegistry.sol/SubVaultRegistry.json',
     'VaultFactory.sol/VaultFactory.json',
+    'FeeEngine.sol/FeeEngine.json',
+    'AggregationRouterAdapter.sol/AggregationRouterAdapter.json',
+    'DirectPoolAdapter.sol/DirectPoolAdapter.json',
   ];
   /** @type {Map<string, Set<string>>} */
   const sigs = new Map();

--- a/packages/indexer/test/abis.test.mjs
+++ b/packages/indexer/test/abis.test.mjs
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { CONTRACT_ABIS, allEventFragments, eventSignature } from '../src/abis.mjs';
+import { CONTRACT_ABIS, allEventFragments, eventSignature, typeOf } from '../src/abis.mjs';
 import { HANDLED_EVENTS } from '../src/projections.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -38,7 +38,11 @@ function compiledEventSignatures() {
     const abi = JSON.parse(readFileSync(p, 'utf8')).abi ?? [];
     for (const item of abi) {
       if (item.type !== 'event') continue;
-      const sig = `${item.name}(${item.inputs.map((i) => i.type).join(',')})`;
+      // Foundry's ABI JSON gives a struct input the bare `type: "tuple"` too, with the real shape
+      // in `components` — expand it the same way abis.mjs's eventSignature() does, so a reordered
+      // or retyped struct field (e.g. Governance.GovConfig) actually fails this test instead of
+      // both sides silently agreeing on the string "tuple".
+      const sig = `${item.name}(${item.inputs.map(typeOf).join(',')})`;
       if (!sigs.has(item.name)) sigs.set(item.name, new Set());
       sigs.get(item.name).add(sig);
     }

--- a/packages/indexer/test/event-coverage.test.mjs
+++ b/packages/indexer/test/event-coverage.test.mjs
@@ -25,6 +25,9 @@ function contractEvents() {
     'OperatorRegistry.sol/OperatorRegistry.json',
     'SubVaultRegistry.sol/SubVaultRegistry.json',
     'VaultFactory.sol/VaultFactory.json',
+    'FeeEngine.sol/FeeEngine.json',
+    'AggregationRouterAdapter.sol/AggregationRouterAdapter.json',
+    'DirectPoolAdapter.sol/DirectPoolAdapter.json',
   ];
   const names = new Set();
   for (const rel of contracts) {

--- a/packages/indexer/test/projections.test.mjs
+++ b/packages/indexer/test/projections.test.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { applyAll, leaderboard, vaultView, emptyState, apply, memberPosition, modeFExitRate } from '../src/projections.mjs';
+import { applyAll, leaderboard, vaultView, emptyState, apply, memberPosition, modeFExitRateBps } from '../src/projections.mjs';
 
 const V = '0x' + '1'.repeat(40);
 const A = '0x' + 'a'.repeat(40);
@@ -145,7 +145,7 @@ test('standing default counts in tally but not quorum (revealedWeight)', () => {
   assert.equal(p.revealedWeight, 500n, 'default NOT in quorum');
 });
 
-test('ExitQueued + ExitSettled counts drive an approximate modeFExitRate', () => {
+test('ExitQueued + ExitSettled counts drive an approximate modeFExitRateBps', () => {
   const s = applyAll([
     ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 100n }),
     ev('ExitQueued', 2, 0, V, { member: A, shares: 100n }),
@@ -153,14 +153,25 @@ test('ExitQueued + ExitSettled counts drive an approximate modeFExitRate', () =>
   ]);
   assert.equal(vaultView(s, V).exitQueuedCount, 1);
   assert.equal(vaultView(s, V).exitSettledCount, 1);
-  assert.equal(modeFExitRate(s, V), 1);
+  assert.equal(modeFExitRateBps(s, V), 10000, 'one queued, one settled == 100%');
 });
 
-test('modeFExitRate is null for an unknown vault or a vault with no settled exits', () => {
+test('modeFExitRateBps is null for an unknown vault or a vault with no settled exits', () => {
   const unknown = '0x' + '9'.repeat(40);
   const s = applyAll([ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 100n })]);
-  assert.equal(modeFExitRate(s, unknown), null);
-  assert.equal(modeFExitRate(s, V), null, 'no ExitSettled yet');
+  assert.equal(modeFExitRateBps(s, unknown), null);
+  assert.equal(modeFExitRateBps(s, V), null, 'no ExitSettled yet');
+});
+
+test('modeFExitRateBps can exceed 10000 (a stranded-queue backlog), and is not clamped', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 300n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 100n }),
+    ev('ExitQueued', 3, 0, V, { member: A, shares: 100n }),
+    ev('ExitQueued', 4, 0, V, { member: A, shares: 100n }),
+    ev('ExitSettled', 5, 0, V, { member: A, sharesBurned: 100n }),
+  ]);
+  assert.equal(modeFExitRateBps(s, V), 30000, '3 queued over 1 settled == 300%, not clamped');
 });
 
 test('stat-only events (SliceEscrowed, EscrowClaimed, ModuleCallFailed, FeeAssessed, FeeCredited, '

--- a/packages/indexer/test/projections.test.mjs
+++ b/packages/indexer/test/projections.test.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { applyAll, leaderboard, vaultView, emptyState, apply, memberPosition } from '../src/projections.mjs';
+import { applyAll, leaderboard, vaultView, emptyState, apply, memberPosition, modeFExitRate } from '../src/projections.mjs';
 
 const V = '0x' + '1'.repeat(40);
 const A = '0x' + 'a'.repeat(40);
@@ -143,6 +143,59 @@ test('standing default counts in tally but not quorum (revealedWeight)', () => {
   const p = s.proposals.get(2);
   assert.equal(p.forWeight, 900n, 'default in tally');
   assert.equal(p.revealedWeight, 500n, 'default NOT in quorum');
+});
+
+test('ExitQueued + ExitSettled counts drive an approximate modeFExitRate', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 100n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 100n }),
+    ev('ExitSettled', 3, 0, V, { member: A, sharesBurned: 100n }),
+  ]);
+  assert.equal(vaultView(s, V).exitQueuedCount, 1);
+  assert.equal(vaultView(s, V).exitSettledCount, 1);
+  assert.equal(modeFExitRate(s, V), 1);
+});
+
+test('modeFExitRate is null for an unknown vault or a vault with no settled exits', () => {
+  const unknown = '0x' + '9'.repeat(40);
+  const s = applyAll([ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 100n })]);
+  assert.equal(modeFExitRate(s, unknown), null);
+  assert.equal(modeFExitRate(s, V), null, 'no ExitSettled yet');
+});
+
+test('stat-only events (SliceEscrowed, EscrowClaimed, ModuleCallFailed, FeeAssessed, FeeCredited, '
+  + 'FeesClaimed, VaultRegistered, Committed, SwapExecuted) are counted with a last-seen cursor, not dropped', () => {
+  const s = emptyState();
+  apply(s, ev('SliceEscrowed', 1, 0, V, { member: A, asset: '0x' + '3'.repeat(40), amount: 10n }));
+  apply(s, ev('SliceEscrowed', 2, 0, V, { member: A, asset: '0x' + '3'.repeat(40), amount: 5n }));
+  apply(s, ev('EscrowClaimed', 3, 0, V, { member: A, asset: '0x' + '3'.repeat(40), amount: 10n }));
+  apply(s, ev('ModuleCallFailed', 4, 0, V, { module: '0x' + '0'.repeat(64), member: A }));
+  apply(s, ev('FeeAssessed', 5, 0, V, { member: A, netGain: 100n, fee: 10n }));
+  apply(s, ev('FeeCredited', 6, 0, V, { opId: 1, token: A, amount: 10n }));
+  apply(s, ev('FeesClaimed', 7, 0, V, { operator: A, token: A, amount: 10n }));
+  apply(s, ev('VaultRegistered', 8, 0, V, {
+    config: { commitDuration: 3600, revealDuration: 3600, timelockDuration: 0, executionWindow: 3600, quorumBps: 2500, proposalThresholdBps: 0, concentrationCapBps: 5000, proposalCooldown: 0 },
+  }));
+  apply(s, ev('Committed', 9, 0, V, { pid: 1, voter: A }));
+  apply(s, ev('SwapExecuted', 10, 0, V, { tokenIn: A, tokenOut: B, amountIn: 100n, amountOut: 99n }));
+
+  assert.equal(s.eventStats.get('SliceEscrowed').count, 2);
+  assert.equal(s.eventStats.get('SliceEscrowed').lastBlock, 2);
+  assert.equal(s.eventStats.get('EscrowClaimed').count, 1);
+  assert.equal(s.eventStats.get('ModuleCallFailed').count, 1);
+  assert.equal(s.eventStats.get('FeeAssessed').count, 1);
+  assert.equal(s.eventStats.get('FeeCredited').count, 1);
+  assert.equal(s.eventStats.get('FeesClaimed').count, 1);
+  assert.equal(s.eventStats.get('VaultRegistered').count, 1);
+  assert.equal(s.eventStats.get('Committed').count, 1);
+  assert.equal(s.eventStats.get('SwapExecuted').lastLogIndex, 0);
+});
+
+test('RebalanceExecuted learns the adapter address into state.adapters', () => {
+  const ADAPTER = '0x' + '7'.repeat(40);
+  const s = applyAll([ev('RebalanceExecuted', 1, 0, V, { adapter: ADAPTER, orderCount: 3n })]);
+  assert.ok(s.adapters.has(ADAPTER));
+  assert.equal(s.eventStats.get('RebalanceExecuted').count, 1);
 });
 
 test('memberPosition reports shares and vault fraction', () => {

--- a/packages/indexer/test/rpc.test.mjs
+++ b/packages/indexer/test/rpc.test.mjs
@@ -20,7 +20,9 @@ const FACTORY = '0x' + 'f'.repeat(40);
 const OPREG = '0x' + 'e'.repeat(40);
 const SUBREG = '0x' + 'd'.repeat(40);
 const GOV = '0x' + 'c'.repeat(40);
+const FEE_ENGINE = '0x' + '9'.repeat(40);
 const ADDRESSES = { factory: FACTORY, operatorRegistry: OPREG, subvaultRegistry: SUBREG, governance: GOV };
+const ADDRESSES_WITH_FEE_ENGINE = { ...ADDRESSES, feeEngine: FEE_ENGINE };
 
 // A vault whose address has mixed case. viem gives us the checksummed form in decoded args and
 // the lowercased form as the emitting log.address — the two must collapse to ONE projection key.
@@ -108,6 +110,42 @@ test('folds through the daemon into a single, correct vault + leaderboard', asyn
   } finally {
     await rm(path, { force: true });
   }
+});
+
+test('feeEngine is an optional singleton: its events are only polled when an address is configured', async () => {
+  const feeLog = L(FEE_ENGINE, 'FeeAssessed', 5, 0, { vault: V_LOWER, member: MEMBER, netGain: 100n, fee: 10n });
+
+  const withoutFeeEngine = createChainSource({ client: fakeClient([feeLog], 20), addresses: ADDRESSES });
+  const eventsWithout = await withoutFeeEngine.fetchEvents(1, 20);
+  assert.ok(!eventsWithout.some((e) => e.name === 'FeeAssessed'), 'no feeEngine address configured — not polled');
+
+  const withFeeEngine = createChainSource({ client: fakeClient([feeLog], 20), addresses: ADDRESSES_WITH_FEE_ENGINE });
+  const eventsWith = await withFeeEngine.fetchEvents(1, 20);
+  assert.ok(eventsWith.some((e) => e.name === 'FeeAssessed'), 'feeEngine address configured — polled like any other singleton');
+});
+
+test('adapter discovery: an adapter used and swapped through in the SAME batch is fully captured', async () => {
+  const ADAPTER = '0x' + '7'.repeat(40);
+  const logs = [
+    ...fixture(),
+    L(V_LOWER, 'RebalanceExecuted', 14, 0, { adapter: ADAPTER, orderCount: 1n }),
+    L(ADAPTER, 'SwapExecuted', 14, 1, { vault: V_LOWER, tokenIn: ('0x' + '4'.repeat(40)), tokenOut: ('0x' + '5'.repeat(40)), amountIn: 100n, amountOut: 99n }),
+  ];
+  const src = createChainSource({ client: fakeClient(logs, 20), addresses: ADDRESSES });
+  const events = await src.fetchEvents(1, 20);
+
+  assert.ok(events.some((e) => e.name === 'RebalanceExecuted' && e.args.adapter === ADAPTER));
+  assert.ok(events.some((e) => e.name === 'SwapExecuted' && e.vault === V_LOWER), 'adapter learned from RebalanceExecuted, then polled in the same batch');
+  assert.deepEqual([...src.knownAdapters], [ADAPTER]);
+});
+
+test('adapter resume seeding: SwapExecuted indexes even with no RebalanceExecuted in the current range', async () => {
+  const ADAPTER = '0x' + '8'.repeat(40);
+  const laterLogs = [L(ADAPTER, 'SwapExecuted', 30, 0, { vault: V_LOWER, tokenIn: ('0x' + '4'.repeat(40)), tokenOut: ('0x' + '5'.repeat(40)), amountIn: 1n, amountOut: 1n })];
+  const src = createChainSource({ client: fakeClient(laterLogs, 40), addresses: ADDRESSES, knownAdapters: [ADAPTER] });
+  const events = await src.fetchEvents(25, 35);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].name, 'SwapExecuted');
 });
 
 test('resume seeding: VaultCore events index even with no VaultCreated in the current range', async () => {

--- a/packages/indexer/test/store.test.mjs
+++ b/packages/indexer/test/store.test.mjs
@@ -39,6 +39,32 @@ test('serialize → deserialize is a faithful round-trip (bigints + Maps preserv
   assert.equal(back.shares.get(V).get(A), 100n * 10n ** 12n);
 });
 
+test('serialize → deserialize round-trips eventStats and adapters', () => {
+  const ADAPTER = '0x' + '7'.repeat(40);
+  const events = [
+    ev('VaultCreated', 1, 0, V, { creator: A, usdc: A, capacityCapUsdc: 1n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 10n }),
+    ev('RebalanceExecuted', 3, 0, V, { adapter: ADAPTER, orderCount: 1n }),
+  ];
+  const built = applyAll(events);
+  const back = deserializeState(JSON.parse(JSON.stringify(serializeState(built))));
+  assert.equal(back.eventStats.get('ExitQueued').count, 1);
+  assert.equal(back.eventStats.get('ExitQueued').lastBlock, 2);
+  assert.equal(back.eventStats.get('RebalanceExecuted').count, 1);
+  assert.ok(back.adapters.has(ADAPTER));
+  assert.equal(back.vaults.get(V).exitQueuedCount, 1);
+});
+
+test('deserializeState defaults eventStats/adapters to empty for a snapshot written before they existed', () => {
+  const legacy = JSON.parse(JSON.stringify(serializeState(richState())));
+  delete legacy.eventStats;
+  delete legacy.adapters;
+  const back = deserializeState(legacy);
+  assert.equal(back.eventStats.size, 0);
+  assert.equal(back.adapters.size, 0);
+  assert.equal(back.lastBlock, richState().lastBlock);
+});
+
 test('snapshot survives a file save/load cycle', async () => {
   const path = join(tmpdir(), `idx-${process.pid}-${Date.now()}.json`);
   try {


### PR DESCRIPTION
## What

Adds the ABI fragments and minimum projection wiring for build-order items 1-3 in
`Business/Verticals/data-analytics.md` §8 (lines ~841-843):

1. **VaultCore** — `ExitQueued`, `SliceEscrowed`, `EscrowClaimed`, `ModuleCallFailed`,
   `RebalanceExecuted`. The note calls `ExitQueued` "the single highest-priority indexer change in
   this document" (§3.6, ~line 480) — Mode-F exit rate is uncomputable without it.
2. **FeeEngine** (new optional singleton) — `FeeAssessed`, `FeeCredited`, `FeesClaimed`, plus
   **Governance** `VaultRegistered` (quorum/timelock config) and `Committed`. Fixes the
   understated-fees defect the note documents at §3.7 (~line 531): the registry's `FeeRecorded`
   only ever sees the USDC cash leg, so a vault paying fees partly in-kind understates
   `lifetimeFeesUsdc` if that's the only stream indexed. `FeeCredited` is the per-token stream that
   fixes it (pricing it into a USD-equivalent is future work, not done here).
3. **Execution adapters** — `SwapExecuted`, via a new dynamic adapter-address set.

## Why the events, not invented

Every event name and field list was checked by hand against `contracts/src/{VaultCore,FeeEngine,
Governance,AggregationRouterAdapter,DirectPoolAdapter}.sol` at `origin/protocol/main` — **every
event named in the vault note exists under that exact name and signature**. Nothing was invented or
guessed. `Governance.VaultRegistered`'s `GovConfig` struct was transcribed field-for-field from the
Solidity struct declaration and encoded as a proper ABI tuple fragment.

## Adapter discovery — same pattern as vault discovery, one hop deeper

Vaults are discovered from a singleton's event (`VaultFactory.VaultCreated`). Adapters have no
singleton or factory announcement — `VaultCore`'s constructor takes a fixed `allowedAdapters_`
allowlist with no corresponding event (EX-1, immutable). The only on-chain trace of an adapter
address is `RebalanceExecuted(adapter, orderCount)`, itself emitted by a dynamically-discovered
`VaultCore` instance. So this PR discovers adapters the same *shape* as vaults — learn an address
from an event in the current batch, then poll that address for further events in the same batch
(`rpc.mjs`'s `fetchEvents`) — one hop deeper than vault discovery, and resume-seeded from
`state.adapters` across restarts the same way `knownVaults` is.

## Projection wiring (minimum, per scope)

- `state.eventStats`: a generic per-event count + last-seen `(block, logIndex)` cursor for every
  new event, so none of them are silently dropped even before dedicated reducers exist.
- `VaultState.exitQueuedCount` / `exitSettledCount` feed `modeFExitRateBps(state, vault)` — an
  **approximate** Mode-F exit rate in integer bps (matches the note's own `mode_f_exit_rate_bps`
  field name and the repo's `shareOfVaultBps` convention). This is explicitly documented as *not*
  the exact per-member Mode-F/Mode-I discriminator from §3.6 (that needs a per-member exit ledger —
  the bigger Postgres-substrate work in build-order item 4+); it can legitimately exceed 10000 bps
  when exits are queued faster than they settle, and that is deliberately not clamped.

## What this does NOT build (deliberately out of scope)

- No Postgres `event_log` table or any of the analytics tables in §2-§3 (build-order item 4+).
- No exact per-member Mode-F/Mode-I ledger (`exit_event` table, §3.6) — only the approximate
  count-ratio above.
- No calldata decoder / `action_hash` verification (build-order item 8).
- No priced `fees_total_usd_equivalent` (§3.7's stated fix) — only the raw `FeeCredited` stream is
  now indexable; pricing it requires the oracle-read enrichment layer.
- **`packages/indexer/README.md` and `docs/api/openapi.yaml`** were checked and neither contains a
  table of indexed events today, so neither was touched (task scope: update them "only where a
  table of indexed events exists").
- Did not touch `contracts/src/` (launch freeze) or `packages/canary` (another builder is active
  there).

This unblocks `Business/finance-tokenomics.md` backlog #5 (realized-fee-vs-paper-gain ρ
instrumentation) by making the raw fee/exit inputs indexable — **ρ itself is not built here.**

## Finance department check

`Business/Finance/Member Cost and the HWM.md` (~line 13) records that the exit fee applies to both
Mode-I and Mode-F exits unconditionally in code. No new comment, doc string, or test in this PR
claims otherwise — `modeFExitRateBps` and its surrounding comments describe it purely as a count
ratio, making no fee-applicability claim.

## Test / gate result

- `npm run build:contracts` (forge build), then `abis.test.mjs` + `event-coverage.test.mjs` run
  against the **real compiled Foundry ABIs**: all 6 tests pass — every new fragment's name and full
  type signature (tuples expanded to their component list, not compared as the bare string
  "tuple") matches the actual contract source.
- Full `test:backend` surface (oplog, indexer, canary, agent-sdk, reference-agent, apps/api,
  apps/web, apps/site, scripts/test) run via the cheap loop: 0 failures, 2 pre-existing/
  environmental skips (Windows SIGTERM-to-child; a canary test needing a live snapshot file not
  present in this checkout) — neither related to this change.
- **`npm run gate` run once: GATE PASSED (42.9s), 9/9 steps** (fmt, syntax, build, opscheck,
  backend, test, snapshot, sizes all `pass`; slither `warn` — 1 advisory, pre-existing, this PR
  touches no `contracts/src` files).
- Two small review refinements landed after the gate run (bps rename, tuple-signature drift-test
  fix — see second commit); re-verified via the cheap loop only per the "run gate at most once"
  instruction, not by re-running the full gate.

No existing test was deleted, skipped, or loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)