### PR TITLE
feat(canary): governance-watch signal for proposal and phase transitions (Monitoring Gap Analysis G8)

### DIFF
--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -427,6 +427,120 @@ proxy anywhere, so feed identity is not a capability that exists to be blind abo
 
 ---
 
+### (h) `governance-watch` — a proposal is moving, and here is when its windows close
+
+**Why it exists.** Monitoring Gap Analysis G8 (Incident Catalogue OPS-7): the design's answer to
+governance capture is *publish analysis during the reveal window*, and until this signal nothing
+said when a window had opened. A hostile proposal could move through commit into reveal overnight
+and consume the only defence window the protocol has. Operations specified it as SEV-2 — page
+during 08:00–24:00 UTC, queue overnight. **Cite the two halves to the right notes**: the SEV-2
+label comes from Monitoring Gap Analysis §3 item 5 (the Severity Ladder's SEV-2 definition
+enumerates OPS-1/2/3/5 and does not mention governance, and the Incident Catalogue's OPS-7 entry
+assigns no tier); the 08:00–24:00 UTC window is the Severity Ladder's. **The routing belongs to the
+sinks**:
+the signal is in `PAGE_SIGNALS`, so its ALERTs reach `PAGE_WEBHOOK_URL` and its recoveries and
+DETECTOR BROKEN lines reach `LOG_WEBHOOK_URL` (§5.3). This signal reports state, knows nothing about
+the time of day, and promises nothing about who responds when.
+
+**What it measures.** `vault.governance()` (immutable, so no extra env var) locates the
+`Governance` module; then `activeProposalOf(vault)`, `proposals(pid)` and `configOf(vault)`. The
+**phase** is derived from the proposal's stored deadlines against **chain time**, never the host
+clock, because two of the transitions that matter — commit→reveal and timelock→executable — are
+clock crossings that emit no event. The four lifecycle events (`Proposed`, `Finalized`,
+`Executed`, `ProposalExpired`) are scanned over the poll window for block/tx attribution only,
+using the same `MAX_LOG_SPAN_BLOCKS` plumbing as signal (e).
+
+**Shape.** One transition key per phase — `commit`, `reveal`, `tally` (reveals closed, `finalize`
+not yet called), `timelock`, `execution`, `lapsed` (passed, window closed, `markExpired` not yet
+called) — and every key is emitted every sweep: the phase the proposal is in reads ALERT, the other
+five read OK. **The six keys are not cosmetic and must not be collapsed into one:** the tracker
+emits on a status change, so a single key would produce *no line at all* on commit→reveal — the
+signal would already be `alert`, and the reveal window would open unannounced. That is the general
+masking failure of single-key signals, and it is why per-leg keys are the house pattern here
+(`nav-backing` splits composition/custody, the oracle signals split per asset). Entering a phase is one ALERT line; leaving it is one RECOVERED line saying where the
+proposal went (`commit phase of proposal 3 … is over; now in the reveal phase`, or `settled as
+Executed at block N`). A full lifecycle is therefore about eight lines spread over hours or days.
+Low volume by construction, and the bound is **CM-6**: `propose` requires the previous proposal to
+be settled (`Governance.sol:278`), so one vault cannot have two proposals running at once however
+many proposers try. That, not the phase durations, is what bounds pages per vault per hour — and it
+is the answer to M-7's per-proposer cooldown sidestep. "Every phase is at least an hour" is **not**
+true: `_validateConfig` floors `commitDuration`, `revealDuration` and `executionWindow` at 1 hour
+but only *caps* `timelockDuration`, so a zero timelock is legal and that phase is skipped outright.
+
+The phase boundaries copy `Governance.sol`'s own `require`s and the tests pin them: commits need
+`now < commitDeadline`, reveals `commitDeadline ≤ now < revealDeadline`, `finalize` needs
+`now ≥ revealDeadline`, `execute` needs `executableAt ≤ now ≤ expiresAt` (inclusive at the top),
+`markExpired` needs `now > expiresAt`.
+
+**What `detail` carries.** `revealDeadline` (+ `…Iso`), `earliestExecuteAt` (+ `…Iso`) and
+`earliestExecuteBasis`, `executionWindowClosesAt`, the decoded `proposal` (type, proposer,
+`actionHash`, every stored timestamp, tallies) and the four `config` durations, `pid`, `phase`,
+`governance`, `modeFExitQueueing` (true from reveal start until settlement — VO-8, the reason a
+reveal-phase line matters to members and not only to voters), the window's `events` with
+block/tx, `severity: 'SEV-2'`, `incident: 'OPS-7'`, `gap: 'G8'`.
+
+**`earliestExecuteAt` is exact once the proposal has passed** (`executableAt` is stored) **and a
+lower bound before that**: `finalize` is permissionless and callable the second reveals close, so
+the floor is `revealDeadline + timelockDuration`; a late `finalize` pushes the timelock and the
+execution window later, which is why no *upper* bound is claimed for an Active proposal and why
+the floor keeps moving with the clock while the `tally` key is alert.
+
+**Tier: `PAGE_SIGNALS`, unconditionally — and here is why not `CONDITIONAL_PAGE`.** This signal has
+the shape that category exists for: one signal name covering two severities, a routine creator
+rebalance and a hostile proposal. It does not have the **discriminator**, which is what the category
+actually requires. `feed-identity` earned it because chain state says which severity you are in
+(`detail.harm`). Here all three candidate predicates fail:
+
+1. **The payload** — the axis the two severities genuinely differ on — is not on-chain until
+   `execute`. `Proposed` carries only `actionHash`, which is exactly why this signal ships
+   `payloadOnChain: false`. There is nothing to condition on.
+2. **The proposer is the wrong thing to condition on, on the merits — not because it is hard.**
+   Incident Catalogue OPS-7 opens *"An operator key signs a bad proposal, or a hostile bloc passes a
+   rebalance"*: the operator key is the **first named threat this signal exists for**. Any proposer
+   predicate — including the cheap one, a creator/operator allowlist, which needs no scoring at all
+   and is trivially available on-chain — would therefore demote exactly the case OPS-7 names first.
+   The objection is not "we cannot build it"; it is that building it blinds the primary threat.
+3. **The phase** is the wrong axis. The two arguably-less-urgent keys are `tally` and `lapsed`, and
+   both mean a governance action is *stalled* — untallied, or passed and never executed. Demoting
+   them demotes the wrong two.
+
+So paging on a routine proposal is an accepted cost, not an oversight: it is what "every occurrence
+PAGEs at SEV-2" buys when no predicate can separate routine from hostile. If a payload-publication
+location ever exists, predicate 1 becomes available and this decision should be revisited.
+
+**Threshold.** No active proposal.
+
+**Reads are pinned to `toBlock`**, the same height the log window ends at, the way `nav-backing`
+pins its legs. Unpinned, state would come from `latest` while logs stop at `head - CONFIRMATIONS`,
+so a proposal executed inside the confirmation lag would read `Executed` while its `Executed` log
+was still outside the window, and the line would attribute the settlement to the earlier `Finalized`
+transaction. Pinning also stops a `finalize`/`execute` that gets reorged out of those last blocks
+from producing a spurious ALERT→RECOVERED pair.
+
+**When it fires.** Read `detail.actionHash`, find the published payload, and check that it hashes
+to it — `execute` is permissionless and hash-gated, so the payload is the authority, not the
+caller. Publish the analysis before `revealDeadline`. A `tally` alert that stands for long means
+nobody has called `finalize`; a `lapsed` alert means a passed proposal was never executed — both
+calls are permissionless. `execution` on a `RuleChange` is the vault's config about to change.
+
+**What it does NOT check, and why: whether the payload behind `actionHash` has been published**
+(security-ops §5.3 names this as the unmonitored condition). The payload is not on-chain until
+`execute` — `Proposed` carries only its keccak — and there is no publication surface anywhere in
+this tree: the indexer folds the hash, the API has no proposal route, and the reference agent's own
+evaluator treats the payload as opaque from chain state. There is nothing for a read-only monitor to
+read. `detail.actionHash` and `detail.payloadOnChain: false` are carried so a receiver with an
+out-of-band payload source can make the comparison itself; the check lands the day a publication
+location exists.
+
+**Detector-broken branches.** A vault that does not answer `governance()`, answers `address(0)`,
+or points at a contract that does not answer `activeProposalOf()` reports DETECTOR BROKEN and
+re-asserts — a vault whose proposals cannot be seen is unmonitored, not quiet.
+
+Threat-model rows: [VO-7](THREAT-MODEL.md) (reveal-order visibility), [VO-8](THREAT-MODEL.md)
+(Mode-F from reveal start), [CM-6](THREAT-MODEL.md) (one proposal at a time).
+
+---
+
 ## 4. Signals that cannot run
 
 A DEGRADED line is not a false alarm to be tuned away — it means a check is **not covering** the
@@ -473,7 +587,19 @@ raise it or scan that range manually.
 ```
 
 The level signals (a–d) read current state and are unaffected. Only the two window-scoped event
-signals have the hole. Raise `MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
+signals have the hole — signal (h) reads the proposal's phase from state and uses the window only
+for block/tx attribution, so **a log-window gap costs it a tx hash, never a page**. Raise
+`MAX_LOG_SPAN_BLOCKS` or sweep the range by hand.
+
+**A sweep gap is a different thing, and signal (h) is not exempt from it.** If the canary process is
+down long enough to span a whole proposal lifecycle (≥2h), every phase key was OK before and is OK
+again after, so the tracker emits **no transition at all** and the proposal is never narrated — no
+line is produced, so nothing in `detail` reaches any sink. That is not recoverable inside a
+state-poller, and it is precisely what the off-host dead-man's switch (`DEADMAN_PING_URL`, §5.3)
+exists to make visible: it tells you the canary was down, which is the cue to sweep governance by
+hand for the window it missed. The narrower case — a whole *reveal window* falling between two
+sweeps — **is** covered: `reveal` stays OK→OK and says nothing, but `commit` emits ALERT→RECOVERED
+and `tally` emits OK→ALERT naming the closed window and the un-called `finalize`.
 
 ---
 
@@ -510,7 +636,12 @@ watcher's watcher. This section is the fix in three parts.
 Severity Ladder rates SEV-1/2 and worth waking a human for: `nav-backing`, `share-conservation`,
 `fee-routing`, `exit-liveness`, `oracle-freshness` (this is the "oracle-v2"/"oracle-health" the
 Monitoring Gap Analysis' §3 item 4 refers to — `signals/oracle-health.mjs`'s `SIGNAL` constant is
-still `'oracle-freshness'`, unchanged across the post-pivot rename). `LOG_WEBHOOK_URL` receives every
+still `'oracle-freshness'`, unchanged across the post-pivot rename), and `governance-watch`, which
+§3 item 5 places here in as many words ("every occurrence PAGEs at SEV-2 during waking hours") — a
+citation of Operations' spec, not an escalation inferred here, and unconditional rather than
+`CONDITIONAL_PAGE` because no on-chain predicate separates a routine proposal from a hostile one
+(see §3(h)). **The waking-hours half is the receiver's**: nothing in this process knows the time of
+day, and no string it emits promises a response time. `LOG_WEBHOOK_URL` receives every
 other transition: recoveries, every DEGRADED / DETECTOR BROKEN line, and the harmless half of
 `feed-identity`. `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback used for whichever of
 the two is unset — set only that one and every transition reaches the one configured URL exactly
@@ -582,7 +713,7 @@ named `tier` must not be able to demote its own page.
 
 ## 6. Tests
 
-`npm run test:backend` includes `packages/canary/test/*.test.mjs` — 247 tests, every one with a
+`npm run test:backend` includes `packages/canary/test/*.test.mjs` — 284 tests, every one with a
 mocked client. **No live RPC in CI.** Both a healthy and an alerting fixture exist for every signal,
 and for both oracle flavors.
 
@@ -603,6 +734,10 @@ Four guards worth knowing about:
   Chainlink's `EACAggregatorProxy`, which is not in this tree, so they are **not** pinned that way and
   the test says so rather than pretending; their runtime failure is covered instead, by a
   DETECTOR BROKEN result.
+- The same file cross-checks every `Governance` getter signal (h) reads — name, `view`-ness and the
+  full flattened **output shape** — against the compiled `Governance`, and the four lifecycle events'
+  signatures and indexed flags. Public mapping-to-struct getters flatten positionally, so a reordered
+  struct field would otherwise swap two deadlines silently.
 - `test/reader.test.mjs` asserts the chain reader exposes no send/sign/write surface, and
   `test/abis.test.mjs` asserts the ABI table declares no non-`view` function. The read-only claim is
   enforced, not just documented.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -322,6 +322,7 @@ can:
 | Exit liveness | any `requestExit` reverting for a non-gate reason (H-1 regression sentinel) |
 | Fee routing | any USDC leaving a vault to an operator address outside the FeeEngine claim flow |
 | Module-call failures | `ModuleCallFailed` and `SliceEscrowed` events (a creator-chosen module or a basket token misbehaving) |
+| Governance watch | a proposal entering any phase — commit, reveal, awaiting finalize, timelock, executable, lapsed — with the reveal deadline and earliest `execute` in `detail` ([CANARY.md §3(h)](CANARY.md)) |
 
 ## 8. Mainnet gate
 

--- a/packages/canary/README.md
+++ b/packages/canary/README.md
@@ -38,6 +38,7 @@ its own `CANARY_STATE_PATH`.
 | `src/signals/*.mjs` | one file per signal, each a pure function over an injected reader |
 | `src/signals/oracle-health.mjs` | signal (a) against the LIVE `ChainlinkOracle`, plus the flavor probe that dispatches to it or to the retired `oracle-freshness.mjs` |
 | `src/signals/feed-identity.mjs` | signal (g): the feed's live `decimals()` against the oracle's CACHED `scale`, its `description()` against the constructor's own USD predicate, and the aggregator behind the proxy. The one signal that owns persistent state (`feedIdentity` in the canary state file) |
+| `src/signals/governance-watch.mjs` | signal (h): the active proposal's phase from `Governance` state against chain time, one transition key per phase, with the reveal deadline and earliest `execute` in `detail`; lifecycle events scanned for tx attribution only (Monitoring Gap Analysis G8) |
 
 ## Design notes
 
@@ -100,6 +101,6 @@ every transition, same channel, no severity. Full env reference is in
 node --test packages/canary/test/*.test.mjs
 ```
 
-247 tests, all mocked. `test/helpers.mjs` carries the shared fixtures: `healthyVault()` (retired
+284 tests, all mocked. `test/helpers.mjs` carries the shared fixtures: `healthyVault()` (retired
 multi-source oracle) and `chainlinkVault()` (the live single-feed one) are healthy on every signal,
 so each test perturbs exactly one thing and proves the signal reacts to that and nothing else.

--- a/packages/canary/src/abis.mjs
+++ b/packages/canary/src/abis.mjs
@@ -51,6 +51,9 @@ export const VAULT_VIEWS = Object.freeze([
   view('childVaults', ['uint256'], ['address']),
   view('sharesOf', ['address'], ['uint256']),
   view('totalPendingUsdc', [], ['uint256']),
+  // The vault's immutable governance module — how `governance-watch` finds the Governance
+  // contract without a second env var, exactly the way `oracle` locates the oracle.
+  view('governance', [], ['address']),
 ]);
 
 /**
@@ -170,6 +173,61 @@ export const ERC20_TRANSFER_EVENT = Object.freeze(
 export const VAULT_WATCH_EVENTS = Object.freeze([
   ev('ModuleCallFailed', [{ name: 'module', type: 'bytes32', indexed: true }, addr('member', true)]),
   ev('SliceEscrowed', [addr('member', true), addr('asset', true), u256('amount')]),
+]);
+
+/**
+ * Governance — the three public getters `signals/governance-watch.mjs` reads. `proposals` and
+ * `configOf` are public mapping-to-struct getters, so viem flattens each to its struct fields in
+ * declaration order; the field ORDER below is copied from Governance.sol and pinned against the
+ * compiled ABI by test/abis.test.mjs. `Status` and `ProposalType` come back as uint8 enum indices.
+ */
+export const GOVERNANCE_VIEWS = Object.freeze([
+  view('activeProposalOf', ['address'], ['uint256']),
+  view('proposals', ['uint256'], [
+    { name: 'vault', type: 'address' },
+    { name: 'ptype', type: 'uint8' },
+    { name: 'proposer', type: 'address' },
+    { name: 'createdAt', type: 'uint64' },
+    { name: 'commitDeadline', type: 'uint64' },
+    { name: 'revealDeadline', type: 'uint64' },
+    { name: 'executableAt', type: 'uint64' },
+    { name: 'expiresAt', type: 'uint64' },
+    { name: 'status', type: 'uint8' },
+    { name: 'actionHash', type: 'bytes32' },
+    { name: 'snapshotTotal', type: 'uint256' },
+    { name: 'memberCount', type: 'uint256' },
+    { name: 'forWeight', type: 'uint256' },
+    { name: 'againstWeight', type: 'uint256' },
+    { name: 'revealedWeight', type: 'uint256' },
+    { name: 'revealedVoterCount', type: 'uint256' },
+  ]),
+  view('configOf', ['address'], [
+    { name: 'commitDuration', type: 'uint32' },
+    { name: 'revealDuration', type: 'uint32' },
+    { name: 'timelockDuration', type: 'uint32' },
+    { name: 'executionWindow', type: 'uint32' },
+    { name: 'quorumBps', type: 'uint16' },
+    { name: 'proposalThresholdBps', type: 'uint16' },
+    { name: 'concentrationCapBps', type: 'uint16' },
+    { name: 'proposalCooldown', type: 'uint32' },
+  ]),
+]);
+
+/**
+ * Governance lifecycle events `governance-watch` scans over the poll window — for block/tx
+ * attribution only. The PHASE a proposal is in is read from `proposals(pid)` against chain time,
+ * because commit→reveal and timelock→executable are clock crossings that emit no event at all.
+ * The indexer folds these four too, but the canary must not depend on the projection being
+ * caught up to notice a proposal.
+ */
+export const GOVERNANCE_WATCH_EVENTS = Object.freeze([
+  ev('Proposed', [
+    u256('pid', true), addr('vault', true), { name: 'ptype', type: 'uint8', indexed: false },
+    addr('proposer', true), { name: 'actionHash', type: 'bytes32', indexed: false },
+  ]),
+  ev('Finalized', [u256('pid', true), { name: 'status', type: 'uint8', indexed: false }]),
+  ev('Executed', [u256('pid', true)]),
+  ev('ProposalExpired', [u256('pid', true)]),
 ]);
 
 /** ExitSettled — not folded here, but needed to tell an operator's honest exit payout from a fee leak. */

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -23,7 +23,11 @@
  *   EXTRA_OPERATOR_ADDRESSES   comma-separated extra operator addresses to treat as prohibited
  *   PAGE_WEBHOOK_URL           POST one JSON body per PAGE-tier transition (Monitoring Gap
  *                              Analysis §2 G6 / §3 item 4): nav-backing, share-conservation,
- *                              fee-routing, exit-liveness ALERT, oracle-freshness ALERT.
+ *                              fee-routing, exit-liveness ALERT, oracle-freshness ALERT, and
+ *                              governance-watch ALERT (§3 item 5 puts it here in as many words:
+ *                              "every occurrence PAGEs at SEV-2 during waking hours"). The
+ *                              waking-hours half is the receiver's to implement; nothing in this
+ *                              process knows the time of day or promises a response.
  *   LOG_WEBHOOK_URL            POST one JSON body per LOG-tier transition — everything else,
  *                              including every DEGRADED/DETECTOR BROKEN line and feed-identity.
  *   ALERT_WEBHOOK_URL          back-compat fallback: used for whichever of PAGE_WEBHOOK_URL /
@@ -108,6 +112,7 @@ import { checkShareConservation } from './signals/share-conservation.mjs';
 import { checkExitLiveness } from './signals/exit-liveness.mjs';
 import { checkModuleEvents } from './signals/module-events.mjs';
 import { checkFeeRouting } from './signals/fee-routing.mjs';
+import { checkGovernanceWatch } from './signals/governance-watch.mjs';
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 const lc = (a) => (typeof a === 'string' ? a.toLowerCase() : a);
@@ -317,6 +322,10 @@ export async function collectSignals({ reader, state, vaults, cfg, window, ident
       operatorRegistry: cfg.operatorRegistry, extraOperators: cfg.extraOperators,
       fromBlock, toBlock,
     }));
+
+    // Phase is read from Governance state against chain time; the window scan only attributes
+    // the block/tx. Finds the Governance module through vault.governance(), so it needs no env.
+    await run('governance-watch', () => checkGovernanceWatch({ reader, vault, fromBlock, toBlock, nowSec }));
   }
 
   return out;
@@ -392,6 +401,11 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
     // never see them. Say so: a silent coverage gap is precisely what this package exists to
     // prevent, and an operator who sees this line can widen MAX_LOG_SPAN_BLOCKS or sweep the gap
     // by hand before it scrolls away.
+    // governance-watch is NOT in that list on purpose: it reads the proposal's phase from state
+    // and uses the window only for tx attribution, so THIS gap costs it a tx hash, not a page.
+    // A SWEEP gap is the one that can cost it the page — a canary down across a whole lifecycle
+    // sees every phase key OK before and OK after and emits nothing at all. That is what the
+    // off-host dead-man ping covers; no state-poller can recover it.
     if (windowFrom > fromBlock) {
       errLine(`canary: event scan gap — blocks ${fromBlock}-${windowFrom - 1} (${windowFrom - fromBlock} blocks) were NOT scanned for ModuleCallFailed/SliceEscrowed/fee outflows. The backlog exceeded MAX_LOG_SPAN_BLOCKS=${cfg.maxLogSpanBlocks}; raise it or scan that range manually.`);
     }

--- a/packages/canary/src/signals/governance-watch.mjs
+++ b/packages/canary/src/signals/governance-watch.mjs
@@ -1,0 +1,340 @@
+// @ts-check
+/**
+ * Signal (h) — GOVERNANCE WATCH. Closes Monitoring Gap Analysis G8 (Incident Catalogue OPS-7).
+ *
+ * The protocol's whole answer to governance capture is "publish analysis during the reveal
+ * window" — and until this signal nothing said when a window had opened. A hostile proposal
+ * could move through commit into reveal while both humans slept and consume the only defence
+ * window the protocol has. This signal says, once per phase entry, that the clock is running and
+ * exactly when it runs out.
+ *
+ * WHAT IT READS. `vault.governance()` (immutable) locates the Governance module, then
+ * `activeProposalOf(vault)`, `proposals(pid)` and `configOf(vault)`. The phase is derived from
+ * the proposal's stored deadlines against CHAIN time, never the host clock, because two of the
+ * transitions that matter — commit→reveal and timelock→executable — are clock crossings that
+ * emit no event. The four lifecycle events (`Proposed`, `Finalized`, `Executed`,
+ * `ProposalExpired`) are scanned over the poll window for block/tx attribution only, with the
+ * same `MAX_LOG_SPAN_BLOCKS` plumbing as `module-events`.
+ *
+ * TWO DIFFERENT GAPS, and only one of them is harmless. A LOG-WINDOW gap (the backlog exceeded
+ * `MAX_LOG_SPAN_BLOCKS`) costs this signal a tx hash and never a page, because the phase is read
+ * from state rather than from the events. A SWEEP gap — the canary process down long enough to
+ * span a whole lifecycle — is different in kind: every phase key was OK before and is OK again
+ * after, so the tracker emits NO transition and the proposal is never narrated at all. No
+ * state-poller can recover that, and nothing here should claim otherwise; it is what the off-host
+ * dead-man ping (`DEADMAN_PING_URL`) exists to make visible.
+ *
+ * Reads are PINNED to the same `toBlock` the log window ends at, the way `nav-backing` pins its
+ * legs. Unpinned, state comes from `latest` while logs stop at `head - CONFIRMATIONS`, so a
+ * proposal executed inside the confirmation lag reads `Executed` while its `Executed` log is still
+ * outside the window — the line would then attribute the settlement to the earlier `Finalized` tx.
+ * Pinning also means a `finalize`/`execute` reorged out of those last blocks cannot produce a
+ * spurious ALERT→RECOVERED pair.
+ *
+ * SHAPE. One tracked key per PHASE (`commit`, `reveal`, `tally`, `timelock`, `execution`,
+ * `lapsed`), every one of them emitted every sweep: the phase the proposal is in reads ALERT and
+ * the other five read OK. Entering a phase is therefore one OK→ALERT line carrying the deadlines,
+ * and leaving it is one ALERT→OK line saying where the proposal went. Low volume by construction, and the bound
+ * is CM-6: `propose` requires the previous proposal to be settled (Governance.sol:278), so one
+ * vault cannot have two proposals running at once however many proposers try — that, not the phase
+ * durations, is what bounds pages per vault per hour, and it is also the answer to M-7's
+ * per-proposer cooldown sidestep. Do NOT reach for "every phase is at least an hour": it is false.
+ * `_validateConfig` floors `commitDuration`, `revealDuration` and `executionWindow` at 1 hour but
+ * only CAPS `timelockDuration`, so a zero timelock is legal and that phase is skipped outright.
+ *
+ * DO NOT COLLAPSE THESE SIX KEYS INTO ONE, however tempting the line count looks. The transition
+ * tracker keys state by `signal|vault|key` and emits on a STATUS change, so a single key holding a
+ * changing message would emit nothing at all on commit→reveal — the vault is already `alert`, the
+ * message text would silently start describing a different phase, and the reveal window, the one
+ * the whole signal exists to announce, would open unannounced. The general form of that failure is
+ * MASKING: with one key, any second condition arising while the first is still firing produces no
+ * transition and therefore no page. Per-leg keys are the house pattern for exactly this reason —
+ * `nav-backing` splits composition/custody, `oracle-freshness` and `feed-identity` split per asset.
+ * (Argument sharpened by the PR #115 review, which found the masking case the hard way.)
+ *
+ * Every alert carries the reveal-window deadline and the earliest possible `execute` timestamp in
+ * `detail`. The SEV-2 label comes from Monitoring Gap Analysis §3 item 5, which is the note that
+ * assigns this signal a severity at all — the Severity Ladder's SEV-2 definition enumerates
+ * OPS-1/2/3/5 and does not mention governance, and the Incident Catalogue's OPS-7 entry assigns no
+ * tier; what the Ladder supplies is the 08:00–24:00 UTC waking-hours window quoted below.
+ *
+ * Routing lives in the sinks, not here: the signal name is in `PAGE_SIGNALS` (sinks.mjs), so an
+ * ALERT from it reaches `PAGE_WEBHOOK_URL` while its recoveries and blind-detector lines go to
+ * `LOG_WEBHOOK_URL`. The waking-hours half is the receiver's — this signal reports state, knows
+ * nothing about the time of day, and makes no promise about who responds when.
+ *
+ * `governance() == 0` is a MISDEPLOYMENT, not a supported configuration. Neither VaultCore's
+ * constructor nor VaultFactory zero-checks `governance_`, and `VaultCore._hasPendingExecution`
+ * tolerates a broken governance by falling back to Mode I (H-1) — so such a vault is contractually
+ * survivable, and this signal will re-assert DETECTOR BROKEN against it on the doubling backoff
+ * indefinitely. That is the correct behaviour (a vault whose proposals cannot be seen is
+ * unmonitored, not quiet), and the real deploy path always constructs a Governance, so the
+ * standing alert means the deployment is wrong rather than the detector.
+ *
+ * NOT CHECKED, and why: whether the execution payload behind `actionHash` has been PUBLISHED
+ * (security-ops §5.3). The payload is not on-chain until `execute` — `Proposed` carries only
+ * its keccak — and there is no publication surface in this tree: the indexer folds the hash, the
+ * API has no proposal route, and the reference agent's own evaluator says the payload is opaque
+ * from chain state. There is nothing to read. `detail.actionHash` and `detail.payloadOnChain`
+ * are carried so a receiver with an out-of-band payload source can do the comparison itself.
+ */
+
+import { VAULT_VIEWS, GOVERNANCE_VIEWS, GOVERNANCE_WATCH_EVENTS } from '../abis.mjs';
+import { ok, alert, detectorBroken, shortAddr } from '../signal.mjs';
+
+export const SIGNAL = 'governance-watch';
+
+/** Phase keys, in lifecycle order. Each is its own transition key. */
+export const PHASES = Object.freeze(['commit', 'reveal', 'tally', 'timelock', 'execution', 'lapsed']);
+
+/** Governance.ProposalType and Governance.Status, by enum index. */
+export const PROPOSAL_TYPES = Object.freeze(['Rebalance', 'RuleChange', 'ChildAllocation']);
+export const STATUSES = Object.freeze(['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expired']);
+
+const ZERO_ADDR = `0x${'0'.repeat(40)}`;
+const [PROPOSED, FINALIZED, EXECUTED, PROPOSAL_EXPIRED] = GOVERNANCE_WATCH_EVENTS;
+
+const num = (x) => Number(x ?? 0);
+const iso = (sec) => new Date(num(sec) * 1000).toISOString();
+const stamp = (sec) => `${iso(sec)} (unix ${num(sec)})`;
+const secs = (n) => `${n}s`;
+
+/** Flatten the `proposals(pid)` tuple viem returns into a named, plain-number record. */
+export function decodeProposal(tuple) {
+  const t = Array.isArray(tuple) ? tuple : Object.values(tuple ?? {});
+  const ptype = num(t[1]);
+  const status = num(t[8]);
+  return {
+    vault: t[0],
+    ptype: PROPOSAL_TYPES[ptype] ?? `type#${ptype}`,
+    proposer: t[2],
+    createdAt: num(t[3]),
+    commitDeadline: num(t[4]),
+    revealDeadline: num(t[5]),
+    executableAt: num(t[6]),
+    expiresAt: num(t[7]),
+    status: STATUSES[status] ?? `status#${status}`,
+    actionHash: t[9],
+    snapshotTotal: String(t[10] ?? 0),
+    memberCount: num(t[11]),
+    forWeight: String(t[12] ?? 0),
+    againstWeight: String(t[13] ?? 0),
+    revealedWeight: String(t[14] ?? 0),
+    revealedVoterCount: num(t[15]),
+  };
+}
+
+/** Flatten the `configOf(vault)` tuple. Only the four durations matter here. */
+export function decodeGovConfig(tuple) {
+  const t = Array.isArray(tuple) ? tuple : Object.values(tuple ?? {});
+  return {
+    commitDuration: num(t[0]),
+    revealDuration: num(t[1]),
+    timelockDuration: num(t[2]),
+    executionWindow: num(t[3]),
+  };
+}
+
+/**
+ * Which phase a proposal is in at chain time `nowSec`, or null once it is settled. The
+ * boundaries copy Governance.sol exactly: commits need `now < commitDeadline`, reveals need
+ * `commitDeadline <= now < revealDeadline`, finalize needs `now >= revealDeadline`, execute needs
+ * `executableAt <= now <= expiresAt` (inclusive at the top), and `markExpired` needs
+ * `now > expiresAt`.
+ * @param {ReturnType<typeof decodeProposal>} p
+ * @param {number} nowSec
+ */
+export function phaseOf(p, nowSec) {
+  if (p.status === 'Active') {
+    if (nowSec < p.commitDeadline) return 'commit';
+    if (nowSec < p.revealDeadline) return 'reveal';
+    return 'tally';
+  }
+  if (p.status === 'Passed') {
+    if (nowSec < p.executableAt) return 'timelock';
+    if (nowSec <= p.expiresAt) return 'execution';
+    return 'lapsed';
+  }
+  return null;
+}
+
+/**
+ * The two timestamps the alert exists to deliver.
+ *
+ * `revealDeadline` is stored. `earliestExecuteAt` is stored only once the proposal has PASSED
+ * (`executableAt`); while it is still Active the floor is `revealDeadline + timelockDuration`,
+ * because `finalize` is permissionless and callable the second reveals close. That is a LOWER
+ * bound: a late finalize pushes both the timelock and the execution window later, so no upper
+ * bound is claimed for an Active proposal.
+ * @param {ReturnType<typeof decodeProposal>} p
+ * @param {ReturnType<typeof decodeGovConfig>} cfg
+ * @param {number} nowSec
+ */
+export function timingOf(p, cfg, nowSec) {
+  if (p.status === 'Passed') {
+    return {
+      revealDeadline: p.revealDeadline,
+      earliestExecuteAt: p.executableAt,
+      earliestExecuteBasis: 'executableAt',
+      executionWindowClosesAt: p.expiresAt,
+    };
+  }
+  if (p.status === 'Active') {
+    const finalizeFloor = Math.max(nowSec, p.revealDeadline);
+    return {
+      revealDeadline: p.revealDeadline,
+      earliestExecuteAt: finalizeFloor + cfg.timelockDuration,
+      earliestExecuteBasis: 'revealDeadline+timelock (lower bound; a late finalize moves it later)',
+      executionWindowClosesAt: null,
+    };
+  }
+  return { revealDeadline: p.revealDeadline, earliestExecuteAt: null, earliestExecuteBasis: null, executionWindowClosesAt: null };
+}
+
+/** Shape one decoded log for `detail.events`. */
+function eventRow(l) {
+  const a = l.args ?? {};
+  return {
+    event: l.eventName,
+    pid: a.pid != null ? num(a.pid) : undefined,
+    ...(a.ptype != null ? { ptype: PROPOSAL_TYPES[num(a.ptype)] ?? `type#${num(a.ptype)}` } : {}),
+    ...(a.proposer != null ? { proposer: a.proposer } : {}),
+    ...(a.actionHash != null ? { actionHash: a.actionHash } : {}),
+    ...(l.eventName === 'Finalized' ? { status: STATUSES[num(a.status)] ?? `status#${num(a.status)}` } : {}),
+    blockNumber: num(l.blockNumber),
+    txHash: l.transactionHash ?? null,
+  };
+}
+
+/**
+ * @param {Object} ctx
+ * @param {any} ctx.reader
+ * @param {string} ctx.vault
+ * @param {number} ctx.fromBlock
+ * @param {number} ctx.toBlock
+ * @param {number} ctx.nowSec   chain time, from the reader — never the host clock
+ * @param {number} [ctx.atBlock]  pin every state read to this height; defaults to `toBlock`, so
+ *        state and logs describe the same instant. See the header for why that matters. Note this
+ *        DEFAULTS, where `nav-backing`/`share-conservation` pin only when handed a number and
+ *        otherwise read `latest` — this signal's reads must agree with its own log window.
+ * @returns {Promise<import('../signal.mjs').SignalResult[]>}
+ */
+export async function checkGovernanceWatch({ reader, vault, fromBlock, toBlock, nowSec, atBlock }) {
+  // Same instant for state and logs. `!= null` is the package's idiom — nav-backing.mjs,
+  // share-conservation.mjs and reader.mjs all collapse null and undefined the same way — so both
+  // mean "not specified" here too and fall through to the toBlock default. There is deliberately
+  // NO third "explicitly unpinned" state: no caller passes one, and inventing one would make this
+  // the only signal in the package where null and undefined differ.
+  const pinned = atBlock != null ? atBlock : toBlock;
+  const at = pinned != null ? { blockNumber: pinned } : {};
+  const gov = await reader.tryRead(vault, VAULT_VIEWS, 'governance', [], at);
+  if (!gov.ok || typeof gov.value !== 'string' || gov.value.toLowerCase() === ZERO_ADDR) {
+    return [detectorBroken({
+      signal: SIGNAL, vault,
+      message: `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: governance() ${gov.ok ? `returned ${gov.value}` : `did not answer (${gov.error ?? 'reverted'})`} — no proposal on this vault can be seen, so it is unmonitored for governance, not quiet`,
+      detail: { vault, error: gov.ok ? `governance() = ${gov.value}` : gov.error ?? 'reverted' },
+    })];
+  }
+  const governance = gov.value;
+
+  const active = await reader.tryRead(governance, GOVERNANCE_VIEWS, 'activeProposalOf', [vault], at);
+  if (!active.ok) {
+    return [detectorBroken({
+      signal: SIGNAL, vault,
+      message: `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: Governance ${shortAddr(governance)} did not answer activeProposalOf() (${active.error ?? 'reverted'}) — it may not be a Governance contract; the vault is unmonitored for governance, not quiet`,
+      detail: { vault, governance, error: active.error ?? 'reverted' },
+    })];
+  }
+  const pid = num(active.value);
+
+  const window = { vault, governance, fromBlock, toBlock, nowSec, atBlock: pinned ?? null };
+  const meta = { severity: 'SEV-2', incident: 'OPS-7', gap: 'G8', threatModelRows: ['VO-7', 'VO-8', 'CM-6'], payloadOnChain: false };
+
+  // ── no proposal was ever opened on this vault ──
+  if (pid === 0) {
+    const proposed = await reader.getLogs({ address: governance, event: PROPOSED, args: { vault }, fromBlock, toBlock });
+    const detail = { ...window, ...meta, pid: 0, events: proposed.map(eventRow) };
+    return PHASES.map((phase) => ok({
+      signal: SIGNAL, vault, key: phase,
+      message: `no governance proposal has been opened on vault ${shortAddr(vault)}`,
+      measured: 'no proposal', threshold: 'no active proposal', detail: { ...detail, phase: null },
+    }));
+  }
+
+  const [rawProposal, rawCfg, proposed, finalized, executed, expired] = await Promise.all([
+    reader.read(governance, GOVERNANCE_VIEWS, 'proposals', [BigInt(pid)], at),
+    reader.read(governance, GOVERNANCE_VIEWS, 'configOf', [vault], at),
+    reader.getLogs({ address: governance, event: PROPOSED, args: { vault }, fromBlock, toBlock }),
+    reader.getLogs({ address: governance, event: FINALIZED, args: { pid: BigInt(pid) }, fromBlock, toBlock }),
+    reader.getLogs({ address: governance, event: EXECUTED, args: { pid: BigInt(pid) }, fromBlock, toBlock }),
+    reader.getLogs({ address: governance, event: PROPOSAL_EXPIRED, args: { pid: BigInt(pid) }, fromBlock, toBlock }),
+  ]);
+  const p = decodeProposal(rawProposal);
+  const cfg = decodeGovConfig(rawCfg);
+  const phase = phaseOf(p, nowSec);
+  const timing = timingOf(p, cfg, nowSec);
+  const events = [...proposed, ...finalized, ...executed, ...expired]
+    .map(eventRow)
+    .sort((a, b) => a.blockNumber - b.blockNumber);
+
+  const detail = {
+    ...window, ...meta,
+    pid, phase, proposal: p, config: cfg, ...timing,
+    revealDeadlineIso: iso(p.revealDeadline),
+    earliestExecuteAtIso: timing.earliestExecuteAt != null ? iso(timing.earliestExecuteAt) : null,
+    executionWindowClosesAtIso: timing.executionWindowClosesAt != null ? iso(timing.executionWindowClosesAt) : null,
+    // VO-8: from reveal start until settlement an exit request queues in Mode F.
+    modeFExitQueueing: phase != null && phase !== 'commit' && phase !== 'lapsed',
+    actionHash: p.actionHash,
+    events,
+  };
+  const who = `proposal ${pid} (${p.ptype}, by ${shortAddr(p.proposer)}) on vault ${shortAddr(vault)}`;
+  const settledAt = events.filter((e) => e.event !== 'Proposed').at(-1);
+  const settledWhere = settledAt ? ` at block ${settledAt.blockNumber}${settledAt.txHash ? ` (tx ${settledAt.txHash})` : ''}` : '';
+
+  // ── settled: Defeated / Executed / Expired ──
+  if (phase == null) {
+    return PHASES.map((k) => ok({
+      signal: SIGNAL, vault, key: k,
+      message: `no governance proposal active on vault ${shortAddr(vault)}; ${who} settled as ${p.status}${settledWhere}`,
+      measured: `proposal ${pid} ${p.status}`, threshold: 'no active proposal', detail,
+    }));
+  }
+
+  const execFloor = timing.earliestExecuteAt != null ? `earliest execute ${stamp(timing.earliestExecuteAt)} (timelock ${secs(cfg.timelockDuration)})` : '';
+  const messages = {
+    commit: `GOVERNANCE PROPOSAL OPEN — ${who} is in the COMMIT phase since ${stamp(p.createdAt)}: commits close ${stamp(p.commitDeadline)} (in ${secs(p.commitDeadline - nowSec)}), reveals close ${stamp(p.revealDeadline)}; ${execFloor}; actionHash ${p.actionHash}`,
+    reveal: `GOVERNANCE REVEAL PHASE — ${who} is in the REVEAL phase: reveals close ${stamp(p.revealDeadline)} (in ${secs(p.revealDeadline - nowSec)}); the running tally is readable on-chain and exit requests now queue in Mode-F; ${execFloor}; actionHash ${p.actionHash}`,
+    tally: `GOVERNANCE AWAITING FINALIZE — ${who}: reveals closed ${stamp(p.revealDeadline)} (${secs(nowSec - p.revealDeadline)} ago) and finalize() has not been called; it is permissionless; ${execFloor}; actionHash ${p.actionHash}`,
+    timelock: `GOVERNANCE PROPOSAL PASSED, IN TIMELOCK — ${who}: executable from ${stamp(p.executableAt)} (in ${secs(p.executableAt - nowSec)}), execution window closes ${stamp(p.expiresAt)}; execute() is permissionless and hash-gated on actionHash ${p.actionHash}`,
+    execution: `GOVERNANCE PROPOSAL EXECUTABLE NOW — ${who}: execute() has been callable since ${stamp(p.executableAt)} and the window closes ${stamp(p.expiresAt)} (in ${secs(p.expiresAt - nowSec)}); permissionless, hash-gated on actionHash ${p.actionHash}`,
+    lapsed: `GOVERNANCE PROPOSAL LAPSED UNEXECUTED — ${who} passed but nobody called execute() before the window closed ${stamp(p.expiresAt)} (${secs(nowSec - p.expiresAt)} ago); markExpired() is permissionless and the next propose() settles it; actionHash ${p.actionHash}`,
+  };
+
+  const current = PHASES.indexOf(phase);
+  return PHASES.map((k, i) => {
+    if (k === phase) {
+      return alert({
+        signal: SIGNAL, vault, key: k,
+        message: messages[k],
+        measured: `proposal ${pid} in ${k} phase`, threshold: 'no active proposal', detail,
+      });
+    }
+    // `timelockDuration` has no floor (Governance caps it, nothing floors it), so a zero-timelock
+    // proposal goes tally→execution and never has a timelock phase at all. Saying that phase "is
+    // over" would assert something that never happened, so the skipped case is named instead.
+    const skipped = k === 'timelock' && cfg.timelockDuration === 0;
+    // Only offer the reveal deadline while it is still ahead; past it the hint reads as a stale
+    // future date on every remaining line.
+    const revealHint = nowSec < p.revealDeadline ? ` (reveals close ${stamp(p.revealDeadline)})` : '';
+    const message = skipped
+      ? `${who} has no ${k} phase — timelockDuration is 0, so it became executable at finalize; now in the ${phase} phase`
+      : i < current
+        ? `${k} phase of ${who} is over; now in the ${phase} phase${revealHint}`
+        : `${who} has not reached the ${k} phase; now in the ${phase} phase`;
+    return ok({
+      signal: SIGNAL, vault, key: k,
+      message, measured: `proposal ${pid} in ${phase} phase`, threshold: 'no active proposal', detail,
+    });
+  });
+}

--- a/packages/canary/src/sinks.mjs
+++ b/packages/canary/src/sinks.mjs
@@ -43,6 +43,33 @@ export function createConsoleSink({ log = console.log, error = console.error } =
  */
 export const PAGE_SIGNALS = new Set([
   'nav-backing', 'share-conservation', 'fee-routing', 'exit-liveness', 'oracle-freshness',
+  // Added with signal (h). A CITATION, not an escalation: Monitoring Gap Analysis §3 item 5
+  // specifies governance-watch as "every occurrence PAGEs at SEV-2 during waking hours" in as many
+  // words. The waking-hours half is the RECEIVER's; nothing in this process knows the time of day.
+  //
+  // WHY UNCONDITIONAL, and not CONDITIONAL_PAGE below. It has the two-severities-one-name shape —
+  // a routine creator rebalance is not an incident and this does page on it — but it has no
+  // DISCRIMINATOR, which is what CONDITIONAL_PAGE actually requires. feed-identity qualifies
+  // because chain state tells you which severity you are in (`detail.harm`). Here the axis is
+  // routine vs hostile proposal, and all three candidate predicates fail: (1) the PAYLOAD, the axis
+  // they truly differ on, is not on-chain until `execute` — `Proposed` carries only `actionHash`,
+  // which is why this signal ships `payloadOnChain: false`; (2) the PROPOSER is the wrong axis on
+  // the MERITS, not because scoring is hard — Incident Catalogue OPS-7 names "an operator key signs
+  // a bad proposal" as its FIRST threat, so any proposer predicate, including the cheap
+  // creator/operator allowlist that needs no scoring at all, would demote precisely the case this
+  // signal exists for; (3) the
+  // PHASE is the wrong axis — `tally` means a proposal sits untallied and `lapsed` means a passed
+  // one was never executed, both stalled governance actions someone must act on, so demoting them
+  // demotes the wrong two. Paging on a routine proposal is the accepted cost of having no
+  // discriminator, not an oversight.
+  //
+  // VOLUME. The tracker emits on change and tierOf gates on `to === 'alert'`, so this is one page
+  // per phase ENTRY — 4 per lifecycle, at most 6 when `finalize` is late and the proposal lapses.
+  // The 4-6 RECOVERED lines route LOG. Six keys x every sweep is NOT six pages. Per vault per hour
+  // the bound is CM-6 (one active proposal at a time, plus the proposal cooldown), not the phase
+  // durations: `_validateConfig` floors commit, reveal and executionWindow at 1 hour but only CAPS
+  // `timelockDuration`, so a zero timelock is legal and that phase is skipped entirely.
+  'governance-watch',
 ]);
 
 /**

--- a/packages/canary/test/abis.test.mjs
+++ b/packages/canary/test/abis.test.mjs
@@ -20,6 +20,7 @@ import {
   REQUEST_EXIT_SELECTOR, EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS,
   VAULT_VIEWS, ORACLE_VIEWS, CHAINLINK_ORACLE_VIEWS, AGGREGATOR_V3_VIEWS, CHAINLINK_FEED_IDENTITY_VIEWS,
   VAULT_WATCH_EVENTS, ERC20_TRANSFER_EVENT, EXIT_SETTLED_EVENT,
+  GOVERNANCE_VIEWS, GOVERNANCE_WATCH_EVENTS,
   signatureOf,
 } from '../src/abis.mjs';
 
@@ -45,6 +46,10 @@ const feedAbi = feedBuilt ? JSON.parse(readFileSync(feedAbiPath, 'utf8')).abi ??
 const descAbiPath = join(OUT, 'ChainlinkOracle.sol/IAggregatorV3Description.json');
 const descBuilt = existsSync(descAbiPath);
 const descAbi = descBuilt ? JSON.parse(readFileSync(descAbiPath, 'utf8')).abi ?? [] : [];
+
+const govAbiPath = join(OUT, 'Governance.sol/Governance.json');
+const govBuilt = existsSync(govAbiPath);
+const govAbi = govBuilt ? JSON.parse(readFileSync(govAbiPath, 'utf8')).abi ?? [] : [];
 
 /** Every embedded selector, mapped to the Solidity signature it must equal. */
 const EXPECTED = {
@@ -250,4 +255,39 @@ test('the feed-identity IDENTITY legs are the EACAggregatorProxy signatures, and
     CHAINLINK_FEED_IDENTITY_VIEWS.map(signatureOf).sort(),
     ['aggregator()', 'decimals()', 'description()', 'phaseId()'],
   );
+});
+
+// ── governance-watch: the getters and events it reads, against the COMPILED Governance ──
+
+test('every Governance view governance-watch reads exists on the compiled contract, as a view, with the same output shape', { skip: !govBuilt && 'contracts/out absent — run `cd contracts && forge build`' }, () => {
+  const fns = new Map(govAbi.filter((i) => i.type === 'function').map((i) => [canonical(i), i]));
+  for (const frag of GOVERNANCE_VIEWS) {
+    const sig = signatureOf(frag);
+    const onChain = fns.get(sig);
+    assert.ok(onChain, `Governance has no ${sig} — the canary would read a reverting selector`);
+    assert.equal(onChain.stateMutability, 'view', `${sig} is not a view on the compiled contract`);
+    // Public mapping-to-struct getters flatten to the struct fields IN ORDER, and the decoder in
+    // signals/governance-watch.mjs indexes them positionally. A reordered field would silently
+    // swap, say, commitDeadline and revealDeadline — so the whole output shape is pinned.
+    assert.deepEqual(
+      onChain.outputs.map((o) => o.type),
+      frag.outputs.map((o) => o.type),
+      `${sig} output shape drifted from the compiled Governance`,
+    );
+  }
+});
+
+test('the governance lifecycle events exist on the compiled Governance with the same signature and indexing', { skip: !govBuilt && 'contracts/out absent' }, () => {
+  const declared = new Map(govAbi.filter((i) => i.type === 'event').map((i) => [canonical(i), i]));
+  for (const frag of GOVERNANCE_WATCH_EVENTS) {
+    const onChain = declared.get(signatureOf(frag));
+    assert.ok(onChain, `${signatureOf(frag)} is not an event on the compiled Governance`);
+    // The window scan filters on indexed `vault` / `pid`; a topic that stopped being indexed
+    // would make getLogs return nothing rather than fail.
+    assert.deepEqual(onChain.inputs.map((i) => i.indexed), frag.inputs.map((i) => i.indexed), `${frag.name}: indexed flags drifted`);
+  }
+});
+
+test('the Governance table declares only views — the read-only invariant holds for the new signal too', () => {
+  for (const frag of GOVERNANCE_VIEWS) assert.equal(frag.stateMutability, 'view', `${frag.name} is not a view`);
 });

--- a/packages/canary/test/governance-watch.test.mjs
+++ b/packages/canary/test/governance-watch.test.mjs
@@ -1,0 +1,469 @@
+// @ts-check
+/**
+ * Signal (h) — governance-watch (Monitoring Gap Analysis G8 / OPS-7).
+ *
+ * Every phase boundary below is copied from Governance.sol's own requires, and every deadline in
+ * an alert is checked against the fixture's stored fields — the point of the signal is the
+ * timestamps, so the tests pin them rather than the prose around them.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  checkGovernanceWatch, phaseOf, timingOf, decodeProposal, decodeGovConfig, PHASES, SIGNAL,
+} from '../src/signals/governance-watch.mjs';
+import { createTransitionTracker } from '../src/transitions.mjs';
+import { createTieredWebhookSink, emitAll } from '../src/sinks.mjs';
+import {
+  mockReader, log, healthyVault, proposalTuple,
+  VAULT, GOVERNANCE, PROPOSER, GOV_CONFIG,
+} from './helpers.mjs';
+
+const NOW = 1_700_000_000;
+const T0 = NOW - 600; // proposal opened ten minutes ago
+const [COMMIT_S, REVEAL_S, TIMELOCK_S, EXEC_WINDOW_S] = GOV_CONFIG;
+const ACTION = `0x${'ab'.repeat(32)}`;
+const WINDOW = { fromBlock: 900, toBlock: 995 };
+
+/** An Active proposal opened at T0 with the fixture config's 1h commit / 1h reveal. */
+const activeProposal = (over = {}) => proposalTuple({
+  createdAt: T0, commitDeadline: T0 + COMMIT_S, revealDeadline: T0 + COMMIT_S + REVEAL_S, status: 1, ...over,
+});
+/** A Passed proposal finalized at `finalizedAt`, with the fixture config's 1h timelock / 1d window. */
+const passedProposal = (finalizedAt, over = {}) => proposalTuple({
+  createdAt: T0, commitDeadline: T0 + COMMIT_S, revealDeadline: T0 + COMMIT_S + REVEAL_S,
+  executableAt: finalizedAt + TIMELOCK_S, expiresAt: finalizedAt + TIMELOCK_S + EXEC_WINDOW_S, status: 2, ...over,
+});
+
+function readerWith({ pid = 1n, proposal, config = GOV_CONFIG, logs = [], nowSec = NOW, governance = {} } = {}) {
+  const contracts = healthyVault({
+    [GOVERNANCE]: {
+      activeProposalOf: () => pid,
+      configOf: () => config,
+      proposals: () => proposal,
+      ...governance,
+    },
+  });
+  return mockReader({ contracts, logs, nowSec });
+}
+
+const run = (reader, nowSec = NOW) => checkGovernanceWatch({ reader, vault: VAULT, ...WINDOW, nowSec });
+const alertsOf = (rs) => rs.filter((r) => r.status === 'alert');
+const byKey = (rs, k) => rs.find((r) => r.key === k);
+
+// ── pure helpers ─────────────────────────────────────────────────────────────
+
+test('phaseOf copies the contract boundaries exactly: strict at commit/reveal, inclusive at the top of the execution window', () => {
+  const p = decodeProposal(activeProposal());
+  assert.equal(phaseOf(p, p.commitDeadline - 1), 'commit');
+  assert.equal(phaseOf(p, p.commitDeadline), 'reveal', 'revealVote needs now >= commitDeadline');
+  assert.equal(phaseOf(p, p.revealDeadline - 1), 'reveal');
+  assert.equal(phaseOf(p, p.revealDeadline), 'tally', 'finalize needs now >= revealDeadline');
+
+  const q = decodeProposal(passedProposal(NOW));
+  assert.equal(phaseOf(q, q.executableAt - 1), 'timelock');
+  assert.equal(phaseOf(q, q.executableAt), 'execution', 'execute needs now >= executableAt');
+  assert.equal(phaseOf(q, q.expiresAt), 'execution', 'execute allows now == expiresAt');
+  assert.equal(phaseOf(q, q.expiresAt + 1), 'lapsed', 'markExpired needs now > expiresAt');
+
+  for (const status of [3, 4, 5]) {
+    assert.equal(phaseOf(decodeProposal(activeProposal({ status })), NOW), null, `status ${status} is settled`);
+  }
+});
+
+test('timingOf: a Passed proposal reports its stored executableAt; an Active one reports revealDeadline + timelock as a lower bound', () => {
+  const cfg = decodeGovConfig(GOV_CONFIG);
+  const active = decodeProposal(activeProposal());
+  const t = timingOf(active, cfg, NOW);
+  assert.equal(t.revealDeadline, T0 + COMMIT_S + REVEAL_S);
+  assert.equal(t.earliestExecuteAt, T0 + COMMIT_S + REVEAL_S + TIMELOCK_S);
+  assert.match(t.earliestExecuteBasis, /lower bound/);
+  assert.equal(t.executionWindowClosesAt, null, 'no upper bound is claimed while finalize is still pending');
+
+  // Once reveals have closed and nobody has finalized, the floor moves with the clock.
+  const late = active.revealDeadline + 500;
+  assert.equal(timingOf(active, cfg, late).earliestExecuteAt, late + TIMELOCK_S);
+
+  const passed = decodeProposal(passedProposal(NOW));
+  const u = timingOf(passed, cfg, NOW);
+  assert.equal(u.earliestExecuteAt, NOW + TIMELOCK_S);
+  assert.equal(u.earliestExecuteBasis, 'executableAt');
+  assert.equal(u.executionWindowClosesAt, NOW + TIMELOCK_S + EXEC_WINDOW_S);
+});
+
+test('decodeProposal maps the tuple positionally and names both enums', () => {
+  const p = decodeProposal(activeProposal({ ptype: 1, status: 2 }));
+  assert.equal(p.ptype, 'RuleChange');
+  assert.equal(p.status, 'Passed');
+  assert.equal(p.proposer, PROPOSER);
+  assert.equal(p.commitDeadline, T0 + COMMIT_S);
+  assert.equal(p.actionHash, ACTION);
+});
+
+// ── quiet vault ──────────────────────────────────────────────────────────────
+
+test('OK on every phase key when no proposal has ever been opened — and silent through the tracker', async () => {
+  const results = await run(readerWith({ pid: 0n, proposal: proposalTuple({ status: 0 }) }));
+  assert.equal(results.length, PHASES.length);
+  assert.deepEqual(results.map((r) => r.key), [...PHASES]);
+  assert.ok(results.every((r) => r.status === 'ok'));
+  assert.equal(results[0].detail.pid, 0);
+  assert.equal(results[0].detail.severity, 'SEV-2');
+
+  const tracker = createTransitionTracker();
+  assert.deepEqual(tracker.observe(results), [], 'a first-sighting OK announces nothing');
+});
+
+test('the shared healthy fixture reads OK — the signal adds no noise to every other test\'s healthy vault', async () => {
+  const results = await run(mockReader({ contracts: healthyVault(), nowSec: NOW }));
+  assert.ok(results.every((r) => r.status === 'ok'), results.map((r) => r.message).join('\n'));
+});
+
+// ── the six phases ───────────────────────────────────────────────────────────
+
+test('ALERTS on the commit key when a proposal is open, with the reveal deadline and earliest execute in detail', async () => {
+  const results = await run(readerWith({
+    proposal: activeProposal(),
+    logs: [log(GOVERNANCE, 'Proposed', 950, { pid: 1n, vault: VAULT, ptype: 0, proposer: PROPOSER, actionHash: ACTION }, { transactionHash: '0xproposed' })],
+  }));
+  const alerts = alertsOf(results);
+  assert.equal(alerts.length, 1, 'exactly one phase pages');
+  const a = alerts[0];
+  assert.equal(a.signal, SIGNAL);
+  assert.equal(a.key, 'commit');
+  assert.match(a.message, /GOVERNANCE PROPOSAL OPEN/);
+  assert.match(a.message, /proposal 1 \(Rebalance/);
+  assert.match(a.message, new RegExp(`reveals close .*unix ${T0 + COMMIT_S + REVEAL_S}`));
+  assert.match(a.message, new RegExp(`earliest execute .*unix ${T0 + COMMIT_S + REVEAL_S + TIMELOCK_S}`));
+  assert.match(a.message, new RegExp(ACTION));
+
+  const d = a.detail;
+  assert.equal(d.pid, 1);
+  assert.equal(d.phase, 'commit');
+  assert.equal(d.governance, GOVERNANCE);
+  assert.equal(d.revealDeadline, T0 + COMMIT_S + REVEAL_S);
+  assert.equal(d.revealDeadlineIso, new Date((T0 + COMMIT_S + REVEAL_S) * 1000).toISOString());
+  assert.equal(d.earliestExecuteAt, T0 + COMMIT_S + REVEAL_S + TIMELOCK_S);
+  assert.equal(d.executionWindowClosesAt, null);
+  assert.equal(d.modeFExitQueueing, false, 'Mode-F queueing starts at reveal start, not at propose');
+  assert.equal(d.actionHash, ACTION);
+  assert.equal(d.payloadOnChain, false);
+  assert.deepEqual(d.config, { commitDuration: COMMIT_S, revealDuration: REVEAL_S, timelockDuration: TIMELOCK_S, executionWindow: EXEC_WINDOW_S });
+  assert.equal(d.events.length, 1);
+  assert.equal(d.events[0].event, 'Proposed');
+  assert.equal(d.events[0].blockNumber, 950);
+  assert.equal(d.events[0].txHash, '0xproposed');
+  assert.deepEqual(d.threatModelRows, ['VO-7', 'VO-8', 'CM-6']);
+  assert.equal(d.incident, 'OPS-7');
+
+  // The other five phases read OK and say where the proposal actually is.
+  for (const k of PHASES.filter((k) => k !== 'commit')) {
+    assert.equal(byKey(results, k).status, 'ok');
+    assert.match(byKey(results, k).message, /now in the commit phase/);
+  }
+});
+
+test('ALERTS on the reveal key once chain time crosses commitDeadline, and flags Mode-F queueing', async () => {
+  const now = T0 + COMMIT_S + 5;
+  const results = await run(readerWith({ proposal: activeProposal(), nowSec: now }), now);
+  const [a] = alertsOf(results);
+  assert.equal(a.key, 'reveal');
+  assert.match(a.message, /GOVERNANCE REVEAL PHASE/);
+  assert.match(a.message, new RegExp(`in ${REVEAL_S - 5}s`));
+  assert.equal(a.detail.modeFExitQueueing, true);
+  assert.match(byKey(results, 'commit').message, /commit phase of proposal 1 .* is over; now in the reveal phase/);
+});
+
+test('ALERTS on the tally key when reveals have closed and nobody has called finalize', async () => {
+  const now = T0 + COMMIT_S + REVEAL_S + 120;
+  const results = await run(readerWith({ proposal: activeProposal(), nowSec: now }), now);
+  const [a] = alertsOf(results);
+  assert.equal(a.key, 'tally');
+  assert.match(a.message, /AWAITING FINALIZE/);
+  assert.match(a.message, /120s ago/);
+  assert.match(a.message, /permissionless/);
+  assert.equal(a.detail.earliestExecuteAt, now + TIMELOCK_S, 'the floor tracks the clock while finalize is pending');
+});
+
+test('ALERTS on the timelock key for a Passed proposal, with the stored executableAt and window close', async () => {
+  const finalizedAt = NOW - 100;
+  const results = await run(readerWith({
+    proposal: passedProposal(finalizedAt),
+    logs: [log(GOVERNANCE, 'Finalized', 990, { pid: 1n, status: 2 }, { transactionHash: '0xfin' })],
+  }));
+  const [a] = alertsOf(results);
+  assert.equal(a.key, 'timelock');
+  assert.match(a.message, /PASSED, IN TIMELOCK/);
+  assert.match(a.message, new RegExp(`executable from .*unix ${finalizedAt + TIMELOCK_S}`));
+  assert.equal(a.detail.earliestExecuteAt, finalizedAt + TIMELOCK_S);
+  assert.equal(a.detail.earliestExecuteBasis, 'executableAt');
+  assert.equal(a.detail.executionWindowClosesAt, finalizedAt + TIMELOCK_S + EXEC_WINDOW_S);
+  assert.equal(a.detail.events[0].event, 'Finalized');
+  assert.equal(a.detail.events[0].status, 'Passed');
+  assert.equal(a.detail.modeFExitQueueing, true);
+});
+
+test('ALERTS on the execution key inside the window, and on lapsed past it', async () => {
+  const finalizedAt = NOW - TIMELOCK_S - 10;
+  const inWindow = await run(readerWith({ proposal: passedProposal(finalizedAt) }));
+  const [a] = alertsOf(inWindow);
+  assert.equal(a.key, 'execution');
+  assert.match(a.message, /EXECUTABLE NOW/);
+  assert.match(a.message, /hash-gated/);
+
+  const late = finalizedAt + TIMELOCK_S + EXEC_WINDOW_S + 1;
+  const lapsed = await run(readerWith({ proposal: passedProposal(finalizedAt), nowSec: late }), late);
+  const [b] = alertsOf(lapsed);
+  assert.equal(b.key, 'lapsed');
+  assert.match(b.message, /LAPSED UNEXECUTED/);
+  assert.equal(b.detail.modeFExitQueueing, false, 'hasPendingExecution is false past expiresAt');
+});
+
+test('a settled proposal reads OK on every key and names the outcome and its tx', async () => {
+  for (const [status, name, ev] of [[4, 'Executed', 'Executed'], [3, 'Defeated', 'Finalized'], [5, 'Expired', 'ProposalExpired']]) {
+    const results = await run(readerWith({
+      proposal: passedProposal(NOW - 5000, { status }),
+      logs: [log(GOVERNANCE, ev, 980, ev === 'Finalized' ? { pid: 1n, status: 3 } : { pid: 1n }, { transactionHash: `0x${name}` })],
+    }));
+    assert.ok(results.every((r) => r.status === 'ok'), name);
+    assert.match(results[0].message, new RegExp(`settled as ${name} at block 980 \\(tx 0x${name}\\)`));
+    assert.equal(results[0].detail.phase, null);
+  }
+});
+
+// ── the lifecycle through the transition tracker: the lines an operator actually sees ──
+
+test('a full lifecycle emits one ALERT per phase entered and one RECOVERED per phase left — nothing else', async () => {
+  const tracker = createTransitionTracker();
+  const lines = [];
+  const sweep = async (reader, now, poll) => {
+    const t = tracker.observe(await run(reader, now), { poll });
+    lines.push(...t.map((x) => `${x.to}:${x.key}`));
+  };
+
+  await sweep(readerWith({ pid: 0n, proposal: proposalTuple({ status: 0 }) }), T0 - 60, 1);
+  await sweep(readerWith({ proposal: activeProposal(), nowSec: T0 + 30 }), T0 + 30, 2);
+  await sweep(readerWith({ proposal: activeProposal(), nowSec: T0 + 60 }), T0 + 60, 3); // still commit: silent
+  const revealAt = T0 + COMMIT_S + 30;
+  await sweep(readerWith({ proposal: activeProposal(), nowSec: revealAt }), revealAt, 4);
+  const finalizedAt = T0 + COMMIT_S + REVEAL_S + 10;
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt), nowSec: finalizedAt + 5 }), finalizedAt + 5, 5);
+  const execAt = finalizedAt + TIMELOCK_S + 5;
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt), nowSec: execAt }), execAt, 6);
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt, { status: 4 }), nowSec: execAt + 60 }), execAt + 60, 7);
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt, { status: 4 }), nowSec: execAt + 120 }), execAt + 120, 8); // settled: silent
+
+  assert.deepEqual(lines, [
+    'alert:commit',
+    'ok:commit', 'alert:reveal',
+    'ok:reveal', 'alert:timelock',
+    'ok:timelock', 'alert:execution',
+    'ok:execution',
+  ]);
+});
+
+test('a restart mid-phase does not re-page: the persisted tracker state carries the phase', async () => {
+  const first = createTransitionTracker();
+  first.observe(await run(readerWith({ proposal: activeProposal() })), { poll: 1 });
+  const restored = createTransitionTracker({ initial: JSON.parse(JSON.stringify(first.snapshot())) });
+  assert.deepEqual(restored.observe(await run(readerWith({ proposal: activeProposal() })), { poll: 2 }), []);
+});
+
+// ── the detector, not the vault ──────────────────────────────────────────────
+
+test('DETECTOR BROKEN when the vault does not answer governance() — never a false OK', async () => {
+  const contracts = healthyVault();
+  delete contracts[VAULT].governance;
+  const [r] = await run(mockReader({ contracts, nowSec: NOW }));
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true);
+  assert.match(r.message, /GOVERNANCE DETECTOR BLIND/);
+});
+
+test('DETECTOR BROKEN when governance() is the zero address or the module does not answer activeProposalOf()', async () => {
+  const zero = healthyVault({ [VAULT]: { governance: `0x${'0'.repeat(40)}` } });
+  const [z] = await run(mockReader({ contracts: zero, nowSec: NOW }));
+  assert.equal(z.detail.detectorBroken, true);
+  assert.match(z.message, /returned 0x0{40}/);
+
+  const notGov = healthyVault({ [GOVERNANCE]: { activeProposalOf: { revert: '0xdeadbeef' } } });
+  const [n] = await run(mockReader({ contracts: notGov, nowSec: NOW }));
+  assert.equal(n.detail.detectorBroken, true);
+  assert.match(n.message, /did not answer activeProposalOf/);
+});
+
+test('reads Governance through vault.governance() and never through any env — no address is assumed', async () => {
+  const reader = readerWith({ proposal: activeProposal() });
+  await run(reader);
+  const govReads = reader.calls.filter((c) => c.kind === 'read' && c.address === GOVERNANCE).map((c) => c.fn);
+  assert.deepEqual([...new Set(govReads)].sort(), ['activeProposalOf', 'configOf', 'proposals']);
+  assert.ok(reader.calls.some((c) => c.address === VAULT && c.fn === 'governance'));
+  assert.ok(reader.calls.every((c) => c.kind !== 'staticCall'), 'no eth_call impersonation — this signal only reads views');
+});
+
+test('ignores lifecycle events for OTHER proposals and other vaults in the same window', async () => {
+  const OTHER_VAULT = `0x${'77'.repeat(20)}`;
+  const results = await run(readerWith({
+    proposal: activeProposal(),
+    logs: [
+      log(GOVERNANCE, 'Proposed', 950, { pid: 9n, vault: OTHER_VAULT, ptype: 0, proposer: PROPOSER, actionHash: ACTION }),
+      log(GOVERNANCE, 'Executed', 951, { pid: 9n }),
+      log(GOVERNANCE, 'Finalized', 952, { pid: 2n, status: 2 }),
+    ],
+  }));
+  assert.deepEqual(alertsOf(results)[0].detail.events, []);
+});
+
+// ── read pinning (Review117 F4) ──────────────────────────────────────────────
+
+test('every state read is PINNED to toBlock, so state and logs describe the same instant', async () => {
+  const reader = readerWith({ proposal: activeProposal() });
+  await run(reader);
+  const reads = reader.calls.filter((c) => c.kind === 'read');
+  // FOUR, not `>= 3`: `vault.governance()` is a read too, and a lower bound would let a read
+  // DISAPPEAR while the pin assertion below stayed green (three pinned reads are still [toBlock]).
+  // The assertion catches un-pinning; this guard catches removal, and a loose bound forfeits it.
+  assert.equal(reads.length, 4, 'governance, activeProposalOf, proposals, configOf');
+  assert.deepEqual(
+    [...new Set(reads.map((c) => c.blockNumber))],
+    [WINDOW.toBlock],
+    'an unpinned read would come from `latest` while logs stop at toBlock — that is the wrong-tx attribution bug',
+  );
+});
+
+test('an explicit atBlock overrides the default; null and undefined both fall through to it', async () => {
+  const reader = readerWith({ proposal: activeProposal() });
+  await checkGovernanceWatch({ reader, vault: VAULT, ...WINDOW, nowSec: NOW, atBlock: 42 });
+  assert.deepEqual(
+    [...new Set(reader.calls.filter((c) => c.kind === 'read').map((c) => c.blockNumber))],
+    [42],
+  );
+
+  // `!= null` is the package idiom (nav-backing, share-conservation and reader all collapse the
+  // two), so this signal must not be the one place where null and undefined diverge.
+  for (const atBlock of [null, undefined]) {
+    const r = readerWith({ proposal: activeProposal() });
+    await checkGovernanceWatch({ reader: r, vault: VAULT, ...WINDOW, nowSec: NOW, atBlock });
+    assert.deepEqual(
+      [...new Set(r.calls.filter((c) => c.kind === 'read').map((c) => c.blockNumber))],
+      [WINDOW.toBlock],
+      `atBlock: ${atBlock} must fall through to the toBlock default`,
+    );
+  }
+});
+
+test('the settled line attributes to the LAST settling event in the pinned window, not to an earlier one', async () => {
+  // Finalized(Passed) then Executed, both inside the window: the line must name the Executed tx.
+  const results = await run(readerWith({
+    proposal: passedProposal(NOW - 5000, { status: 4 }),
+    logs: [
+      log(GOVERNANCE, 'Finalized', 970, { pid: 1n, status: 2 }, { transactionHash: '0xfinalize' }),
+      log(GOVERNANCE, 'Executed', 990, { pid: 1n }, { transactionHash: '0xexecute' }),
+    ],
+  }));
+  assert.ok(results.every((r) => r.status === 'ok'));
+  assert.match(results[0].message, /settled as Executed at block 990 \(tx 0xexecute\)/);
+});
+
+// ── skipped-phase wording (Review117 F5) ─────────────────────────────────────
+
+test('a zero timelock does not claim a timelock phase "is over" — it says the phase never existed', async () => {
+  // Governance caps timelockDuration but does not floor it, so finalize -> executable is legal.
+  const cfg = [3600, 3600, 0, 86400, 2500, 500, 5000, 3600];
+  const finalizedAt = NOW - 10;
+  const results = await run(readerWith({
+    proposal: passedProposal(finalizedAt, { executableAt: finalizedAt, expiresAt: finalizedAt + 86400 }),
+    config: cfg,
+  }));
+  const [a] = alertsOf(results);
+  assert.equal(a.key, 'execution', 'with no timelock the proposal is executable immediately');
+  const timelock = byKey(results, 'timelock');
+  assert.equal(timelock.status, 'ok');
+  assert.match(timelock.message, /has no timelock phase — timelockDuration is 0/);
+  assert.doesNotMatch(timelock.message, /is over/, 'a phase that never happened cannot be over');
+});
+
+test('the reveal-deadline hint is dropped once that deadline is in the past', async () => {
+  const past = T0 + COMMIT_S + REVEAL_S + 900; // in the tally phase, reveals long closed
+  const results = await run(readerWith({ proposal: activeProposal(), nowSec: past }), past);
+  const commit = byKey(results, 'commit');
+  assert.equal(commit.status, 'ok');
+  assert.match(commit.message, /commit phase of proposal 1 .* is over/);
+  assert.doesNotMatch(commit.message, /reveals close/, 'quoting a past deadline as if it were ahead is misleading');
+
+  // While it IS ahead, the hint is still offered.
+  const during = T0 + COMMIT_S + 30;
+  const early = await run(readerWith({ proposal: activeProposal(), nowSec: during }), during);
+  assert.match(byKey(early, 'commit').message, /reveals close/);
+});
+
+// ── end-to-end dispatch: real signal → real tracker → real tiered sink ───────
+//
+// The route test in sinks.test.mjs builds its transition as a literal, which is faithful only
+// while `tierOf` reads nothing but `t.to` and `t.signal` — it would stop being faithful the moment
+// this signal moved to CONDITIONAL_PAGE, because a predicate reads `result.detail`. This one uses
+// no literals: the transitions are whatever the real signal and the real tracker produce, and the
+// assertion is which URL physically received each POST. (Test design suggested by the Fix117
+// session, which mutation-tested the sinks.mjs version and found this gap in it.)
+
+test('a full lifecycle physically POSTs one PAGE per phase entry and every recovery to LOG', async () => {
+  const tracker = createTransitionTracker();
+  const posts = [];
+  const sink = createTieredWebhookSink({
+    pageUrl: 'https://example.invalid/page',
+    logUrl: 'https://example.invalid/log',
+    fetchImpl: async (url, init) => {
+      const body = JSON.parse(init.body);
+      posts.push({ endpoint: url.endsWith('/page') ? 'PAGE' : 'LOG', key: body.key, status: body.status });
+      return { ok: true, status: 200 };
+    },
+  });
+
+  const sweep = async (reader, now, poll) => {
+    const transitions = tracker.observe(await run(reader, now), { poll });
+    await emitAll([sink], transitions, { onError: () => { throw new Error('sink error'); } });
+  };
+
+  const finalizedAt = T0 + COMMIT_S + REVEAL_S + 10;
+  const execAt = finalizedAt + TIMELOCK_S + 5;
+  await sweep(readerWith({ pid: 0n, proposal: proposalTuple({ status: 0 }) }), T0 - 60, 1);
+  await sweep(readerWith({ proposal: activeProposal(), nowSec: T0 + 30 }), T0 + 30, 2);
+  await sweep(readerWith({ proposal: activeProposal(), nowSec: T0 + COMMIT_S + 30 }), T0 + COMMIT_S + 30, 3);
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt), nowSec: finalizedAt + 5 }), finalizedAt + 5, 4);
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt), nowSec: execAt }), execAt, 5);
+  await sweep(readerWith({ proposal: passedProposal(finalizedAt, { status: 4 }), nowSec: execAt + 60 }), execAt + 60, 6);
+
+  // Every ALERT — one per phase ENTERED — physically reached the pager.
+  assert.deepEqual(
+    posts.filter((p) => p.endpoint === 'PAGE').map((p) => p.key),
+    ['commit', 'reveal', 'timelock', 'execution'],
+    'four pages for a four-phase lifecycle: this is what "every occurrence PAGEs" means in practice',
+  );
+  // And every recovery went to the log sink, so leaving a phase never wakes anyone.
+  assert.ok(posts.filter((p) => p.endpoint === 'LOG').length >= 4);
+  assert.ok(
+    posts.filter((p) => p.endpoint === 'LOG').every((p) => p.status === 'ok'),
+    'only recoveries route LOG here — no ALERT may land on the log endpoint',
+  );
+  // Six keys observed every sweep is NOT six pages per sweep. That is the claim the PAGE tiering
+  // rests on, so it is asserted rather than argued.
+  assert.equal(posts.filter((p) => p.endpoint === 'PAGE').length, 4);
+});
+
+test('a blind governance detector does NOT page — recorded, not endorsed', async () => {
+  // tierOf routes on `to === 'alert'`, and DETECTOR BROKEN is a `skipped`. So "no proposal on this
+  // vault can be seen at all" reaches the log sink. That is the package-wide rule for every
+  // signal's non-alert statuses; changing it is an escalation across all of them and Operations'
+  // call. Pinned here so the behaviour is visible rather than discovered during an incident.
+  const tracker = createTransitionTracker();
+  const posts = [];
+  const sink = createTieredWebhookSink({
+    pageUrl: 'https://example.invalid/page', logUrl: 'https://example.invalid/log',
+    fetchImpl: async (url) => { posts.push(url.endsWith('/page') ? 'PAGE' : 'LOG'); return { ok: true, status: 200 }; },
+  });
+  const contracts = healthyVault();
+  delete contracts[VAULT].governance;
+  const results = await run(mockReader({ contracts, nowSec: NOW }));
+  assert.equal(results[0].detail.detectorBroken, true);
+  await emitAll([sink], tracker.observe(results, { poll: 1 }), { onError: () => {} });
+  assert.deepEqual(posts, ['LOG']);
+});

--- a/packages/canary/test/helpers.mjs
+++ b/packages/canary/test/helpers.mjs
@@ -25,6 +25,35 @@ export const FEE_ENGINE = A('8');
 export const SRC1 = A('a');
 export const SRC2 = A('b');
 export const SRC3 = A('c');
+/** The vault's immutable Governance module, as `vault.governance()` reports it. */
+export const GOVERNANCE = `0x${'90'.repeat(18)}0005`;
+export const PROPOSER = A('d');
+
+/**
+ * A `configOf(vault)` tuple in Governance.GovConfig field order: 1h commit, 1h reveal, 1h
+ * timelock, 1-day execution window, then the four non-timing fields. Matches base-sepolia.json's
+ * shape closely enough that the derived deadlines read like a real vault's.
+ */
+export const GOV_CONFIG = Object.freeze([3600, 3600, 3600, 86400, 2500, 500, 5000, 3600]);
+
+/**
+ * A `proposals(pid)` tuple in Governance.Proposal field order. `status` is the enum index
+ * (1 Active, 2 Passed, 3 Defeated, 4 Executed, 5 Expired); `ptype` likewise (0 Rebalance).
+ * Every test builds its proposal from this so the FIELD ORDER — which viem flattens positionally
+ * and which the decoder in signals/governance-watch.mjs depends on — is pinned in one place.
+ */
+export function proposalTuple({
+  vault = VAULT, ptype = 0, proposer = PROPOSER, createdAt = 0, commitDeadline = 0, revealDeadline = 0,
+  executableAt = 0, expiresAt = 0, status = 1, actionHash = `0x${'ab'.repeat(32)}`,
+  snapshotTotal = 500_000000000000000000n, memberCount = 2n, forWeight = 0n, againstWeight = 0n,
+  revealedWeight = 0n, revealedVoterCount = 0n,
+} = {}) {
+  return [
+    vault, ptype, proposer, BigInt(createdAt), BigInt(commitDeadline), BigInt(revealDeadline),
+    BigInt(executableAt), BigInt(expiresAt), status, actionHash, snapshotTotal, memberCount,
+    forWeight, againstWeight, revealedWeight, revealedVoterCount,
+  ];
+}
 
 // ChainlinkOracle fixtures (the LIVE oracle). Deliberately not built from A(), so they can never
 // collide with the `0x9999…`-style throwaway addresses the existing tests use inline.
@@ -137,6 +166,7 @@ export function healthyVault(overrides = {}) {
       feeEngine: FEE_ENGINE,
       creator: CREATOR,
       operatorRegistry: REGISTRY,
+      governance: GOVERNANCE,
       basketLength: 1n,
       basketAssets: () => ASSET,
       assetUnit: (a) => (lc(a) === lc(ASSET) ? 1_000000000000000000n : 0n),
@@ -157,6 +187,12 @@ export function healthyVault(overrides = {}) {
     [REGISTRY]: {
       operatorOf: () => 7n,
       operatorAddressOf: () => OPERATOR,
+    },
+    // Registered, quiet: no proposal has ever been opened. governance-watch reads OK on this.
+    [GOVERNANCE]: {
+      activeProposalOf: () => 0n,
+      configOf: () => GOV_CONFIG,
+      proposals: () => proposalTuple({ status: 0 }),
     },
   };
 

--- a/packages/canary/test/runner.test.mjs
+++ b/packages/canary/test/runner.test.mjs
@@ -18,7 +18,7 @@ import { emptyState } from '../../indexer/src/projections.mjs';
 import {
   mockReader, healthyVault, healthyState, chainlinkVault, log,
   VAULT, USDC, ORACLE, ASSET, REGISTRY, MEMBER, CREATOR, OPERATOR, SRC1, SRC2, SRC3, SEQ_FEED,
-  AGGREGATOR, AGGREGATOR_2,
+  AGGREGATOR, AGGREGATOR_2, GOVERNANCE, GOV_CONFIG, proposalTuple,
 } from './helpers.mjs';
 
 const NOW = 1_700_000_000;
@@ -115,8 +115,8 @@ test('a healthy deployment produces ZERO alerts across every signal', async () =
   assert.deepEqual(bad.map((r) => `${r.signal}: ${r.message}`), [], 'every signal must read healthy');
   assert.deepEqual(
     [...new Set(results.map((r) => r.signal))].sort(),
-    ['exit-liveness', 'fee-routing', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
-    'all six signals must actually have run',
+    ['exit-liveness', 'fee-routing', 'governance-watch', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
+    'all seven signals must actually have run',
   );
 });
 
@@ -625,7 +625,7 @@ test('a full sweep derives the early-warning bar from ORACLE_FEED_CADENCE_SECOND
 
 // ── feed identity (signal g) is wired into the sweep ─────────────────────────
 
-test('a healthy PIVOTED sweep runs SEVEN signals — feed-identity included, and silent', async () => {
+test('a healthy PIVOTED sweep runs EIGHT signals — feed-identity and governance-watch included, and silent', async () => {
   const results = await collectSignals({
     reader: mockReader({ contracts: pivotedFixture(), nowSec: NOW }),
     state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
@@ -633,11 +633,11 @@ test('a healthy PIVOTED sweep runs SEVEN signals — feed-identity included, and
   assert.deepEqual(results.filter((r) => r.status !== 'ok').map((r) => r.message), []);
   assert.deepEqual(
     [...new Set(results.map((r) => r.signal))].sort(),
-    ['exit-liveness', 'fee-routing', 'feed-identity', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
+    ['exit-liveness', 'fee-routing', 'feed-identity', 'governance-watch', 'module-events', 'nav-backing', 'oracle-freshness', 'share-conservation'],
   );
 });
 
-test('a RETIRED-oracle sweep still runs exactly six signals — feed-identity has nothing to watch there', async () => {
+test('a RETIRED-oracle sweep still runs exactly seven signals — feed-identity has nothing to watch there', async () => {
   const results = await collectSignals({
     reader: mockReader({ contracts: healthyFixture(), nowSec: NOW }),
     state: healthyState(), vaults: [VAULT], cfg: baseCfg, window: WINDOW,
@@ -816,4 +816,29 @@ test('CANARY_TEST_ALERT_ON_START fires the self-test once, before the sweep loop
       'the self-test must never be recorded as a real signal transition, even once the real sweep loop has also run',
     );
   });
+});
+
+// ── governance watch (signal h) is wired into the sweep ──────────────────────
+
+test('an open proposal pages exactly once from governance-watch while every other signal reads healthy', async () => {
+  const contracts = healthyFixture({
+    [GOVERNANCE]: {
+      activeProposalOf: () => 1n,
+      configOf: () => GOV_CONFIG,
+      proposals: () => proposalTuple({ createdAt: NOW - 60, commitDeadline: NOW + 3540, revealDeadline: NOW + 7140, status: 1 }),
+    },
+  });
+  const results = await collectSignals({
+    reader: mockReader({ contracts, nowSec: NOW }), state: healthyState(),
+    vaults: [VAULT], cfg: baseCfg, window: WINDOW,
+  });
+  const alerts = results.filter((r) => r.status === 'alert');
+  assert.equal(alerts.length, 1, alerts.map((r) => r.message).join('; '));
+  assert.equal(alerts[0].signal, 'governance-watch');
+  assert.equal(alerts[0].key, 'commit');
+  assert.equal(alerts[0].detail.revealDeadline, NOW + 7140);
+  assert.equal(alerts[0].detail.earliestExecuteAt, NOW + 7140 + GOV_CONFIG[2]);
+  // The sweep found Governance through the vault itself — no config carries its address.
+  assert.equal(alerts[0].detail.governance, GOVERNANCE);
+  assert.equal(baseCfg.governance, undefined);
 });

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -160,6 +160,30 @@ test('tierOf: detail.tier is honoured ONLY alongside detail.selfTest — a real 
   assert.equal(tierOf(promoted), 'log', 'and the override cannot promote a real LOG signal either');
 });
 
+test('a governance-watch ALERT reaches the PAGER, and its recovery and blind-detector lines do not', async () => {
+  // Monitoring Gap Analysis §3 item 5 is explicit that this signal pages. Asserting the ROUTE, not
+  // membership of PAGE_SIGNALS, is what stops a future tierOf() refactor from quietly demoting it:
+  // the set could stay correct while the derivation stopped consulting it.
+  const { SIGNAL: GOVERNANCE_WATCH } = await import('../src/signals/governance-watch.mjs');
+  const calls = [];
+  const sink = createTieredWebhookSink({
+    pageUrl: 'https://example.invalid/page', logUrl: 'https://example.invalid/log',
+    fetchImpl: async (url) => { calls.push(url); return { ok: true, status: 200 }; },
+  });
+  await sink.emit(tr('alert', GOVERNANCE_WATCH));
+  // Leaving a phase is a RECOVERED line and a blind governance detector is a DEGRADED one; both
+  // route LOG, because tierOf pages only on `to === 'alert'`. That is the package-wide rule for
+  // every signal's non-alert statuses, recorded here rather than changed.
+  await sink.emit(tr('ok', GOVERNANCE_WATCH));
+  await sink.emit(tr('skipped', GOVERNANCE_WATCH));
+  assert.deepEqual(calls, [
+    'https://example.invalid/page',
+    'https://example.invalid/log',
+    'https://example.invalid/log',
+  ]);
+  assert.equal(tierOf(tr('alert', GOVERNANCE_WATCH)), 'page');
+});
+
 test('coverage: every signal ON DISK is an explicit PAGE / CONDITIONAL / LOG decision', async () => {
   const liveSignals = await signalNamesOnDisk();
   // Not a file: `canary-runner.mjs` synthesises this one when a whole vault is unreadable.


### PR DESCRIPTION
## What

Closes **Monitoring Gap Analysis G8 / Incident Catalogue OPS-7**: a new read-only canary signal, `governance-watch`, that says when a proposal has opened and exactly when its windows close. Until now nothing alerted on a proposal at all, so a hostile proposal could move through commit into reveal overnight and consume the only defence window the design has ("publish analysis during the reveal window").

## How it works

- **Finds Governance through the vault itself** — `VaultCore.governance()` is a public immutable, so no new env var. Reads `activeProposalOf(vault)`, `proposals(pid)`, `configOf(vault)`.
- **Phase is derived from stored deadlines against chain time**, not from events. The real contract has no `ProposalCreated` (the gap note's name) — it has `Proposed`, `Finalized`, `Executed`, `ProposalExpired` — and the two transitions that matter most, commit→reveal and timelock→executable, are clock crossings that emit **no event at all**. An event-only scan would miss both. The four lifecycle events are scanned over the poll window (same `MAX_LOG_SPAN_BLOCKS` plumbing as `module-events`) for block/tx attribution only; a scan gap costs a tx hash, never a page.
- **One transition key per phase** — `commit`, `reveal`, `tally` (reveals closed, `finalize` pending), `timelock`, `execution`, `lapsed` — all emitted every sweep; the current phase reads ALERT, the other five OK. Entering a phase is one line, leaving it is one line. A single key with a changing message would emit nothing on commit→reveal, because the tracker keys on status. A full lifecycle is eight lines spread over hours or days; the lifecycle test pins that exact sequence.
- **Phase boundaries copy `Governance.sol`'s requires exactly** and the tests pin them: `now < commitDeadline`, `commitDeadline ≤ now < revealDeadline`, `now ≥ revealDeadline`, `executableAt ≤ now ≤ expiresAt` (inclusive at the top), `now > expiresAt`.
- **`detail` carries** `revealDeadline` (+ ISO), `earliestExecuteAt` (+ ISO, exact once Passed via `executableAt`; a stated *lower bound* `revealDeadline + timelock` while Active, because `finalize` is permissionless and a late finalize moves everything later — no upper bound is claimed), `executionWindowClosesAt`, the decoded proposal and the four config durations, `modeFExitQueueing` (VO-8), the window's events, `severity: 'SEV-2'`, `incident: 'OPS-7'`, `gap: 'G8'`, `actionHash`, `payloadOnChain: false`.
- **Routing is not in the signal, but it IS wired.** Operations owns the spec (SEV-2; page 08:00–24:00 UTC, queue overnight — Severity Ladder). No time-of-day logic and no response-time promise appears in any string; the waking-hours half is the receiver's. `governance-watch` is now in `PAGE_SIGNALS` (`sinks.mjs`), so its ALERTs reach `PAGE_WEBHOOK_URL` and its recoveries and DETECTOR BROKEN lines reach `LOG_WEBHOOK_URL`.

## Tiering, after #109 and #121 both merged

**This supersedes two earlier versions of this section.** The first said PAGE routing would land later with #109; the second was written against #109's two-category model. Both are gone because both became false — #109 merged, then #121 replaced the model with three categories and a `readdir`-based coverage test. What follows is measured against `c3c789ba`.

`governance-watch` is in **`PAGE_SIGNALS`, unconditionally**.

**Putting it in PAGE at all is a citation, not an escalation.** Monitoring Gap Analysis §3 item 5 specifies this signal as *"every occurrence PAGEs at SEV-2 during waking hours"* in as many words. The waking-hours half is the receiver's; nothing in this process knows the time of day, and no string it emits promises a response time.

**Why unconditional, and not #121's new `CONDITIONAL_PAGE`.** This signal has the shape that category exists for — one name covering two severities, a routine creator rebalance and a hostile proposal — and it will page on the routine one. What it lacks is the **discriminator**, which is what the category actually requires. `feed-identity` earned it because chain state says which severity you are in (`detail.harm`). All three candidate predicates here fail:

1. **The payload** — the axis the severities genuinely differ on — is not on-chain until `execute`. `Proposed` carries only `actionHash`, which is why this signal ships `payloadOnChain: false`. There is nothing to condition on.
2. **The proposer is the wrong thing to condition on, on the merits — not because it is hard.** Incident Catalogue OPS-7 opens *"An operator key signs a bad proposal, or a hostile bloc passes a rebalance"*: the operator key is the **first named threat this signal exists for**. Any proposer predicate — including the cheap one, a creator/operator allowlist, which needs no scoring at all and is trivially available on-chain — would demote exactly the case OPS-7 names first. Stating this as "the proposer cannot be scored" would have been a *capability* claim, and a capability claim is refuted by building the capability; the merits version is the one that survives someone who finds flat PAGE inconvenient.
3. **The phase** is the wrong axis. The two arguably-less-urgent keys are `tally` and `lapsed`, and both mean a governance action is *stalled* — untallied, or passed and never executed. Demoting them demotes the wrong two.

Paging on a routine proposal is therefore an accepted cost, not an oversight. The reasoning lives in `docs/CANARY.md` §3(h) rather than only in a code comment, because the question a reader will ask after #121 is "why not a predicate here too?" and the answer should be where operators read. If a payload-publication location ever exists, predicate 1 becomes available and the decision should be revisited.

**Volume is bounded by CM-6, not by phase durations.** `propose` requires the previous proposal to be settled (`Governance.sol:278`), so one vault cannot run two at once however many proposers try — and that, not the phase lengths, is the answer to M-7's per-proposer cooldown sidestep. An earlier version of this PR said "every phase is at least an hour"; **that is false** and is corrected here. `_validateConfig` floors `commitDuration`, `revealDuration` and `executionWindow` at 1 hour but only *caps* `timelockDuration`, so a zero timelock is legal and that phase is skipped outright — which is also what finding F5 is about.

**Evidence is dispatch-based, not set membership.** Two tests drive the real signal through the real transition tracker into a real `createTieredWebhookSink` and assert **which endpoint physically received each POST**: a full lifecycle produces exactly four PAGE posts keyed `commit`/`reveal`/`timelock`/`execution` with every recovery on LOG, and a blind governance detector posts LOG only. Membership alone would let a later `tierOf` refactor demote the signal while `PAGE_SIGNALS` still looked correct. No hand-maintained entry was added to the coverage test — #121's `readdir` finds the file by itself.

## The unpublished-payload sub-check (security-ops §5.3) — NOT buildable, and why

The payload is not on-chain until `execute(pid, payload)`; `Proposed` carries only `actionHash`. There is no publication surface anywhere in this tree: the indexer projection folds the hash only, `apps/api` has no proposal route, and `packages/reference-agent/src/evaluators.mjs` itself states the payload is opaque from chain state and expects an out-of-band `knownActions` map. A read-only monitor has nothing to read. `detail.actionHash` and `detail.payloadOnChain: false` ride along so a receiver with an out-of-band source can compare; the check lands the day a publication location exists.

## Read-only invariant

Views only (`governance`, `activeProposalOf`, `proposals`, `configOf`) plus `getLogs`. No `staticCall`, no key. `test/reader.test.mjs` unchanged and passing; the new abis test asserts the Governance table is all-`view`.

## Tests

- `packages/canary/test/governance-watch.test.mjs` — 17 tests: every boundary, every phase's alert with its deadlines checked against the fixture's stored fields, settled outcomes, the full lifecycle through the transition tracker (exact line sequence), restart-does-not-re-page, three DETECTOR BROKEN branches, event filtering by pid/vault, and a read-surface assertion.
- `abis.test.mjs` +3: the Governance getters' **full flattened output shape** (public mapping-to-struct getters flatten positionally — a reordered field would swap two deadlines silently) and the events' indexed flags, against the compiled `Governance`.
- `runner.test.mjs`: signal-set lists updated (seven / eight), plus an end-to-end sweep in which an open proposal pages exactly once.
- `sinks.test.mjs`: the PAGE/LOG routing test above, plus `governance-watch` added to the coverage test's `liveSignals`.
- Shared fixture: `healthyVault()` gained `governance` + a quiet Governance contract so every other signal's healthy fixture stays healthy. **284 canary tests, 0 fail, 0 skipped**, none loosened or deleted.

## Files

`packages/canary/src/signals/governance-watch.mjs` (new), `packages/canary/test/governance-watch.test.mjs` (new), `packages/canary/src/abis.mjs`, `packages/canary/src/canary-runner.mjs`, `packages/canary/src/sinks.mjs`, `packages/canary/test/{abis,runner,sinks}.test.mjs`, `packages/canary/test/helpers.mjs`, `packages/canary/README.md`, `docs/CANARY.md` (§3(h), §4, §5.3, §6), `docs/DEPLOYMENT.md` (§7 row). `contracts/src/` untouched, so there are no EIP-170 margins to report.

## Gate

`npm run gate` on the pushed tree (`9c5afb27`, on `c3c789ba`): **GATE PASSED (591.4s), 9/9 steps**, one advisory warning — Slither's standing informational output. `cd contracts && forge clean` was run first, per the COMMON brief's note that a green gate leaves the artifact in the state that makes the next one fail step 6. `contracts/src` is untouched, so there are no EIP-170 margins to report. **284 canary tests, 0 fail, 0 skipped.**

**Every number in this body is measured on `9c5afb27`.** Earlier revisions quoted 247, 269 and 274 tests and gates of 503s and 573s, each against a tree that no longer exists. A measured number in prose is a citation and it goes stale exactly the way a line number does.

**Every number in this body is measured on `bc2b1f23` and none is carried across a rebase.** Earlier revisions quoted 247, then 269, then 274 tests and a 503s gate — all against trees that no longer exist. A measured number in prose is a citation and it goes stale exactly the way a line number does.

Two comment-only hunks landed after that run (the "do not collapse the six keys" note in the signal header and §3(h)). Rather than add a sixth concurrent `forge build` to an already-saturated machine, I re-ran the only steps a comment in a `.mjs`/`.md` file can affect — `node --check` over all six gate entrypoints, and `npm run test:backend` (**890 pass, 0 fail, 2 pre-existing env-conditional skips**). The seven Solidity steps cannot be affected by them. Full detail in the findings file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
