### PR TITLE
fix(canary): page on a latching feed-identity drift, withhold the dead-man on an empty watch set (Review109 REJECT findings on #109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,17 +61,28 @@ HEARTBEAT_MS=3600000                     # hourly "still watching" line so silen
                                          # Non-negotiable (security-ops.md §5.2) — set 0 to opt out.
 # ── Canary alerting (docs/CANARY.md §5.3) ──
 # PAGE_WEBHOOK_URL=https://hooks.example/canary-page   # nav-backing / share-conservation /
-                                         # fee-routing / exit-liveness / oracle-freshness ALERTs
+                                         # fee-routing / exit-liveness / oracle-freshness ALERTs,
+                                         # plus feed-identity ALERTs that carry HARM (a decimals or
+                                         # denomination drift — those LATCH and are not caught by
+                                         # the sane-price band above BTC $100k)
 # LOG_WEBHOOK_URL=https://hooks.example/canary-log     # everything else (recoveries, DEGRADED,
-                                         # DETECTOR BROKEN, feed-identity)
+                                         # DETECTOR BROKEN, and the self-clearing feed-identity
+                                         # aggregator-swap ALERT)
 # ALERT_WEBHOOK_URL=https://hooks.example/canary       # back-compat fallback for whichever of the
                                          # two above is unset; set only this for pre-tiering behaviour
 # DEADMAN_PING_URL=https://hc-ping.com/your-check-uuid # off-host dead-man's switch, pinged once per
-                                         # successful sweep. Off by default. The check ACCOUNT on the
-                                         # external service is a human task, not this code's job.
+                                         # successful sweep THAT WATCHED AT LEAST ONE VAULT — an
+                                         # empty watch set withholds the ping on purpose, so the
+                                         # external check goes red instead of reporting a canary that
+                                         # is watching nothing. Off by default. The check ACCOUNT on
+                                         # the external service is a human task, not this code's job.
 # CANARY_TEST_ALERT_ON_START=1           # fire one synthetic PAGE + one synthetic LOG transition
                                          # through the real sinks at startup, before the first real
                                          # page — or run on demand: `node canary-runner.mjs test-alert`
+                                         # DO NOT LEAVE THIS SET. Compose runs the canary under
+                                         # `restart: unless-stopped`, so it re-fires a synthetic PAGE
+                                         # on EVERY automatic restart, not once. Startup warns when
+                                         # it is on; unset it as soon as both tiers have arrived.
 
 # ── API pricing (x402) ──
 PRICE_ASSET=0x036CbD53842c5426634e7929541eC2318f3dCF7e   # USDC on the chain above

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,12 @@ services:
   # Post-launch canary (docs/CANARY.md). Read-only against the chain: no key, no wallet, no
   # transaction — it only reads. It mounts the shared volume because two of its signals compare
   # the indexer's projection against chain state; it reads that snapshot and never writes it.
-  # Silent while healthy: one line per signal transition, nothing otherwise. Set ALERT_WEBHOOK_URL
-  # in .env to also POST each transition.
+  # Silent while healthy: one line per signal transition, nothing otherwise. Set PAGE_WEBHOOK_URL /
+  # LOG_WEBHOOK_URL in .env to also POST each transition, split by severity tier (or the single
+  # ALERT_WEBHOOK_URL fallback for both), and DEADMAN_PING_URL for the off-host dead-man's switch —
+  # `restart: unless-stopped` below restarts a CRASHED canary, but only something not on this host
+  # notices a dead host. Do NOT leave CANARY_TEST_ALERT_ON_START set in .env: this service restarts
+  # automatically and the self-test fires on every one of those restarts (docs/CANARY.md §5.3).
   canary:
     build: .
     command: npm run start:canary

--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -511,17 +511,35 @@ Severity Ladder rates SEV-1/2 and worth waking a human for: `nav-backing`, `shar
 `fee-routing`, `exit-liveness`, `oracle-freshness` (this is the "oracle-v2"/"oracle-health" the
 Monitoring Gap Analysis' §3 item 4 refers to — `signals/oracle-health.mjs`'s `SIGNAL` constant is
 still `'oracle-freshness'`, unchanged across the post-pivot rename). `LOG_WEBHOOK_URL` receives every
-other transition: recoveries, every DEGRADED / DETECTOR BROKEN line, and `feed-identity` — that
-signal can ALERT (§3(g)) but is deliberately not in the PAGE list: a benign aggregator-swap ALERT
-there self-clears the next sweep by design, and escalating that list further is Operations' call, not
-inferred here. `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback used for whichever of
+other transition: recoveries, every DEGRADED / DETECTOR BROKEN line, and the harmless half of
+`feed-identity`. `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback used for whichever of
 the two is unset — set only that one and every transition reaches the one configured URL exactly
 once per transition, same as before tiering existed. The webhook body also carries a `tier: 'page'|
 'log'` field, so a receiver on a single shared URL can still route without re-deriving the map.
 
+**`feed-identity` pages on HARM only.** `feed-identity` (§3(g)) is the one signal whose ALERTs are
+not all the same severity, so it routes on a predicate (`CONDITIONAL_PAGE` in `sinks.mjs`) rather
+than on its name: **PAGE** when `detail.harm` is `'decimals'` or `'denomination'`, **LOG** when it is
+`null` (the aggregator swap). The two harm cases LATCH — `ChainlinkOracle`'s cached scale and its
+USD-quoted proof are fixed at construction and its config is immutable, so a drift there is not a
+freeze, it is every price being silently wrong until the vault is evacuated. The swap case is
+legitimate routine Chainlink operation and self-clears on the next sweep once the pin is re-taken.
+Nothing else covers the harm cases: the sane-price band catches a ±2-decimal drift only while the
+live price sits inside the band, and per `Owner Decisions 2026-09-01.md` §1 that window closes for
+cbBTC at BTC $100,000 — above it `feed-identity` is the only detector there is, and `nav-backing`
+cannot substitute because it recomputes through the same mis-scaled `priceWad`. The Monitoring Gap
+Analysis' §3 item 4 PAGE list was written 2026-08-30, before `feed-identity` existed (2026-09-01,
+PR #103), so its "LOG: everything else" never ruled on this; the tier map here is the reconciliation
+and the note remains Operations' to update.
+
 **Off-host dead-man's switch.** `DEADMAN_PING_URL` is pinged (plain `GET`) once per **successful**
-sweep — the same condition that gates the `ops-check` heartbeat file, so a canary that cannot reach
-the RPC neither claims to be watching nor pings as if it were. Point it at an external
+sweep that watched **at least one vault** — a canary that cannot reach the RPC, and a canary whose
+watch set is empty (no `VAULTS`, missing or unmounted indexer snapshot), are both "not watching the
+chain" and neither may tell the one off-host monitor otherwise. A sweep that finds no vaults logs
+`sweep.no_vaults` and says on stderr that the ping is being withheld, so the external check going red
+reads as the configuration problem it is. The on-host `ops-check` heartbeat file is still written in
+that state: it reports process liveness, and promoting an empty watch set to "canary dead" there is
+an Operations decision, not this package's. Point it at an external
 heartbeat-monitoring check — e.g. a Healthchecks.io-style URL (`https://hc-ping.com/<uuid>`) — so a
 dead host is noticed by something that is not itself on that host. Off by default when unset; a
 failed ping is logged, never fatal — the ping's whole purpose is to be noticed from outside this
@@ -536,7 +554,15 @@ transition through the exact sinks a real sweep uses, right after startup and be
 begins. On demand, without starting anything: `node packages/canary/src/canary-runner.mjs test-alert`
 (mirrors the existing `verify` subcommand — same env, no sweep). Both paths bypass the transition
 tracker entirely, so a self-test can never plant fake state in `CANARY_STATE_PATH` that would
-suppress a real future transition on a colliding id.
+suppress a real future transition on a colliding id. The forced tier travels as
+`detail.tier` alongside `detail.selfTest: true`, and `tierOf` honours it **only** in that pair — a
+real signal's `detail` is a bag of decoded on-chain values, and one that happened to carry a field
+named `tier` must not be able to demote its own page.
+
+> **Do not leave `CANARY_TEST_ALERT_ON_START` set in `.env`.** Compose runs the canary under
+> `restart: unless-stopped`, so it fires a synthetic PAGE on **every** automatic restart, not once.
+> Startup warns on stderr when it is set. Run the self-test, confirm both tiers arrived, unset it —
+> or use the `test-alert` subcommand, which is the same path without starting the service.
 - **Cold start sees no history.** With the default `LOG_LOOKBACK_BLOCKS=0`, the first sweep scans a
   single block, so `ModuleCallFailed`, `SliceEscrowed`, and fee outflows from *before* the canary
   started are never reported. That is deliberate — starting a monitor should not replay a backlog as

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -240,12 +240,16 @@ when one fires. Reuses `RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `CONFIRMATIONS`, `ST
 | `OPERATOR_REGISTRY_ADDRESS` | | — | enables the fee-routing signal |
 | `CANARY_STATE_PATH` | | `./data/canary-state.json` | its OWN transition state — never the indexer's |
 | `CANARY_POLL_INTERVAL_MS` | | `30000` | sweep cadence; named apart from the indexer's `POLL_INTERVAL_MS` |
-| `ALERT_WEBHOOK_URL` | | — | POST one JSON body per transition |
+| `PAGE_WEBHOOK_URL` | | — | POST one JSON body per **PAGE-tier** transition — the wake-a-human set (docs/CANARY.md §5.3) |
+| `LOG_WEBHOOK_URL` | | — | POST one JSON body per **LOG-tier** transition — everything else |
+| `ALERT_WEBHOOK_URL` | | — | back-compat fallback for whichever of the two above is unset; set only this and behaviour is pre-tiering |
+| `DEADMAN_PING_URL` | | — | off-host dead-man's switch, `GET` once per successful sweep that watched **at least one vault** (docs/CANARY.md §5.3) |
+| `CANARY_TEST_ALERT_ON_START` | | off | `1`/`true`: fire the alert self-test at startup. **Fires on every restart** — see docs/CANARY.md §5.3 |
 | `NAV_DIVERGENCE_BPS` | | `50` | NAV composition bar, 50 = 0.5% |
 | `ORACLE_MIN_MARGIN` | | `0` | retired-oracle deployments only — alert when fresh sources minus quorum <= this |
 | `ORACLE_FEED_CADENCE_SECONDS` | | — | `ChainlinkOracle` only — `addr:seconds` feed cadences that drive the derived early-warning bar (docs/CANARY.md §3a) |
 | `ORACLE_STALENESS_WARN_PCT` | | unset (derived) | `ChainlinkOracle` only — manual override of that bar; unset lets it derive from the cadence above |
-| `HEARTBEAT_MS` | | `0` (off) | periodic "still watching" line (distinct from the heartbeat FILE in §8.2) |
+| `HEARTBEAT_MS` | | `3600000` (one hour) | periodic "still watching" line (distinct from the heartbeat FILE in §8.2). Non-negotiable per security-ops.md §5.2; set `0` to explicitly opt out |
 | `SNAPSHOT_BACKUPS` / `SNAPSHOT_BACKUP_INTERVAL_MS` | | `3` / `300000` | backup ring for the canary state file too (§8.3) |
 | `HEARTBEAT_DIR` | | dirname of `STATE_PATH` | where `canary.heartbeat.json` is written (§8.2) |
 | `LOG_FORMAT` / `LOG_LEVEL` | | | as above (§8.1) |
@@ -424,6 +428,7 @@ Events worth knowing:
 | `starting` / `listening` | all | boot, with the resolved config on the line |
 | `batch.indexed` (via `indexer.progress`) | indexer | a block range was folded and snapshotted |
 | `poll.failed` / `sweep.failed` | indexer, canary | one cycle failed; it will retry |
+| `sweep.no_vaults` | canary | the canary is UP and watching **nothing** — the dead-man ping is withheld until this clears |
 | `snapshot.reload_failed` | api | serving **stale-but-valid** state — see the incident table |
 | `http.rate_limited` | api | a free route returned 429 |
 | `canary.transition` | canary | a signal changed state — **the** line to page on |
@@ -431,8 +436,9 @@ Events worth knowing:
 | `shutdown.begin` / `.step` / `.complete` | all | a clean stop, hook by hook |
 | `shutdown.timeout` / `.forced` | all | a stop that did **not** finish cleanly |
 
-Alert transitions are also delivered to `ALERT_WEBHOOK_URL` as structured JSON if set — the log is
-not the only path (see [CANARY.md](CANARY.md)).
+Transitions are also delivered as structured JSON to `PAGE_WEBHOOK_URL` / `LOG_WEBHOOK_URL` by
+severity tier (`ALERT_WEBHOOK_URL` is the single-endpoint fallback), and each body carries its own
+`tier` field — the log is not the only path (see [CANARY.md](CANARY.md) §5.3).
 
 ### 8.2 Heartbeats and `ops-check`
 

--- a/packages/canary/README.md
+++ b/packages/canary/README.md
@@ -72,18 +72,27 @@ every transition, same channel, no severity. Full env reference is in
 - **Tiered webhooks.** `PAGE_WEBHOOK_URL` gets only ALERT transitions on `nav-backing`,
   `share-conservation`, `fee-routing`, `exit-liveness`, `oracle-freshness` — the signals Operations'
   Severity Ladder puts at SEV-1/2 and worth waking for. `LOG_WEBHOOK_URL` gets everything else:
-  recoveries, every DEGRADED/DETECTOR BROKEN line, and `feed-identity` (its own ALERT self-clears or
-  is caught at the weekly ops review by design). `ALERT_WEBHOOK_URL` is the backwards-compatible
+  recoveries, every DEGRADED/DETECTOR BROKEN line, and the self-clearing half of `feed-identity`.
+  `ALERT_WEBHOOK_URL` is the backwards-compatible
   fallback for whichever of the two is unset; set only that one and behaviour is exactly what it was
   before tiering existed.
-- **Off-host dead-man's switch.** `DEADMAN_PING_URL` is pinged once per successful sweep. `ops-check`
+- **`feed-identity` pages on harm only.** Its `decimals` / `denomination` ALERTs LATCH (the oracle's
+  cached scale is immutable — every price since is silently wrong, not frozen) and PAGE; its
+  aggregator-swap ALERT self-clears next sweep and LOGs. `sinks.mjs`'s `CONDITIONAL_PAGE` keys that
+  on `detail.harm != null`. Above BTC $100,000 the sane-price band stops catching a −2-decimal drift
+  (`Owner Decisions 2026-09-01.md` §1), and this is then the only detector.
+- **Off-host dead-man's switch.** `DEADMAN_PING_URL` is pinged once per successful sweep **that
+  watched at least one vault** — an empty watch set is not "watching", so the ping is withheld and
+  the external check goes red rather than reporting a canary that watches nothing. `ops-check`
   (`packages/oplog`) already detects a stalled canary, but it runs on the *same host* — this ping is
-  the thing that notices from outside it. Off by default; provisioning the external check account
-  (e.g. Healthchecks.io) is a human task, not something this package does.
+  the thing that notices from outside it. Off by default (startup says so on stderr); provisioning
+  the external check account (e.g. Healthchecks.io) is a human task, not something this package does.
 - **Alert self-test.** `CANARY_TEST_ALERT_ON_START=1` fires one synthetic PAGE and one synthetic LOG
   transition through the real sinks right after startup — the "the first real page must not be the
   first test" requirement (security-ops.md §5.3). Same thing on demand, without starting the sweep
   loop: `node packages/canary/src/canary-runner.mjs test-alert`. Never touches transition state.
+  **Do not leave it set in `.env`:** compose restarts this service automatically and it fires on
+  every restart. Startup warns when it is on.
 
 ## Tests
 

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -399,7 +399,12 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
 
     const { vaults, state } = await resolveVaults();
     if (vaults.length === 0) {
-      errLine(`canary: no vaults to watch — set VAULTS, or point STATE_PATH at an indexer snapshot that has seen a VaultCreated (currently ${cfg.statePath})`);
+      // Structured as well as printed: this is the state in which the canary is UP and watching
+      // NOTHING, which is exactly the state an operator must be able to alert on from the log
+      // stream (docs/RUNTIME.md §8.1). The dead-man ping is withheld for the same reason — see
+      // `loop()`.
+      logger.warn?.('sweep.no_vaults', { statePath: cfg.statePath, vaultsConfigured: cfg.vaults.length });
+      errLine(`canary: no vaults to watch — set VAULTS, or point STATE_PATH at an indexer snapshot that has seen a VaultCreated (currently ${cfg.statePath}). The off-host dead-man ping is being WITHHELD until at least one vault is in scope, so the external monitor will go red rather than report a canary that is watching nothing.`);
       return { transitions: [], results: [], vaults: [] };
     }
 
@@ -468,7 +473,15 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
         // monitoring anything and must not keep telling ops-check that it is — and, symmetrically,
         // must not ping the off-host dead-man's switch either.
         await heartbeat.beat({ vaults: vaults.length, tracked: tracker.size, notOk: tracker.unhealthy().length, lastScannedBlock });
-        await deadman.ping();
+        // ZERO vaults is a successful sweep of nothing: the RPC answered, no signal ran, no
+        // transition could possibly fire. Pinging the off-host dead-man there would make the
+        // EXTERNAL monitor — the one thing not on this host — report "alive" while the canary is
+        // blind (missing snapshot, unset VAULTS, unmounted volume). So the ping is withheld and the
+        // external check goes red, which is the correct alarm for "nobody is watching the chain".
+        // The on-host heartbeat file is still written: `ops-check` reports process liveness, and
+        // turning a configuration problem into a "canary process dead" page is Operations' call to
+        // make, not this PR's.
+        if (vaults.length > 0) await deadman.ping();
         if (cfg.heartbeatMs > 0 && Date.now() - lastHeartbeatLine >= cfg.heartbeatMs) {
           lastHeartbeatLine = Date.now();
           const bad = tracker.unhealthy();
@@ -488,12 +501,33 @@ export async function buildCanary(cfg, { log, error, logger = loggerFromEnv('can
       if (signal.aborted) ac.abort();
       else signal.addEventListener('abort', () => ac.abort(), { once: true });
     }
+    // Booleans, never the URLs: a Slack/PagerDuty webhook and a Healthchecks.io ping UUID are both
+    // credentials, and this log stream is shipped off-host.
     logger.info?.('starting', {
       chainId: cfg.chainId, pollIntervalMs: cfg.pollIntervalMs, statePath: cfg.statePath,
       canaryStatePath: cfg.canaryStatePath, tracked: tracker.size, readOnly: true,
+      pageWebhook: Boolean(cfg.pageWebhookUrl), logWebhook: Boolean(cfg.logWebhookUrl),
+      deadman: deadman.enabled, testAlertOnStart: Boolean(cfg.testAlertOnStart),
+      heartbeatMs: cfg.heartbeatMs,
     });
     line(`canary up: chain ${cfg.chainId}, read-only, polling every ${cfg.pollIntervalMs}ms. Silence means healthy.`);
-    if (cfg.testAlertOnStart) await testAlert();
+    // A sink that is not configured is a sink that will not deliver, and the only moment anyone
+    // reads these lines is the moment they start the service. Saying it once here is the difference
+    // between "silence means healthy" and "silence means nothing was ever wired up".
+    line(`canary sinks: PAGE webhook ${cfg.pageWebhookUrl ? 'configured' : 'NOT configured'}, LOG webhook ${cfg.logWebhookUrl ? 'configured' : 'NOT configured'}, off-host dead-man ${deadman.enabled ? 'configured' : 'NOT configured'}.`);
+    if (!deadman.enabled) {
+      errLine('canary: DEADMAN_PING_URL is unset — nothing OFF THIS HOST will notice if this canary or its host dies. ops-check runs on the same host and cannot cover that. Set it to a Healthchecks.io-style check URL (docs/CANARY.md §5.3).');
+    }
+    if (!cfg.pageWebhookUrl && !cfg.logWebhookUrl) {
+      errLine('canary: neither PAGE_WEBHOOK_URL nor LOG_WEBHOOK_URL (nor the ALERT_WEBHOOK_URL fallback) is set — transitions go to the log and nowhere else. Nobody is being paged.');
+    }
+    if (cfg.testAlertOnStart) {
+      // Compose runs this service under `restart: unless-stopped`. Left set in `.env`, this fires a
+      // synthetic PAGE on every crash-restart, not once — loud here so it is not discovered by the
+      // on-call rotation. See docs/CANARY.md §5.3.
+      errLine('canary: CANARY_TEST_ALERT_ON_START is set — firing one synthetic PAGE and one synthetic LOG transition now. This fires on EVERY start, including every automatic restart under `restart: unless-stopped`; unset it once the self-test has passed.');
+      await testAlert();
+    }
     running = loop(ac.signal);
     return running;
   }

--- a/packages/canary/src/sinks.mjs
+++ b/packages/canary/src/sinks.mjs
@@ -7,7 +7,8 @@
  *            gives you a pure problem feed.
  * webhook  — plain, single-URL POST of one JSON body per transition. Kept for callers that only
  *            want one endpoint.
- * tiered webhook — PAGE vs LOG by signal (Monitoring Gap Analysis §2 G6 / §3 item 4): `sinks.mjs`
+ * tiered webhook — PAGE vs LOG by signal, and by a per-alert predicate where one signal name
+ *            covers alerts of two severities (Monitoring Gap Analysis §2 G6 / §3 item 4): `sinks.mjs`
  *            used to be console + one generic webhook, every transition, same channel, no
  *            severity — this is that gap closed. `PAGE_WEBHOOK_URL` / `LOG_WEBHOOK_URL` route to
  *            two endpoints; `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback for
@@ -31,41 +32,77 @@ export function createConsoleSink({ log = console.log, error = console.error } =
 }
 
 /**
- * Signals that PAGE on ALERT — the four "member capital wrong-priced or invariant broken" /
+ * Signals that PAGE on EVERY ALERT — the four "member capital wrong-priced or invariant broken" /
  * "flagship freeze detector" signals the Monitoring Gap Analysis §3 item 4 names explicitly:
  * "PAGE: nav-backing, share-conservation, fee-routing, exit-liveness ALERT, oracle-v2 ALERT".
  * `oracle-freshness` is the SIGNAL name `signals/oracle-health.mjs` still emits post-pivot (the
  * file was renamed, the wire name was not, so standing transition state and this map both survive
  * the rename) — it is the "oracle-v2" the note refers to.
  *
- * Deliberately NOT here even though it can ALERT: `feed-identity` (G2's on-chain half) — the note's
- * PAGE list does not include it, an aggregator-swap ALERT there self-clears on the next sweep by
- * design, and a decimals-change ALERT there is exactly the kind of thing the weekly ops review is
- * built to catch. Escalating that list is Operations' call, not something to infer here.
+ * `feed-identity` is not here because only SOME of its alerts page — see `CONDITIONAL_PAGE`.
  */
 export const PAGE_SIGNALS = new Set([
   'nav-backing', 'share-conservation', 'fee-routing', 'exit-liveness', 'oracle-freshness',
 ]);
 
 /**
- * Every OTHER signal name the runner can currently emit, spelled out on purpose rather than left
- * as "whatever isn't in PAGE_SIGNALS". A signal rename that lands in neither set fails
- * `sinks.test.mjs`'s coverage test instead of silently defaulting to LOG (or PAGE).
+ * Signals whose ALERTs page on a PREDICATE rather than on the signal name alone, because one signal
+ * name covers alerts of two genuinely different severities.
+ *
+ * `feed-identity` (G2's on-chain half, `signals/feed-identity.mjs`) is why this category exists. It
+ * emits three kinds of ALERT and they are not the same thing:
+ *
+ *   - `detail.harm === 'decimals'`     — the feed's `decimals()` no longer matches the scale
+ *     `ChainlinkOracle` cached at construction. That config is IMMUTABLE, so this LATCHES: it does
+ *     not self-clear and cannot be repaired, only evacuated. Every price served since the change is
+ *     mis-scaled — the vault is not frozen, it is silently WRONG. Severity Ladder SEV-1.
+ *   - `detail.harm === 'denomination'` — the feed no longer describes itself as USD-quoted. Same
+ *     immutability, same latch, same "NAV, deposits and exits are all wrong rather than frozen".
+ *   - `detail.harm === null` (aggregator swap) — legitimate routine Chainlink operation. It
+ *     self-clears next sweep once the pin is re-taken, and there is nothing to fix on-chain. LOG.
+ *
+ * The §3 item 4 severity map ("LOG: everything else") was written 2026-08-30, BEFORE `feed-identity`
+ * existed (2026-09-01, PR #103), so it never ruled on these. Routing all three to LOG would leave
+ * the two LATCHING ones — the ones that mean member capital is wrong-priced right now — waiting for
+ * the weekly ops review. They are not redundantly covered elsewhere either: `ChainlinkOracle`'s
+ * sane-price band catches a ±2-decimal drift only while the live price sits inside it, and per
+ * `Owner Decisions 2026-09-01.md` §1 that window CLOSES for cbBTC at BTC $100,000 (+29.5% from
+ * 2026-09-01). Above that price `feed-identity` is the only detector there is, and nav-backing
+ * cannot substitute because it recomputes through the same mis-scaled `priceWad`.
+ *
+ * Each predicate takes the transition and returns true to PAGE. It is consulted only on an ALERT.
+ * @type {Map<string, (t: import('./transitions.mjs').Transition) => boolean>}
  */
-export const LOG_SIGNALS = new Set(['feed-identity', 'module-events', 'vault-config']);
+export const CONDITIONAL_PAGE = new Map([
+  ['feed-identity', (t) => t?.result?.detail?.harm != null],
+]);
+
+/**
+ * Every OTHER signal name the runner can currently emit, spelled out on purpose rather than left as
+ * "whatever isn't in PAGE_SIGNALS". A signal that lands in NONE of the three categories fails
+ * `sinks.test.mjs`'s coverage test instead of silently defaulting to LOG (or PAGE) — and that test
+ * enumerates `src/signals/` from disk, so a brand-new signal FILE fails it too, not just a rename.
+ */
+export const LOG_SIGNALS = new Set(['module-events', 'vault-config']);
 
 /**
  * PAGE or LOG for one transition. A synthetic self-test transition (see `canary-runner.mjs`
  * `testAlert()`) forces its tier via `result.detail.tier` rather than impersonating a real signal
  * name — that keeps the routing path under test genuine without ever being able to page on a fake
- * `nav-backing` ALERT. Real transitions fall through to the signal/status derivation.
+ * `nav-backing` ALERT. That override is honoured ONLY alongside `detail.selfTest === true`: a real
+ * signal's `detail` is a bag of decoded on-chain values, and a future signal that spreads a struct
+ * field named `tier` into it must not be able to DEMOTE its own page. Real transitions fall through
+ * to the signal/status derivation.
  * @param {import('./transitions.mjs').Transition} t
  * @returns {'page'|'log'}
  */
 export function tierOf(t) {
-  const forced = t?.result?.detail?.tier;
-  if (forced === 'page' || forced === 'log') return forced;
-  return t?.to === 'alert' && PAGE_SIGNALS.has(t?.signal) ? 'page' : 'log';
+  const detail = t?.result?.detail;
+  if (detail?.selfTest === true && (detail.tier === 'page' || detail.tier === 'log')) return detail.tier;
+  if (t?.to !== 'alert') return 'log';
+  if (PAGE_SIGNALS.has(t?.signal)) return 'page';
+  const pagesWhen = CONDITIONAL_PAGE.get(t?.signal);
+  return pagesWhen?.(t) === true ? 'page' : 'log';
 }
 
 /**

--- a/packages/canary/test/runner.test.mjs
+++ b/packages/canary/test/runner.test.mjs
@@ -276,6 +276,159 @@ test('runOnce says so, loudly, when there is nothing to watch', async () => {
   });
 });
 
+// ── the off-host dead-man's switch (Monitoring Gap Analysis G6) ──────────────
+//
+// The dead-man ping exists because `ops-check` runs on the SAME HOST as the canary: host death
+// silences the watcher and the watcher's watcher together. That only works if the ping means
+// "I am watching the chain" and not merely "my process is running".
+
+test('a sweep that found ZERO vaults does NOT ping the dead-man — the external monitor must go red', async () => {
+  await withTempDir(async (dir) => {
+    const pings = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545',
+      STATE_PATH: join(dir, 'absent.json'), CANARY_STATE_PATH: join(dir, 'canary-state.json'),
+      DEADMAN_PING_URL: 'https://hc-ping.invalid/uuid', CANARY_POLL_INTERVAL_MS: '20',
+    });
+    const err = [];
+    const canary = await buildCanary(cfg, {
+      log: () => {}, error: (m) => err.push(m), client: {},
+      fetchImpl: async (url) => { pings.push(url); return { ok: true, status: 200 }; },
+    });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 30));
+    await canary.stop();
+    await running;
+
+    assert.deepEqual(pings, [], 'pinging here would tell the ONE off-host monitor that a canary watching nothing is alive');
+    assert.ok(
+      err.some((m) => /no vaults to watch/.test(m)),
+      'and the empty watch set must be visible, not silent',
+    );
+    assert.ok(
+      err.some((m) => /dead-man ping is being WITHHELD/.test(m)),
+      'the line must say the ping was withheld, or the red external check looks like an unrelated outage',
+    );
+  });
+});
+
+test('a sweep that DID watch vaults pings the dead-man', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const pings = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: join(dir, 'canary-state.json'), OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+      DEADMAN_PING_URL: 'https://hc-ping.invalid/uuid', CANARY_POLL_INTERVAL_MS: '20',
+    });
+    const canary = await buildCanary(cfg, {
+      log: () => {}, error: () => {}, client: {},
+      fetchImpl: async (url) => { pings.push(url); return { ok: true, status: 200 }; },
+    });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 30));
+    await canary.stop();
+    await running;
+
+    assert.ok(pings.length > 0, 'the healthy path must still ping, or the switch is permanently dead');
+    assert.ok(pings.every((u) => u === 'https://hc-ping.invalid/uuid'));
+  });
+});
+
+test('startup states which sinks are wired, by boolean — never the URLs, which are credentials', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const out = [], err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: join(dir, 'canary-state.json'), OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+      CANARY_POLL_INTERVAL_MS: '20',
+    });
+    const canary = await buildCanary(cfg, { log: (m) => out.push(m), error: (m) => err.push(m), client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 10));
+    await canary.stop();
+    await running;
+
+    const sinkLine = out.find((m) => /^canary sinks:/.test(m));
+    assert.ok(sinkLine, 'nothing at startup said whether anything was wired up at all');
+    assert.match(sinkLine, /PAGE webhook NOT configured/);
+    assert.match(sinkLine, /off-host dead-man NOT configured/);
+    assert.ok(err.some((m) => /DEADMAN_PING_URL is unset/.test(m)), 'an unset dead-man must not be a silent no-op');
+    assert.ok(err.some((m) => /Nobody is being paged/.test(m)));
+  });
+});
+
+test('startup never prints a configured webhook or ping URL', async () => {
+  await withTempDir(async (dir) => {
+    const statePath = await seedSnapshot(dir);
+    const out = [], err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', STATE_PATH: statePath,
+      CANARY_STATE_PATH: join(dir, 'canary-state.json'), OPERATOR_REGISTRY_ADDRESS: REGISTRY,
+      PAGE_WEBHOOK_URL: 'https://hooks.invalid/s3cr3t-page',
+      LOG_WEBHOOK_URL: 'https://hooks.invalid/s3cr3t-log',
+      DEADMAN_PING_URL: 'https://hc-ping.invalid/s3cr3t-uuid',
+      CANARY_POLL_INTERVAL_MS: '20',
+    });
+    const canary = await buildCanary(cfg, {
+      log: (m) => out.push(m), error: (m) => err.push(m), client: {},
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+    const mock = mockReader({ contracts: healthyFixture(), nowSec: NOW });
+    Object.assign(canary.reader, { read: mock.read, tryRead: mock.tryRead, getLogs: mock.getLogs, staticCall: mock.staticCall });
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 10));
+    await canary.stop();
+    await running;
+
+    for (const m of [...out, ...err]) {
+      assert.ok(!/s3cr3t/.test(m), `a sink URL leaked into the log stream: ${m}`);
+    }
+    assert.match(out.find((m) => /^canary sinks:/.test(m)) ?? '', /PAGE webhook configured.*LOG webhook configured.*dead-man configured/);
+  });
+});
+
+test('CANARY_TEST_ALERT_ON_START warns that it re-fires on every restart', async () => {
+  await withTempDir(async (dir) => {
+    const err = [];
+    const cfg = resolveCanaryConfig({
+      RPC_URL: 'http://localhost:8545', CANARY_STATE_PATH: join(dir, 'canary-state.json'),
+      STATE_PATH: join(dir, 'absent.json'),
+      CANARY_TEST_ALERT_ON_START: '1', CANARY_POLL_INTERVAL_MS: '20',
+    });
+    const canary = await buildCanary(cfg, { log: () => {}, error: (m) => err.push(m), client: {} });
+    canary.reader.headBlock = async () => 1000;
+    canary.reader.chainNow = async () => NOW;
+
+    const running = canary.start();
+    await new Promise((r) => setTimeout(r, 10));
+    await canary.stop();
+    await running;
+
+    assert.ok(
+      err.some((m) => /fires on EVERY start.*restart: unless-stopped/s.test(m)),
+      'compose restarts this service automatically; a self-test left switched on pages the rotation every time',
+    );
+  });
+});
+
 test('the canary never writes to the indexer snapshot', async () => {
   await withTempDir(async (dir) => {
     const statePath = await seedSnapshot(dir);

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -186,8 +186,11 @@ test('coverage: every signal ON DISK is an explicit PAGE / CONDITIONAL / LOG dec
     assert.ok(liveSignals.has(signal), `${signal} is classified but no signal file emits it any more`);
   }
   // A self-check on the mechanism itself: reading the directory is only worth anything if it is
-  // actually seeing files. Seven signal FILES exported six distinct names when this was written.
-  assert.ok(liveSignals.size >= 7, `only ${liveSignals.size} signals discovered — the readdir is not working`);
+  // actually seeing files. EIGHT signal files exported SEVEN distinct names when this was written
+  // (`oracle-freshness.mjs` and `oracle-health.mjs` both export `'oracle-freshness'`), which with
+  // `vault-config` is eight live names. The old by-name import list held seven of those eight files
+  // and never imported `oracle-freshness.mjs` at all — a second way it was already blind.
+  assert.ok(liveSignals.size >= 8, `only ${liveSignals.size} signals discovered — the readdir is not working`);
 });
 
 // ── the feed-identity split, proven by DISPATCH rather than by set membership ─

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -6,17 +6,33 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readdir } from 'node:fs/promises';
 import {
   createConsoleSink, createWebhookSink, createTieredWebhookSink, createDeadmanPing, emitAll,
-  PAGE_SIGNALS, LOG_SIGNALS, tierOf,
+  PAGE_SIGNALS, LOG_SIGNALS, CONDITIONAL_PAGE, tierOf,
 } from '../src/sinks.mjs';
-import { SIGNAL as EXIT_LIVENESS } from '../src/signals/exit-liveness.mjs';
-import { SIGNAL as FEE_ROUTING } from '../src/signals/fee-routing.mjs';
-import { SIGNAL as FEED_IDENTITY } from '../src/signals/feed-identity.mjs';
-import { SIGNAL as MODULE_EVENTS } from '../src/signals/module-events.mjs';
-import { SIGNAL as NAV_BACKING } from '../src/signals/nav-backing.mjs';
-import { SIGNAL as ORACLE_HEALTH } from '../src/signals/oracle-health.mjs';
-import { SIGNAL as SHARE_CONSERVATION } from '../src/signals/share-conservation.mjs';
+
+/**
+ * Every SIGNAL name `src/signals/` can emit, read from DISK rather than from a hand-written import
+ * list. The list version could only catch a RENAME: adding a whole new signal file left the
+ * coverage test below passing while `tierOf` routed the new signal to LOG by default — exactly the
+ * silent-severity-decision this test exists to prevent. Resolved against `import.meta.url`, not the
+ * cwd, because `npm run gate` runs the suite from the repo root. A file with no `SIGNAL` export is
+ * a shared helper, not a signal, and is skipped.
+ */
+const SIGNALS_DIR = new URL('../src/signals/', import.meta.url);
+async function signalNamesOnDisk() {
+  const files = (await readdir(SIGNALS_DIR)).filter((f) => f.endsWith('.mjs'));
+  assert.ok(files.length > 0, 'src/signals/ resolved to an empty directory — the URL above is wrong');
+  const names = new Set();
+  for (const file of files) {
+    const mod = await import(new URL(file, SIGNALS_DIR).href);
+    // Two files legitimately export the SAME name (`oracle-freshness.mjs` and the post-pivot
+    // `oracle-health.mjs`, which kept the wire name across the rename); a Set is the point.
+    if (typeof mod.SIGNAL === 'string') names.add(mod.SIGNAL);
+  }
+  return names;
+}
 
 const tr = (to = 'alert', signal = 'nav-backing') => ({
   id: `${signal}|0xv`, signal, vault: '0xv', key: undefined,
@@ -97,40 +113,81 @@ test('tierOf: PAGE iff the transition is an ALERT for one of the four named sign
   }
 });
 
-test('tierOf: feed-identity is LOG even on ALERT — not in the note\'s PAGE list', () => {
+test('tierOf: a feed-identity ALERT that carries HARM pages; the self-clearing swap does not', () => {
+  const harmful = (harm) => {
+    const t = tr('alert', 'feed-identity');
+    t.result.detail = { ...t.result.detail, harm };
+    return t;
+  };
+  // The two LATCHING alerts: the oracle's cached scale / denomination is now permanently wrong and
+  // cannot be repaired, only evacuated. Above BTC $100,000 the sane-price band no longer catches a
+  // -2-decimal drift at all (Owner Decisions 2026-09-01 §1), so this is the ONLY detector.
+  assert.equal(tierOf(harmful('decimals')), 'page', 'a mis-scaled feed is member capital wrong-priced — SEV-1');
+  assert.equal(tierOf(harmful('denomination')), 'page', 'a non-USD-quoted feed is the same latch by another route');
+  // The harmless one: a routine Chainlink aggregator swap, re-pinned and self-cleared next sweep.
+  assert.equal(tierOf(harmful(null)), 'log', 'a benign aggregator swap must not wake anyone');
+  // A feed-identity result with no `harm` key at all (an older state file, a future leg) is not
+  // proven harmful, so it must not page.
   assert.equal(tierOf(tr('alert', 'feed-identity')), 'log');
+  // And the predicate is only ever consulted on an ALERT.
+  const degraded = tr('skipped', 'feed-identity');
+  degraded.result.detail = { ...degraded.result.detail, harm: 'decimals' };
+  assert.equal(tierOf(degraded), 'log', 'a DEGRADED feed-identity is a broken detector, not a proven drift');
 });
 
 test('tierOf: an unknown/renamed signal defaults to LOG, never silently PAGE', () => {
   assert.equal(tierOf(tr('alert', 'some-future-signal')), 'log');
 });
 
-test('tierOf: an explicit detail.tier wins over the derived signal/status map (the self-test path)', () => {
+test('tierOf: detail.tier is honoured ONLY alongside detail.selfTest — a real signal cannot demote its own page', () => {
   const forced = tr('ok', 'nav-backing');
   forced.result.detail.tier = 'page';
+  forced.result.detail.selfTest = true;
   assert.equal(tierOf(forced), 'page', 'a synthetic self-test can force PAGE without impersonating a real ALERT');
-  const forcedLog = tr('alert', 'nav-backing');
+  const forcedLog = tr('alert', 'self-test');
   forcedLog.result.detail.tier = 'log';
-  assert.equal(tierOf(forcedLog), 'log', 'and force LOG even on what looks like a real ALERT');
+  forcedLog.result.detail.selfTest = true;
+  assert.equal(tierOf(forcedLog), 'log', 'and force LOG for the LOG-tier half of the self-test');
+
+  // The footgun this scoping closes: `detail` is a bag of DECODED ON-CHAIN VALUES. A future signal
+  // that spreads a struct containing a field named `tier` into it would otherwise be able to
+  // silently route a real SEV-1 ALERT to the LOG endpoint.
+  const smuggled = tr('alert', 'nav-backing');
+  smuggled.result.detail.tier = 'log';
+  assert.equal(tierOf(smuggled), 'page', 'a real nav-backing ALERT pages no matter what detail.tier says');
+  const promoted = tr('alert', 'module-events');
+  promoted.result.detail.tier = 'page';
+  assert.equal(tierOf(promoted), 'log', 'and the override cannot promote a real LOG signal either');
 });
 
-test('coverage: every signal name the runner can actually emit is an explicit PAGE or LOG decision', () => {
-  const liveSignals = new Set([
-    EXIT_LIVENESS, FEE_ROUTING, FEED_IDENTITY, MODULE_EVENTS, NAV_BACKING, ORACLE_HEALTH,
-    SHARE_CONSERVATION,
-    'vault-config', // the whole-vault-unreadable DETECTOR BROKEN result in canary-runner.mjs
-  ]);
+test('coverage: every signal ON DISK is an explicit PAGE / CONDITIONAL / LOG decision', async () => {
+  const liveSignals = await signalNamesOnDisk();
+  // Not a file: `canary-runner.mjs` synthesises this one when a whole vault is unreadable.
+  liveSignals.add('vault-config');
+
+  const classify = (signal) => [
+    PAGE_SIGNALS.has(signal) && 'PAGE_SIGNALS',
+    CONDITIONAL_PAGE.has(signal) && 'CONDITIONAL_PAGE',
+    LOG_SIGNALS.has(signal) && 'LOG_SIGNALS',
+  ].filter(Boolean);
+
   for (const signal of liveSignals) {
-    assert.ok(
-      PAGE_SIGNALS.has(signal) || LOG_SIGNALS.has(signal),
-      `${signal} is not classified in either PAGE_SIGNALS or LOG_SIGNALS — a rename or a new ` +
-      'signal must be an explicit tiering decision, not fall through by accident',
+    assert.deepEqual(
+      classify(signal).length, 1,
+      `${signal} is classified in ${classify(signal).length} of PAGE_SIGNALS / CONDITIONAL_PAGE / ` +
+      'LOG_SIGNALS, and must be in exactly one. A NEW SIGNAL FILE, or a rename, is a severity ' +
+      'decision somebody has to make on purpose — it must not fall through to LOG by accident. ' +
+      'Three canary PRs were adding signals when this test was written (#115 operator-power and ' +
+      'depeg-reference, #117 governance-watch); whichever lands last adds its names to sinks.mjs.',
     );
   }
-  // And nothing in the two sets has silently drifted apart from what actually exists.
-  for (const signal of [...PAGE_SIGNALS, ...LOG_SIGNALS]) {
+  // And nothing classified has silently drifted apart from what actually exists on disk.
+  for (const signal of [...PAGE_SIGNALS, ...CONDITIONAL_PAGE.keys(), ...LOG_SIGNALS]) {
     assert.ok(liveSignals.has(signal), `${signal} is classified but no signal file emits it any more`);
   }
+  // A self-check on the mechanism itself: reading the directory is only worth anything if it is
+  // actually seeing files. Seven signal FILES exported six distinct names when this was written.
+  assert.ok(liveSignals.size >= 7, `only ${liveSignals.size} signals discovered — the readdir is not working`);
 });
 
 test('createTieredWebhookSink routes a PAGE-tier transition to pageUrl only', async () => {

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -190,6 +190,69 @@ test('coverage: every signal ON DISK is an explicit PAGE / CONDITIONAL / LOG dec
   assert.ok(liveSignals.size >= 7, `only ${liveSignals.size} signals discovered — the readdir is not working`);
 });
 
+// ── the feed-identity split, proven by DISPATCH rather than by set membership ─
+//
+// The coverage test above is a claim about the SETS. This is the claim that actually matters, and
+// it is only true if the whole path — emitAll -> tiered sink -> tierOf -> CONDITIONAL_PAGE
+// predicate -> the chosen URL — agrees: a LATCHING feed-identity drift must physically arrive at
+// the PAGE endpoint, and the self-clearing aggregator swap must physically arrive at the LOG one.
+
+/** One real feed-identity ALERT transition, shaped the way `signals/feed-identity.mjs` emits it. */
+const feedIdentityAlert = (harm) => ({
+  id: 'feed-identity|0xv|0xasset', signal: 'feed-identity', vault: '0xv', key: '0xasset',
+  from: 'ok', to: 'alert', line: `ALERT [feed-identity] harm=${harm}`,
+  result: {
+    signal: 'feed-identity', vault: '0xv', key: '0xasset', status: 'alert',
+    measured: 'decimals 6', threshold: 'the cached scale 10000000000',
+    detail: { vault: '0xv', asset: '0xasset', feed: '0xfeed', harm },
+  },
+});
+
+test('dispatch: a LATCHING feed-identity ALERT physically reaches the PAGE endpoint', async () => {
+  for (const harm of ['decimals', 'denomination']) {
+    const posted = [];
+    const sink = createTieredWebhookSink({
+      pageUrl: 'https://example.invalid/page', logUrl: 'https://example.invalid/log',
+      fetchImpl: async (url, init) => { posted.push({ url, body: JSON.parse(init.body) }); return { ok: true, status: 200 }; },
+    });
+    await emitAll([sink], [feedIdentityAlert(harm)]);
+    assert.equal(posted.length, 1, `harm='${harm}' must produce exactly one POST`);
+    assert.equal(posted[0].url, 'https://example.invalid/page', `harm='${harm}' must WAKE somebody: the oracle's cached scale is now permanently wrong and only feed-identity can see it`);
+    assert.equal(posted[0].body.tier, 'page', 'and the body must say so, for a receiver on a single shared URL');
+    assert.equal(posted[0].body.signal, 'feed-identity');
+    assert.equal(posted[0].body.detail.harm, harm);
+  }
+});
+
+test('dispatch: a self-clearing feed-identity aggregator swap physically reaches the LOG endpoint', async () => {
+  const posted = [];
+  const sink = createTieredWebhookSink({
+    pageUrl: 'https://example.invalid/page', logUrl: 'https://example.invalid/log',
+    fetchImpl: async (url, init) => { posted.push({ url, body: JSON.parse(init.body) }); return { ok: true, status: 200 }; },
+  });
+  const swap = feedIdentityAlert(null);
+  swap.result.detail.swapped = true;
+  await emitAll([sink], [swap]);
+  assert.deepEqual(posted.map((p) => p.url), ['https://example.invalid/log'], 'routine Chainlink operation that clears itself next sweep must not wake anyone');
+  assert.equal(posted[0].body.tier, 'log');
+});
+
+test('dispatch: both feed-identity tiers in ONE sweep split across the two endpoints', async () => {
+  const posted = [];
+  const sink = createTieredWebhookSink({
+    pageUrl: 'https://example.invalid/page', logUrl: 'https://example.invalid/log',
+    fetchImpl: async (url) => { posted.push(url); return { ok: true, status: 200 }; },
+  });
+  // Two assets on one vault: one drifted, one merely rotated. Same signal, same sweep.
+  const drifted = feedIdentityAlert('decimals');
+  const rotated = feedIdentityAlert(null);
+  rotated.id = 'feed-identity|0xv|0xasset2';
+  rotated.key = '0xasset2';
+  await emitAll([sink], [drifted, rotated]);
+  assert.deepEqual(posted, ['https://example.invalid/page', 'https://example.invalid/log'],
+    'the split is per-transition, not per-signal — one signal name, two endpoints, same sweep');
+});
+
 test('createTieredWebhookSink routes a PAGE-tier transition to pageUrl only', async () => {
   const calls = [];
   const sink = createTieredWebhookSink({

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -189,7 +189,9 @@ test('coverage: every signal ON DISK is an explicit PAGE / CONDITIONAL / LOG dec
   // actually seeing files. EIGHT signal files exported SEVEN distinct names when this was written
   // (`oracle-freshness.mjs` and `oracle-health.mjs` both export `'oracle-freshness'`), which with
   // `vault-config` is eight live names. The old by-name import list held seven of those eight files
-  // and never imported `oracle-freshness.mjs` at all — a second way it was already blind.
+  // and never imported `oracle-freshness.mjs` at all. That particular omission was HARMLESS — the
+  // unimported file exports the same name as one that was imported, so no name went uncovered — but
+  // it shows the hand-written list had already drifted from the directory it claimed to mirror.
   assert.ok(liveSignals.size >= 8, `only ${liveSignals.size} signals discovered — the readdir is not working`);
 });
 


### PR DESCRIPTION
Fixer pass on [Review109's REJECT verdict](https://github.com/SlumperSan/agent-governed-vaults/pull/109#issuecomment-5501468329) for #109.

**Why this is a new PR and not a push to #109.** #109 merged at 2026-09-01 22:43:44Z (merge commit `885b8b4c`) while its adversarial review was still open. The REJECT verdict landed after the merge, so **F1, F2, F3, F5, F6 and F7 are all live on `protocol/main` right now**. Pushing to `feat/canary-tiered-sinks-deadman` would not reopen #109, so this is the follow-up, branched off `52d10aee`.

## F1 (HIGH) — a latching feed-identity drift now PAGEs

`feed-identity` emits three kinds of ALERT and #109 routed all three to LOG. They are not the same thing:

| `detail.harm` | what it means | self-clears? | tier |
|---|---|---|---|
| `'decimals'` | the feed's `decimals()` no longer matches the scale `ChainlinkOracle` cached at construction | **no — latches** | **PAGE** |
| `'denomination'` | the feed no longer describes itself as USD-quoted | **no — latches** | **PAGE** |
| `null` | routine Chainlink aggregator swap | yes, next sweep once the pin is re-taken | LOG |

The oracle's config is immutable, so the two harm cases cannot be repaired, only evacuated: the vault is not frozen, it is silently **wrong**. Severity Ladder SEV-1.

**Nothing else catches them.** The sane-price band bounds a ±2-decimal drift only while the live price sits inside the band, and per `Owner Decisions 2026-09-01.md` §1 that window closes for cbBTC at **BTC $100,000** — +29.5% from today's $77,223. Above that price `feed-identity` is the only detector there is, and `nav-backing` cannot substitute because it recomputes through the same mis-scaled `priceWad`.

**On the spec.** The Monitoring Gap Analysis §3 item 4 PAGE list ("PAGE: nav-backing, share-conservation, fee-routing, exit-liveness ALERT, oracle-v2 ALERT; LOG: everything else") was written **2026-08-30**, before `feed-identity` existed (**2026-09-01**, #103). Its "everything else" never ruled on this signal. This PR is that reconciliation. `Business/Operations/Monitoring Gap Analysis.md` is deliberately **not** edited here — that sentence is Operations' to write.

### Why a third category, and not just moving feed-identity into `PAGE_SIGNALS`

**The obvious fix — move `feed-identity` into `PAGE_SIGNALS` — is wrong, and the reason is the finding.** `tierOf` was signal-level: PAGE iff `to === 'alert'` and the signal name is in `PAGE_SIGNALS`. One signal name here covers alerts of two genuinely different severities, so neither set can hold it honestly — `PAGE_SIGNALS` would page the benign self-clearing swap on every routine Chainlink rotation, and `LOG_SIGNALS` is the bug being fixed. Splitting `feed-identity` into two signal names was the alternative and is worse: the signal's self-clear is *gated on the harm legs passing* (`feed-identity.mjs:63-65`), so the three legs are one detector and one transition key, and splitting the name would break standing transition state on every deployed canary.

So `sinks.mjs` gains a third category:

```js
export const CONDITIONAL_PAGE = new Map([
  ['feed-identity', (t) => t?.result?.detail?.harm != null],
]);
```

A `Map` from signal name to a predicate, consulted **only on an ALERT**, after `PAGE_SIGNALS` and before the LOG default. This also keeps F3's coverage invariant truthful: the test below asserts every signal is in **exactly one** of the three categories, which a two-set model could only satisfy by claiming `feed-identity` is wholly PAGE or wholly LOG — i.e. by asserting something false.

### The routing is proven by DRIVING DISPATCH, not by asserting the sets are exhaustive

Worth stating plainly because it is the gap in the two prior findings: **both Review109 and Fix92 established `feed-identity`'s tier by *reading* `sinks.mjs`. Neither executed it.** A coverage test over `PAGE_SIGNALS` / `CONDITIONAL_PAGE` / `LOG_SIGNALS` is a claim about the *sets*, and it would keep passing even if `tierOf` or the sink dispatched somewhere else entirely.

So three tests in `packages/canary/test/sinks.test.mjs` drive the whole real path — `emitAll` → `createTieredWebhookSink` → `tierOf` → the `CONDITIONAL_PAGE` predicate → the chosen URL — with a `fetch` stub, and assert **which endpoint physically received the POST**:

1. `harm:'decimals'` and `harm:'denomination'` ALERTs arrive at `pageUrl`, each carrying `tier:'page'` in the body.
2. The `harm:null` aggregator swap arrives at `logUrl`.
3. Both kinds in **one sweep** split across the two endpoints — which is the property the whole design rests on: the split is per *transition*, not per signal *name*.

Mutation-checked, restored after each: **inverting** the predicate fails 5 tests; making it **always-false — #109's exact live behaviour** — fails 3, including both dispatch assertions. That second mutation is the control: it reproduces what is on `protocol/main` today and the suite catches it.

## F2 (MED) — an empty watch set no longer pings the dead-man

`runOnce()` returned `{vaults: []}` as a **success** when the indexer snapshot was missing, `VAULTS` was unset, or the volume was not mounted. `loop()` then beat the heartbeat file *and* pinged the off-host dead-man, so both watchers reported alive while nothing was being watched — and the off-host ping is the one that exists precisely because `ops-check` cannot survive its own host dying.

- `if (vaults.length > 0) await deadman.ping();`
- the state is now visible, not silent: `logger.warn('sweep.no_vaults', {statePath, vaultsConfigured})` (added to the `docs/RUNTIME.md` §8.1 log-event table), and the stderr line now says the ping is being **withheld**, so the red external check reads as the configuration problem it is rather than an unrelated outage.

**For Operations:** the on-host `heartbeat.beat()` is deliberately **not** gated. It reports process liveness, and promoting an empty watch set to a "canary process dead" page would turn a configuration problem into a page. Review109's F2 notes that both watchers currently report alive; gating the on-host half too is your call, not this PR's.

## F3 (MED) — the tier coverage test now reads the directory

The old test imported seven of the eight signal files by name, so it could only catch a **rename**. (On the eighth: it imported `oracle-health.mjs` and never `oracle-freshness.mjs`. I initially wrote that up as a second live blind spot and it is **not** one — the unimported file exports the same `SIGNAL` name as one that was imported, so no name went uncovered. It shows the hand-written list had drifted from the directory it claimed to mirror, which argues for enumerating from disk but is not itself a hole. F3 rests on the mutation below, not on this.) Adding a whole new signal file left it passing while `tierOf` routed the new signal to LOG by default — which is exactly the silent severity decision the test exists to prevent. It now resolves `new URL('../src/signals/', import.meta.url)` (not cwd-relative — `npm run gate` runs from the repo root), imports every `.mjs`, collects each `SIGNAL`, skips files that export none (shared helpers), and asserts membership in **exactly one** of `PAGE_SIGNALS` / `CONDITIONAL_PAGE` / `LOG_SIGNALS`.

Verified by mutation, both restored afterwards:
- added `src/signals/zz-dummy-mutation.mjs` exporting `SIGNAL = 'zz-dummy-mutation'` → coverage test **FAILS** 18 pass / 1 fail, `"zz-dummy-mutation is classified in 0 of PAGE_SIGNALS / CONDITIONAL_PAGE / LOG_SIGNALS"`. Removed → 19/19.
- removed the `vaults.length > 0` gate → the new F2 test **FAILS** 42/1. Restored → 43/43.

## F4–F7 (LOW)

- **F4.** `docs/RUNTIME.md` still listed only `ALERT_WEBHOOK_URL` and `HEARTBEAT_MS` `0 (off)`; it now carries `PAGE_WEBHOOK_URL` / `LOG_WEBHOOK_URL` / `DEADMAN_PING_URL` / `CANARY_TEST_ALERT_ON_START`, the real `3600000` heartbeat default, and `sweep.no_vaults`. `docker-compose.yml:65` said "Set ALERT_WEBHOOK_URL"; it now describes the tiered sinks, the dead-man, and the restart hazard below.
- **F5.** Startup states what is wired: a `canary sinks: …` stdout line, and `logger.info('starting', {pageWebhook, logWebhook, deadman, testAlertOnStart, heartbeatMs})` as **booleans** — a Slack webhook and a Healthchecks.io ping UUID are credentials and this log stream is shipped off-host. There is a test asserting no URL ever reaches the log stream. Stderr warns when `DEADMAN_PING_URL` is unset (nothing off this host would notice a dead host) and when no webhook at all is configured (nobody is being paged).
- **F6.** `tierOf`'s `detail.tier` override now requires `detail.selfTest === true`. `detail` is a bag of decoded on-chain values; a future signal that spreads a struct field named `tier` into it could otherwise demote its own SEV-1 page. The existing test asserting `detail.tier='log'` demotes a real `nav-backing` ALERT **was the bug** and is inverted — that inversion is the proof.
- **F7.** `CANARY_TEST_ALERT_ON_START` under compose's `restart: unless-stopped` fires a synthetic PAGE on **every** automatic restart, not once. Startup now warns loudly on stderr, and `.env.example`, `docs/CANARY.md` §5.3 and `docker-compose.yml` all say not to leave it set.

Docs were updated to match rather than contradict the code: `docs/CANARY.md` §5.3 and `packages/canary/README.md` both carried the old "`feed-identity` … is caught at the weekly ops review by design" rationale, which this PR reverses.

---

## Coordination — three canary PRs are adding signals

Once F3 lands, **any new file under `packages/canary/src/signals/` must declare a tier in `sinks.mjs` or the coverage test fails.** That is the point: nobody can forget any more. Whichever of these lands after **this PR** (not after #109 — #109 is already in `main`, and its `PAGE_SIGNALS` is what you will rebase onto) adds its signals to one of the three categories:

- **#117 `governance-watch`** — I believe **PAGE**. The Gap Analysis spec says PAGE, and the reason holds up: the reveal window is the only defence the design has against a hostile proposal ("publish analysis during the reveal window"), and #117's own description says commit→reveal and timelock→executable are **clock crossings that emit no event at all**. A proposal that opens overnight and is never noticed consumes that window silently. Transitions only fire on change, so PAGE costs roughly one page per phase entry over a lifecycle, not one per sweep. Author's call on whether `lapsed` should be demoted.
- **#115 `operator-power`** — I believe **`CONDITIONAL_PAGE`**, or LOG if you would rather not split it yet. Dilution is slow: at the 1.5× WARN there are hours or days of headroom, and WARN and ALERT ride the same `alert()` status, so plain `PAGE_SIGNALS` would page the early warning too. But the case #115's description calls out — an ALERT while the vault is at `capacityCapUsdc`, i.e. *"no top-up path — decision needed now"* — is genuinely irreversible and is the shape `CONDITIONAL_PAGE` now exists for. Something like `t => t.result.detail?.thresholds?.tripped === 'alert' && t.result.detail?.navAvailable === false` (adapt to the real `detail` keys).
- **#115 `depeg-reference`** — I believe **LOG**, and I hold this one least firmly. #115's own framing is that it is purely informational: the contract keeps pricing USDC at exactly $1.00 by design regardless, and nothing changes until a human relists or unwinds. There is no 3am action. Counter-argument a reviewer should weigh: while depegged, members deposit $0.90 of value for $1.00 of shares, which *is* member capital wrong-priced. I land on LOG because a real USDC depeg is a public event ops will hear about from the news within minutes, unlike a decimals drift, which is invisible to everyone. Operations should overrule me if they disagree.

**For the owner's list, not fixable here.** Routing a signal to `LOG_WEBHOOK_URL` only shortens the exposure window if somebody is actually *reading* that endpoint. Nothing in this repo can establish that, and a passing test must not be read as implying it is answered — it is an operational question about who watches the LOG tier and how often. Raised so it is not lost.

## Verification

- `npm run gate` on **`b3ebcd0a`** (this PR's head), after `cd contracts && forge clean` so the run was not sitting on the artifact state a previous gate leaves behind: **GATE PASSED (529.4s), 9/9** — fmt, syntax, build, opscheck, backend, test, snapshot, sizes; slither advisory only (236 pre-existing informational results, unchanged). An earlier `GATE PASSED (481.5s), 9/9` on `ffe8ca3e` covered the first commit.
- `npm run test:backend` re-run on a clean tree at `b3ebcd0a`: 878 tests, 876 pass, **0 fail**, 2 skipped.
- No `contracts/` changes, so no EIP-170 report and `.gas-snapshot` does not move — confirmed, it did not.
- `PAGE_SIGNALS` / `LOG_SIGNALS` have exactly two consumers in the tree (`sinks.mjs`, `sinks.test.mjs`), so nothing outside the sink layer expected `feed-identity` to be in `LOG_SIGNALS`.

**One thing worth knowing for the review.** `docs/CANARY.md` **§3(g)** — `feed-identity`'s own section — already carried a severity table saying the `decimals` and `denomination` findings **latch** and the aggregator swap **clears itself next sweep**. So #109 shipped a §5.3 routing rationale that contradicted its own §3(g) two hundred lines earlier: the document had the severity argument right and the routing wrong. §3(g) is unchanged here because it corroborates F1; only §5.3 and the README needed correcting.

Not merged, per the fixer brief. Closes the Review109 findings on #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
