### PR TITLE
Add a merge preflight that connects review verdicts to mergeability

### DIFF
--- a/.github/workflows/merge-preflight.yml
+++ b/.github/workflows/merge-preflight.yml
@@ -48,8 +48,19 @@ jobs:
         with:
           node-version: '24'
 
+      # Until this PR merges, protocol/main has no preflight script. Without this guard the job
+      # would post a red `merge-preflight` status derived from a module-not-found error, which is
+      # a false alarm indistinguishable from a real block. It also covers the reverse case: someone
+      # removing the script from main should silence this workflow, not make every PR look blocked.
+      - name: Is the preflight present on the default branch?
+        id: have
+        run: |
+          if [ -f scripts/merge-preflight.mjs ]; then echo "have=true" >> "$GITHUB_OUTPUT"
+          else echo "have=false" >> "$GITHUB_OUTPUT"; echo "::notice::merge-preflight is not on protocol/main yet; posting no status."; fi
+
       - name: Resolve PR number
         id: pr
+        if: steps.have.outputs.have == 'true'
         run: |
           case "${{ github.event_name }}" in
             pull_request)   n='${{ github.event.pull_request.number }}' ;;
@@ -60,6 +71,7 @@ jobs:
 
       - name: Run preflight
         id: check
+        if: steps.have.outputs.have == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -75,6 +87,7 @@ jobs:
           esac
 
       - name: Publish commit status on the PR head
+        if: steps.have.outputs.have == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/merge-preflight.yml
+++ b/.github/workflows/merge-preflight.yml
@@ -31,12 +31,25 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  # `gh run list` hits GET /repos/{o}/{r}/actions/runs. Declaring a permissions block sets every
+  # unlisted scope to none, so without this the script exits 2 ("could not determine") and the
+  # ci-matches-head rule -- the one that exists because of #107's stale green -- silently never
+  # evaluates. That would be a check reporting on a rule it did not run.
+  actions: read
   statuses: write
 
 jobs:
   preflight:
-    # issue_comment fires for plain issues too; only pull requests have this field.
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    # Two filters. issue_comment fires for plain issues too, and only pull requests carry
+    # `issue.pull_request`. And it fires for EVERY comment in the repository -- this repo ran out of
+    # Actions minutes for ~72h on 2026-08-29 -- so a comment only re-runs the preflight when it could
+    # actually change the decision: a token, or a prose verdict the block-only heuristic might read.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request && (
+        contains(github.event.comment.body, 'REVIEW-') ||
+        contains(github.event.comment.body, 'REJECT') ||
+        contains(github.event.comment.body, 'ACCEPT')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/.github/workflows/merge-preflight.yml
+++ b/.github/workflows/merge-preflight.yml
@@ -1,0 +1,86 @@
+# Publishes the merge-preflight decision as a commit status on the PR's head SHA.
+#
+# WHY A COMMIT STATUS AND NOT A CHECK RUN. The decision changes when a *comment* is posted, not when
+# code is pushed — a verdict arriving is the whole event this exists to notice. A `pull_request`
+# workflow does not re-run on a comment, so a PR that legitimately failed ("no verdicts yet") would
+# stay failed with nothing able to clear it. `issue_comment` runs the workflow file from the DEFAULT
+# BRANCH and cannot attach a check run to the PR's head, but it can POST a commit status to any SHA.
+# Branch protection matches required checks by context string and does not care which produced it,
+# so `merge-preflight` is requireable either way.
+#
+# STATUS: this workflow makes the decision VISIBLE. It does not make it BINDING. Until the owner
+# requires the `merge-preflight` context in branch protection with enforce_admins on, a red status
+# here does not stop `gh pr merge`. See docs/reviews/MERGE-POLICY.md § Making this enforcement.
+#
+# It runs in --advisory during rollout: Modes A and C and stale-CI are caught with no convention
+# change, while Mode B waits for reviewers to emit REVIEW-ROSTER / REVIEW-VERDICT tokens. Switching
+# to --strict is step 3 of that section, and is a one-word edit here.
+name: merge-preflight
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  issue_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  preflight:
+    # issue_comment fires for plain issues too; only pull requests have this field.
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          # issue_comment checks out the default branch, which is what we want: the policy and the
+          # script must be the ones on protocol/main, never a version the PR under test supplies.
+          ref: protocol/main
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '24'
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request)   n='${{ github.event.pull_request.number }}' ;;
+            issue_comment)  n='${{ github.event.issue.number }}' ;;
+            *)              n='${{ github.event.inputs.pr }}' ;;
+          esac
+          echo "number=$n" >> "$GITHUB_OUTPUT"
+
+      - name: Run preflight
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          node scripts/merge-preflight.mjs "${{ steps.pr.outputs.number }}" --advisory | tee out.txt
+          code=${PIPESTATUS[0]}
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          # Exit 2 (could not determine) is deliberately NOT a pass — see the script header.
+          case "$code" in
+            0) echo "state=success"     >> "$GITHUB_OUTPUT"; echo "desc=no blocker found"        >> "$GITHUB_OUTPUT" ;;
+            1) echo "state=failure"     >> "$GITHUB_OUTPUT"; echo "desc=blocked, see the job log" >> "$GITHUB_OUTPUT" ;;
+            *) echo "state=error"       >> "$GITHUB_OUTPUT"; echo "desc=could not determine"      >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Publish commit status on the PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha=$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
+          gh api -X POST "repos/${{ github.repository }}/statuses/$sha" \
+            -f state='${{ steps.check.outputs.state }}' \
+            -f context='merge-preflight' \
+            -f description='${{ steps.check.outputs.desc }}' \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -181,6 +181,13 @@ prose in a comment and `gh pr merge` does not read comments. So the verdict is n
 
 Both are HTML comments, invisible in the rendered comment, so they cost a reviewer nothing.
 
+**A fixer pass does not clear a verdict.** Posting "all findings addressed" is a claim, not a
+verdict; only the reviewer's newer `REVIEW-VERDICT` token clears one. And because a fixer's commits
+move the head, the *reviewer* must post that token **after** the fix lands — a verdict written before
+the last commit graded content that is no longer what would merge. This is the one place the review
+pattern costs an extra round trip, and it is deliberate: it is what the four PRs that merged over
+their own REJECTs on 2026-09-01 were missing.
+
 Check a PR with `node scripts/merge-preflight.mjs <n>` before merging — **and before pushing to a
 branch you did not just create**, because a merged branch looks exactly like a live one by git
 divergence and GitHub reopens no PR on a push.

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -166,6 +166,28 @@ Rules that make it work:
   correct votes to reject. Unverified is not the same as correct.
 - **The fixer is a separate step.** The implementer does not grade their own homework.
 
+### Say the verdict in a form a program can read
+
+On 2026-09-01 four PRs merged across REJECT verdicts nobody had addressed, because a verdict was
+prose in a comment and `gh pr merge` does not read comments. So the verdict is now also a token:
+
+- **The orchestrator, when it spawns reviewers**, posts `<!-- REVIEW-ROSTER reviewers=A,B -->`.
+  This is what makes "a review is still running" visible — without it, *nobody objected* and *nobody
+  looked* are the same observation, which is how one PR merged five minutes before its verdict
+  existed.
+- **Each reviewer**, inside its existing `## Adversarial review — VERDICT` comment, posts
+  `<!-- REVIEW-VERDICT reviewer=<its own name> verdict=ACCEPT|REJECT -->`. The fixer or the reviewer
+  posts a newer one once the findings are closed; the latest per reviewer wins.
+
+Both are HTML comments, invisible in the rendered comment, so they cost a reviewer nothing.
+
+Check a PR with `node scripts/merge-preflight.mjs <n>` before merging — **and before pushing to a
+branch you did not just create**, because a merged branch looks exactly like a live one by git
+divergence and GitHub reopens no PR on a push.
+
+Only a token can CLEAR a PR; prose can only block it. The full rules, and an explicit list of what
+the check cannot catch, are in `docs/reviews/MERGE-POLICY.md`.
+
 ## 4. Mechanical faithfulness — do not refactor opportunistically
 
 Bun's rule was: *do the rewrite that looks like we transpiled the Zig code.* No cleanup along the

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -180,6 +180,15 @@ exercise exists to prevent.
 - **Labels and comments are removable by whoever can merge**, so a determined agent can clear its own
   blockers. This raises the cost of a bad merge from zero to deliberate; it does not make it
   impossible.
+- **Whether a conflict resolution was CORRECT.** `verdict-covers-head` catches that the reviewed
+  content changed; judging the change is a re-review, and no check can do it. The per-file "which
+  side and why" note in the PR body is the only thing that makes the choice visible, and it is a
+  convention that detects nothing on its own.
+- **A verdict that graded an older SHA than the one it was posted after.** Mode D is inferred from
+  timestamps — the head commit's `committedDate` against the verdict comment's `createdAt` — so a
+  reviewer who read stale content and posted late looks identical to one who read the head. Binding
+  a SHA into the token would close this; it was rejected because an optional attribute nobody fills
+  in is theatre, and a mandatory one changes the reviewer workflow a second time.
 - **The quality of CI itself.** `ci-matches-head` proves a green run exists for this commit. It says
   nothing about what that run checked.
 

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -12,13 +12,14 @@ that were never addressed, putting two HIGHs onto `protocol/main`. Nothing mecha
 verdict to mergeability: `gh pr merge` does not read comments, and the review pattern in
 `docs/SWARM.md` §3 is a convention.
 
-It was **three distinct failure modes, and a defence against one is useless against the others.**
+It was **four distinct failure modes, and a defence against one is useless against the others.**
 
 | mode | what happened | the PRs | the rule that answers it |
 |---|---|---|---|
 | **A — policy** | merged over a REJECT already standing, in writing, on the PR | #107 by 8 min, #92 by 29 min | `no-standing-reject` |
 | **B — race** | the review lost a race it could not see it was in | #98's REJECT posted **25 s** after the merge; #109's 5.5 min after, so the PR merged before its verdict existed | `roster-declared` + `roster-resolved` |
 | **C — orientation** | pushed to a branch whose PR had already merged | #107's fixer pass, rescued by hand as [#120] | `pr-open` |
+| **D — invisibility** | the reviewed content was replaced *after* a correct verdict | a keep-ours resolution on #117 would have re-introduced the list #121 exists to abolish | `verdict-covers-head` |
 
 Three consequences worth stating plainly, because each one defeats an obvious design:
 
@@ -30,8 +31,39 @@ Three consequences worth stating plainly, because each one defeats an obvious de
   passed the worst case and failed its own purpose.
 
 So the enforceable property is not an interval. It is a conjunction: **the declared complement of
-reviewers has reported, and every report is resolved** — plus CI green on *this* head SHA, plus the
-PR still being open.
+reviewers has reported, and every report is resolved, on the content that would actually merge** —
+plus CI green on *this* head SHA, plus the PR still being open.
+
+### Mode D is a different kind of thing, and it is worth stating separately
+
+A, B and C are all about **when** a merge happens relative to a review. **D is about what a review
+can see at all.** A conflict resolution is an edit nobody reviews: a PR diff shows the merged
+*result* and never the *choice*. So the reviewer can be competent, the review thorough and the
+verdict correct, and a defect still enters afterwards and ships under that verdict.
+
+The live instance, 2026-09-01: #121 replaced a hand-written `liveSignals` array with
+`signalNamesOnDisk()` — abolishing a hand-maintained list was the entire point of the PR — while
+#117 had independently added an entry to that array. A keep-ours resolution re-introduces exactly
+the list #121 exists to abolish, inside a PR whose own subject is unrelated to it. It was caught only
+because a verifier ran `merge-tree` on a branch it did not own and read the *conflict* rather than
+the diff.
+
+`verdict-covers-head` detects that **the reviewed content is no longer the content that would
+merge** — the automatable half. It cannot judge whether a resolution was *correct*; that is a
+re-review, and no check can do it. Two related traps, both seen the same night:
+
+- **"The conflict is only `.gas-snapshot`, so regenerate it" is not a general strategy.** #115 and
+  #117 conflicted on real content. Any mechanism assuming conflicts are mechanical will be wrong on
+  exactly the PRs where the stakes are highest.
+- **A resolution's premise can be stale even when the resolution is right.** #117's correct
+  resolution relies on `readdir` finding a signal file; if a rebase moved it, `readdir` finds
+  nothing, the coverage test still passes because it asserts `size >= 8` and eight *other* signals
+  satisfy it, and the addition is uncovered again with a green suite.
+
+**The cheap convention that makes the choice reviewable at all** — and it is a convention, not a
+gate, because it detects nothing by itself: **when a PR resolves a non-trivial conflict, its body
+should state, per conflicted file, which side was taken and why.** That converts an invisible edit
+into a claim someone can check.
 
 ### The compounding factor
 
@@ -116,7 +148,9 @@ node scripts/merge-preflight.mjs 119
 Exit 0 = clear, 1 = blocked, **2 = could not determine** (no `gh`, no auth, no such PR). Exit 2 is
 not a pass: a preflight that could not see is not a preflight that saw nothing wrong.
 
-`--advisory` drops the two roster rules, and so drops all of Mode B. It is what the rollout workflow
+`--advisory` drops the two roster rules, and so drops all of Mode B. It keeps everything else,
+including Mode D — that rule needs only a verdict token, which is a reviewer's own act rather than an
+orchestrator convention. It is what the rollout workflow
 runs while adoption is partial, and it is honestly weaker: `scripts/test/merge-preflight.test.mjs`
 asserts, as a test rather than as a claim, that advisory mode **clears** both #98 and #109 at their
 real merge instants.
@@ -197,7 +231,7 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
 ```json
 {
   "version": 1,
-  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
+  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed, and a fifth (#121/#117) showed that a conflict resolution can introduce a defect no review ever sees. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
   "tokens": {
     "roster": {
       "form": "<!-- REVIEW-ROSTER reviewers=Name1,Name2 -->",
@@ -214,7 +248,8 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
     "A structured token is the only thing that may CLEAR a blocker. Prose is never sufficient, so 'satisfy the check by writing the word ACCEPT' is impossible by construction.",
     "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
     "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
-    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around."
+    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around.",
+    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice."
   ],
   "rules": [
     {
@@ -236,6 +271,16 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
       "title": "no reviewer's latest verdict may be REJECT",
       "blocksWhen": "any reviewer's latest REVIEW-VERDICT token is REJECT, or a legacy prose REJECT heading is not followed by a later ACCEPT token",
       "why": "Mode A. #107 merged 8 minutes after a REJECT was standing in writing on the PR; #92 merged 29 minutes after one. This is a policy failure, not a visibility one: the standing self-merge rule had no clause about an open REJECT, so an agent following it as written merges correctly and lands a HIGH."
+    },
+    {
+      "id": "verdict-covers-head",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "every verdict must post-date the head commit",
+      "blocksWhen": "any reviewer's latest verdict is older than the PR's head commit",
+      "why": "Mode D. Modes A, B and C are all about WHEN a merge happens relative to a review; D is about WHAT A REVIEW CAN SEE AT ALL. A conflict resolution is an edit nobody reviews -- a PR diff shows the merged RESULT and never the CHOICE -- so a defect can enter after a correct verdict and ship under it. Seen live on 2026-09-01: a keep-ours resolution on #117 would have re-introduced the hand-maintained signal list that #121 exists to abolish, inside a PR whose own subject was unrelated, and it was caught only because a verifier ran merge-tree on a branch it did not own and read the conflict rather than the diff. This rule detects that the reviewed content is no longer the content that would merge; it cannot judge whether the resolution was CORRECT, which is a re-review and not automatable. Runs in BOTH modes, unlike the roster rules: it needs only a verdict token, which is the reviewer's own act rather than an orchestrator convention."
     },
     {
       "id": "ci-matches-head",
@@ -281,6 +326,9 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
       "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
       "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
     ]
+  },
+  "conventions": {
+    "statePerFileResolutions": "When a PR resolves a non-trivial conflict, the PR body should state, per conflicted file, WHICH SIDE was taken and WHY. This detects nothing by itself. It is the only thing that makes an otherwise invisible edit into a claim a reviewer can check, and it is a CONVENTION -- do not describe it as a gate. Note also that 'the conflict is only .gas-snapshot, so regenerate it' is not a general strategy: #115 and #117 conflicted on real content."
   }
 }
 ```

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -158,6 +158,11 @@ These need the repository owner. An agent cannot set branch protection, and shou
 2. **Include administrators.** Tick *Do not allow bypassing the above settings* (`enforce_admins`).
    Without it, branch protection is bypassed by exactly the account that does the merging, and the
    policy reads as real while being advisory for the only identity that matters.
+   **Backfill the PRs already open when you do this.** A required context that has *never* reported
+   blocks exactly as hard as a red one, and a PR whose head SHA predates the workflow has no status
+   and nothing scheduled to give it one. Each already-open PR needs one triggering event — a push, a
+   comment carrying a token, or `gh workflow run merge-preflight.yml -f pr=<n>` — before it can
+   merge. New PRs are unaffected.
 3. **Switch the workflow from advisory to strict** once reviewers are emitting tokens: change
    `--advisory` to `--strict` in `.github/workflows/merge-preflight.yml`. Steps 1 and 2 are worth
    taking before this one — advisory already catches Modes A and C and stale CI.
@@ -167,6 +172,16 @@ These need the repository owner. An agent cannot set branch protection, and shou
 
 The `gh api` equivalents of steps 1 and 2, for the record, are in
 `scripts/lib/merge-policy.json` → `enforcement`.
+
+### The CI cost, so it is your decision and not a surprise
+
+The workflow triggers on `issue_comment`, because a verdict arriving is the event it exists to
+notice and a `pull_request` workflow does not re-run on a comment. That fires on **every** comment in
+the repository. This repo ran out of Actions minutes for ~72 hours on 2026-08-29, so the job is
+filtered to comments that could actually change the decision — ones containing `REVIEW-`, `REJECT` or
+`ACCEPT` — which on a busy night is roughly a third of them rather than all. The job itself is
+short: a checkout, a node setup and two `gh` calls, well under a minute. If even that is too much,
+drop the `issue_comment` trigger entirely and accept that a status only refreshes on a push.
 
 ## The policy itself
 

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -104,9 +104,21 @@ Two HTML comments. They are invisible in the rendered comment, so they cost a re
 <!-- REVIEW-VERDICT reviewer=Review119 verdict=REJECT -->
 ```
 
-...and the fixer or the reviewer posts a newer one with `verdict=ACCEPT` once the findings are
-closed. The latest verdict per reviewer wins; verdicts arrive out of band (#92 collected a second
-REJECT 42 minutes after its merge) and a REJECT must be clearable, or no fixer pass could ever land.
+...and a newer one with `verdict=ACCEPT` clears it once the findings are closed. The latest verdict
+per reviewer wins; verdicts arrive out of band (#92 collected a second REJECT 42 minutes after its
+merge) and a REJECT must be clearable, or no fixer pass could ever land.
+
+**A fixer pass does not clear a verdict**, and this is the one workflow change beyond the tokens
+themselves, so it is worth being blunt about. Posting "all findings addressed" is a claim, not a
+verdict; only the *reviewer* clears one. And because a fixer's commits move the head,
+`verdict-covers-head` requires that token to be posted **after** the fix lands — a verdict written
+before the last commit graded content that is no longer what would merge.
+
+The practical consequence, seen live on #106 while this was being written: a PR with a standing
+REJECT and a fixer mid-pass shows **two** blockers, and only a reviewer can clear either. That is
+the discipline being argued for, not a malfunction — but a rule that mysteriously blocks everything
+gets routed around, so it belongs in `docs/SWARM.md` §3 where reviewers actually read it, and it is
+there.
 
 **The roster is the Mode B mechanism.** It is not a second, separate defence bolted on beside the
 verdicts — it is their denominator. Without it, "nobody objected" and "nobody looked" are the same

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -1,0 +1,277 @@
+# Merge policy — when a PR may land on `protocol/main`
+
+**Status: CONVENTION, not enforcement.** Nothing in this repository can stop a merge today. This
+document and `scripts/merge-preflight.mjs` describe and check the policy; only branch protection —
+which needs the repository owner — makes it binding. The exact steps are in
+[§ Making this enforcement](#making-this-enforcement). Until they are taken, do not call it a gate.
+
+## Why this exists
+
+On 2026-09-01 four pull requests — [#92], [#98], [#107] and [#109] — merged across review verdicts
+that were never addressed, putting two HIGHs onto `protocol/main`. Nothing mechanically connected a
+verdict to mergeability: `gh pr merge` does not read comments, and the review pattern in
+`docs/SWARM.md` §3 is a convention.
+
+It was **three distinct failure modes, and a defence against one is useless against the others.**
+
+| mode | what happened | the PRs | the rule that answers it |
+|---|---|---|---|
+| **A — policy** | merged over a REJECT already standing, in writing, on the PR | #107 by 8 min, #92 by 29 min | `no-standing-reject` |
+| **B — race** | the review lost a race it could not see it was in | #98's REJECT posted **25 s** after the merge; #109's 5.5 min after, so the PR merged before its verdict existed | `roster-declared` + `roster-resolved` |
+| **C — orientation** | pushed to a branch whose PR had already merged | #107's fixer pass, rescued by hand as [#120] | `pr-open` |
+
+Three consequences worth stating plainly, because each one defeats an obvious design:
+
+- **An in-flight marker cannot catch Mode A.** The verdict was already there; it was overridden.
+- **A REJECT-parser cannot catch Mode B.** For #98 there was nothing to parse — the gap was 25
+  seconds.
+- **An interval-based check — "did a merge race ahead of a posted verdict" — cannot catch #109 at
+  all**, because no verdict existed to measure from. A check built to that wording would have
+  passed the worst case and failed its own purpose.
+
+So the enforceable property is not an interval. It is a conjunction: **the declared complement of
+reviewers has reported, and every report is resolved** — plus CI green on *this* head SHA, plus the
+PR still being open.
+
+### The compounding factor
+
+`gh pr checks` reports the runs attached to a PR **without surfacing which commit they belong to**,
+and it returned green for #107 from a run belonging to the previous head. So on the night in
+question an agent could have merged a PR that had an open REJECT, a review still running, and
+"green CI" belonging to someone else's commit — while following every rule as written. The
+`ci-matches-head` rule reads `gh run list --branch <b> --json headSha,status,conclusion` and matches
+`headSha` against the PR's `headRefOid` itself.
+
+### Why not just use GitHub's own reviews
+
+Asked and answered, because it is the first question this design invites. The whole swarm is a
+single GitHub identity (`SlumperSan`) and every PR is authored by it, so GitHub refuses `approve`
+and `request-changes` on its own pull requests: `reviewDecision` is permanently `null` and
+`CHANGES_REQUESTED` — the state branch protection natively blocks on — is unreachable. Verified on
+2026-09-01: `viewerDidAuthor: true` on every PR checked, and **zero** native reviews exist in this
+repository's history. A second machine account is the only path to natively-enforced reviewer
+independence, and it is the owner's call (§ Making this enforcement, step 4).
+
+The same fact has a second consequence: a script cannot tell reviewer 1 from reviewer 2 by identity.
+"Two reviewers reported" is not computable from GitHub — only from a roster the orchestrator
+declares. Hence the tokens below.
+
+## The protocol
+
+Two HTML comments. They are invisible in the rendered comment, so they cost a reviewer nothing.
+
+**The orchestrator, when it spawns reviewers, posts:**
+
+```text
+<!-- REVIEW-ROSTER reviewers=Review119,Review119b -->
+```
+
+**Each reviewer, inside its existing `## Adversarial review — VERDICT` comment, posts:**
+
+```text
+<!-- REVIEW-VERDICT reviewer=Review119 verdict=REJECT -->
+```
+
+...and the fixer or the reviewer posts a newer one with `verdict=ACCEPT` once the findings are
+closed. The latest verdict per reviewer wins; verdicts arrive out of band (#92 collected a second
+REJECT 42 minutes after its merge) and a REJECT must be clearable, or no fixer pass could ever land.
+
+**The roster is the Mode B mechanism.** It is not a second, separate defence bolted on beside the
+verdicts — it is their denominator. Without it, "nobody objected" and "nobody looked" are the same
+observation, which is exactly how #109 merged 5.5 minutes before its review existed.
+
+**The reviewer count is whatever the roster declares.** It is deliberately not a hardcoded two: most
+PRs on 2026-09-01 got one review, and a check demanding two would make most PRs unmergeable, which is
+how a check gets routed around. A weaker rule that is followed beats a stronger one that is not.
+
+## The one decision that stops this being theatre
+
+A check satisfiable by writing the word ACCEPT is theatre. So:
+
+> **A structured token is the only thing that may CLEAR a blocker. The prose heuristic may only ADD
+> one.**
+
+That asymmetry does three things at once:
+
+1. **Prose can never clear**, so the "write ACCEPT to get through" attack does not exist.
+2. **The fragility of natural-language parsing is bounded to false alarms.** A reviewer who writes
+   *"this is not a REJECT, but"* gets blocked and clears it by posting a token — wrong in the safe
+   direction, and self-service to fix.
+3. **Mode A is caught on PRs that have not adopted the convention at all**, including every PR open
+   today. A token-only design would have to wait for adoption before it protected anything.
+
+The heuristic is deliberately narrow: it tests the **first non-empty line** of a comment, with bold
+markers stripped, against `^#{1,6}\s+.*\breview\b.*\bREJECT\b`. Validated against every comment on
+PRs #90–#120 on 2026-09-01: **15 matches, 15 correct.** It catches all 13 real verdict headings and
+correctly skips `## Fixer pass — Review92-B findings` and `## Fixer pass — Review109 findings` —
+both of which quote the word REJECT in their bodies, and both of which a naive body-wide grep flags
+as verdicts. That corpus is pinned in `scripts/test/merge-preflight.test.mjs`.
+
+## Running it
+
+```bash
+node scripts/merge-preflight.mjs 119
+```
+
+Exit 0 = clear, 1 = blocked, **2 = could not determine** (no `gh`, no auth, no such PR). Exit 2 is
+not a pass: a preflight that could not see is not a preflight that saw nothing wrong.
+
+`--advisory` drops the two roster rules, and so drops all of Mode B. It is what the rollout workflow
+runs while adoption is partial, and it is honestly weaker: `scripts/test/merge-preflight.test.mjs`
+asserts, as a test rather than as a claim, that advisory mode **clears** both #98 and #109 at their
+real merge instants.
+
+Run it in two places, not one:
+
+- **Before merging** — `--strict`. This is the merge question.
+- **Before pushing to a PR branch you did not just create** — the `pr-open` rule is Mode C, and it
+  is one call. Divergence is not liveness: `git rev-list --left-right --count` reports "0 behind /
+  N ahead" for a freshly-merged branch exactly as it does for a live one.
+
+## What this cannot catch
+
+Stated plainly, because failing to state a mechanism's blind spots is the failure this whole
+exercise exists to prevent.
+
+- **A reviewer that posts ACCEPT without reviewing.** Nothing here reads the review's quality. The
+  token records that a verdict was reached, never that it was earned.
+- **An agent that simply does not run it.** Everything above is convention until branch protection
+  lands. This is the largest hole by far, and it is the owner's to close.
+- **A duplicated or invented reviewer name.** The roster is self-declared by the same identity that
+  posts the verdicts, so one agent can satisfy a two-name roster. Under one GitHub account this is
+  self-policing by construction; see step 4.
+- **A verdict that arrives after a legitimate merge** — #92's second REJECT, 42 minutes late. A
+  merge gate structurally cannot catch this. It needs a post-merge sweep over recently merged PRs,
+  which is a different tool and is not built.
+- **Labels and comments are removable by whoever can merge**, so a determined agent can clear its own
+  blockers. This raises the cost of a bad merge from zero to deliberate; it does not make it
+  impossible.
+- **The quality of CI itself.** `ci-matches-head` proves a green run exists for this commit. It says
+  nothing about what that run checked.
+
+## Making this enforcement
+
+These need the repository owner. An agent cannot set branch protection, and should not try.
+
+1. **Require the check.** Settings → Branches → `protocol/main` → *Require status checks to pass
+   before merging*, and add the context **`merge-preflight`**.
+2. **Include administrators.** Tick *Do not allow bypassing the above settings* (`enforce_admins`).
+   Without it, branch protection is bypassed by exactly the account that does the merging, and the
+   policy reads as real while being advisory for the only identity that matters.
+3. **Switch the workflow from advisory to strict** once reviewers are emitting tokens: change
+   `--advisory` to `--strict` in `.github/workflows/merge-preflight.yml`. Steps 1 and 2 are worth
+   taking before this one — advisory already catches Modes A and C and stale CI.
+4. **Decide on a second machine account.** It is the only way "two independent reviewers" becomes
+   more than self-policing, and the only way GitHub's own `CHANGES_REQUESTED` becomes usable. Cost:
+   a second identity to provision and hold a token for. Not urgent; not ignorable.
+
+The `gh api` equivalents of steps 1 and 2, for the record, are in
+`scripts/lib/merge-policy.json` → `enforcement`.
+
+## The policy itself
+
+Everything below is `scripts/lib/merge-policy.json`, verbatim. It is the single source of truth:
+`scripts/merge-preflight.mjs` reads it, and `scripts/test/merge-preflight.test.mjs` asserts that this
+block is byte-identical to that file, that the regex published here is the one the code runs, and
+that every rule the evaluator can emit is declared here and vice versa. A rule cannot drift from its
+documentation without a red test — which is the general form of what went wrong: the tracked
+`docs/vault/auto-merge.md` still said merges land "once CI is green", unqualified, while every
+correction lived in a machine-local memory file that no fresh clone, no other machine and no CI
+check could ever read. **A gate nobody can read from a fresh clone is not an interlock.**
+
+```json
+{
+  "version": 1,
+  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
+  "tokens": {
+    "roster": {
+      "form": "<!-- REVIEW-ROSTER reviewers=Name1,Name2 -->",
+      "postedBy": "the orchestrator, when it spawns reviewers",
+      "purpose": "makes 'assigned but not yet posted' a computable state. The roster is the denominator; verdicts are the numerator."
+    },
+    "verdict": {
+      "form": "<!-- REVIEW-VERDICT reviewer=Name verdict=ACCEPT|REJECT -->",
+      "postedBy": "each reviewer, inside its existing '## Adversarial review — VERDICT' comment",
+      "purpose": "the ONLY thing that may CLEAR a PR. Prose can never clear."
+    }
+  },
+  "invariants": [
+    "A structured token is the only thing that may CLEAR a blocker. Prose is never sufficient, so 'satisfy the check by writing the word ACCEPT' is impossible by construction.",
+    "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
+    "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
+    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around."
+  ],
+  "rules": [
+    {
+      "id": "pr-open",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "the PR must be OPEN",
+      "blocksWhen": "state is MERGED or CLOSED, or the PR is a draft",
+      "why": "Mode C. A freshly-merged branch is indistinguishable from a live one by git divergence -- 'git rev-list --left-right --count' reports 0 behind / N ahead for both. GitHub reopens no PR on push, creates no CI run, and still accepts comments onto the closed PR, so the work looks landed and is silently stranded. This cost PR #107's entire fixer pass on 2026-09-01."
+    },
+    {
+      "id": "no-standing-reject",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "no reviewer's latest verdict may be REJECT",
+      "blocksWhen": "any reviewer's latest REVIEW-VERDICT token is REJECT, or a legacy prose REJECT heading is not followed by a later ACCEPT token",
+      "why": "Mode A. #107 merged 8 minutes after a REJECT was standing in writing on the PR; #92 merged 29 minutes after one. This is a policy failure, not a visibility one: the standing self-merge rule had no clause about an open REJECT, so an agent following it as written merges correctly and lands a HIGH."
+    },
+    {
+      "id": "ci-matches-head",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "a successful CI run must exist for THIS head SHA",
+      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid",
+      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion."
+    },
+    {
+      "id": "roster-declared",
+      "modes": [
+        "strict"
+      ],
+      "title": "a review roster must have been declared",
+      "blocksWhen": "no REVIEW-ROSTER token appears on the PR",
+      "why": "Mode B, half one. Without a declared roster there is no denominator, so 'nobody has objected' and 'nobody has looked' are the same observation. #109 merged 5.5 minutes before its review existed."
+    },
+    {
+      "id": "roster-resolved",
+      "modes": [
+        "strict"
+      ],
+      "title": "every rostered reviewer must have posted a verdict",
+      "blocksWhen": "any name in the roster has no REVIEW-VERDICT token",
+      "why": "Mode B, half two. #98 merged at 22:30:54Z holding exactly one verdict -- an ACCEPT from reviewer 1 of 2 -- and its reviewer-2 REJECT posted 25 seconds later. A rule of 'at least one verdict and it is not REJECT' passes #98 and lands its finding. The property is not 'a review exists'; it is 'the declared complement has reported and every report is resolved'."
+    }
+  ],
+  "legacyProseHeuristic": {
+    "pattern": "^#{1,6}\\s+.*\\breview\\b.*\\bREJECT\\b",
+    "appliedTo": "the first non-empty line of a comment, with markdown bold markers stripped",
+    "direction": "block-only",
+    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts."
+  },
+  "enforcement": {
+    "today": "convention. scripts/merge-preflight.mjs is a preflight an orchestrator runs; nothing compels it to.",
+    "toBecomeEnforcement": "branch protection on protocol/main requiring the 'merge-preflight' status context, with enforce_admins true. That needs the repository owner; an agent cannot set it.",
+    "nativeReviewsUnavailable": "The whole swarm is one GitHub identity (SlumperSan) and every PR is authored by it, so GitHub refuses approve/request-changes on its own PRs: reviewDecision is permanently null and CHANGES_REQUESTED -- the state branch protection natively blocks on -- is unreachable. Zero native reviews exist in this repo's history. A second machine account is the only path to natively-enforced reviewer independence, and that is the owner's call.",
+    "requiredStatusContext": "merge-preflight",
+    "ghApi": [
+      "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
+      "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
+    ]
+  }
+}
+```
+
+[#92]: https://github.com/SlumperSan/agent-governed-vaults/pull/92
+[#98]: https://github.com/SlumperSan/agent-governed-vaults/pull/98
+[#107]: https://github.com/SlumperSan/agent-governed-vaults/pull/107
+[#109]: https://github.com/SlumperSan/agent-governed-vaults/pull/109
+[#120]: https://github.com/SlumperSan/agent-governed-vaults/pull/120

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -12,7 +12,7 @@ that were never addressed, putting two HIGHs onto `protocol/main`. Nothing mecha
 verdict to mergeability: `gh pr merge` does not read comments, and the review pattern in
 `docs/SWARM.md` §3 is a convention.
 
-It was **four distinct failure modes, and a defence against one is useless against the others.**
+It was **five distinct failure modes, and a defence against one is useless against the others.**
 
 | mode | what happened | the PRs | the rule that answers it |
 |---|---|---|---|
@@ -20,6 +20,7 @@ It was **four distinct failure modes, and a defence against one is useless again
 | **B — race** | the review lost a race it could not see it was in | #98's REJECT posted **25 s** after the merge; #109's 5.5 min after, so the PR merged before its verdict existed | `roster-declared` + `roster-resolved` |
 | **C — orientation** | pushed to a branch whose PR had already merged | #107's fixer pass, rescued by hand as [#120] | `pr-open` |
 | **D — invisibility** | the reviewed content was replaced *after* a correct verdict | a keep-ours resolution on #117 would have re-introduced the list #121 exists to abolish | `verdict-covers-head` |
+| **E — staleness** | the *base* moved under a verdict whose head never did | #119's valid ACCEPT was falsified by #121 merging, with its own branch untouched | `base-current` |
 
 Three consequences worth stating plainly, because each one defeats an obvious design:
 
@@ -64,6 +65,41 @@ re-review, and no check can do it. Two related traps, both seen the same night:
 gate, because it detects nothing by itself: **when a PR resolves a non-trivial conflict, its body
 should state, per conflicted file, which side was taken and why.** That converts an invisible edit
 into a claim someone can check.
+
+### Mode E is Mode D's mirror, and it defeats every rule keyed to the PR
+
+Mode D is *"the content changed under the verdict"*. Mode E is *"the world the content describes
+changed under it"*. A PR can carry a **genuine, current, unstale ACCEPT on an unmoved head** and
+still be wrong to merge.
+
+The live instance, 2026-09-01: #119 held a valid ACCEPT against `d9293c23`. #121 then merged and
+inverted the canary tier semantics in `sinks.mjs`, making two sentences #119 *adds* false against
+merged `main`. Everything that a PR-keyed check can see stayed correct — `merge-tree` clean (they
+touch different files), CI green on the reviewed head, the verdict untouched, **the branch head never
+moved**. `verdict-covers-head` cannot see it, because nothing about the PR changed.
+
+`base-current` reads `behind_by` from the compare API — `gh pr view`'s `mergeStateStatus` only
+reports `BEHIND` once the repository *already* requires up-to-date branches, which is the setting
+this argues for, so it cannot be the detector for its own absence. It fires only once the PR has been
+reviewed at all: with no review the other rules already block, and reporting base drift there would
+be noise.
+
+**"Reviewed at all" deliberately includes a *prose* verdict of either kind**, and that widening was
+forced by running the tool rather than reasoning about it. The first version gated on a verdict
+*token*, and against **#112** — an ACCEPTed PR **43 commits behind `main`**, sitting on the owner's
+desk to merge — it reported **CLEAR**, because #112's ACCEPT is prose and a token-only gate cannot
+see it. That is precisely the case Mode E exists for, missed by the rule written to catch it. Reading
+a prose ACCEPT to *raise* a blocker keeps the asymmetry intact: prose still never clears anything.
+
+**The enforcement half is a branch-protection setting, not more script.** "Require branches to be up
+to date before merging" (`strict=true` on `required_status_checks`) makes every advance of
+`protocol/main` force each open PR to re-integrate — which moves its head, which trips
+`verdict-covers-head`, which forces a re-verdict. The two rules compose into the property you
+actually want. Its cost is a rebase treadmill proportional to how often the base moves, which here is
+often, so it is a deliberate decision — § Making this enforcement, step 1.
+
+**What it cannot tell you is whether the moved base actually falsifies anything.** That is a re-read.
+`base-current` only establishes that nobody has looked since the ground shifted.
 
 ### The compounding factor
 
@@ -201,15 +237,23 @@ exercise exists to prevent.
   reviewer who read stale content and posted late looks identical to one who read the head. Binding
   a SHA into the token would close this; it was rejected because an optional attribute nobody fills
   in is theatre, and a mandatory one changes the reviewer workflow a second time.
+- **Whether a moved base actually falsifies the PR.** `base-current` establishes only that nobody has
+  looked since the ground shifted. Deciding whether #121 broke #119's sentences is a re-read.
 - **The quality of CI itself.** `ci-matches-head` proves a green run exists for this commit. It says
-  nothing about what that run checked.
+  nothing about what that run checked — and note that a green run on an unmoved head was *also*
+  computed against the old base, so Mode E degrades that evidence too.
 
 ## Making this enforcement
 
 These need the repository owner. An agent cannot set branch protection, and should not try.
 
 1. **Require the check.** Settings → Branches → `protocol/main` → *Require status checks to pass
-   before merging*, and add the context **`merge-preflight`**.
+   before merging*, and add the context **`merge-preflight`**. **Also tick *Require branches to be up
+   to date before merging*** in the same box — that one is the enforcement half of Mode E, and it is
+   easy to miss because it looks like a formality. Without it, a PR keeps a stale-but-unmoved verdict
+   against a `main` that has moved on; with it, every advance of `main` forces a re-integration and
+   therefore a re-verdict. Its cost is a rebase treadmill proportional to how often `main` moves,
+   which in this swarm is often — so it is a real trade, not a default.
 2. **Include administrators.** Tick *Do not allow bypassing the above settings* (`enforce_admins`).
    Without it, branch protection is bypassed by exactly the account that does the merging, and the
    policy reads as real while being advisory for the only identity that matters.
@@ -270,7 +314,8 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
     "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
     "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
     "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around.",
-    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice."
+    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice.",
+    "A verdict is valid only against the base it was computed on. A PR can carry a genuine, current, unstale ACCEPT on an unmoved head and still be wrong to merge, because the base moved beneath it."
   ],
   "rules": [
     {
@@ -330,13 +375,25 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
       "title": "every rostered reviewer must have posted a verdict",
       "blocksWhen": "any name in the roster has no REVIEW-VERDICT token",
       "why": "Mode B, half two. #98 merged at 22:30:54Z holding exactly one verdict -- an ACCEPT from reviewer 1 of 2 -- and its reviewer-2 REJECT posted 25 seconds later. A rule of 'at least one verdict and it is not REJECT' passes #98 and lands its finding. The property is not 'a review exists'; it is 'the declared complement has reported and every report is resolved'."
+    },
+    {
+      "id": "base-current",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "a verdict is only valid against the base it was computed on",
+      "blocksWhen": "the branch is behind its base branch and the PR has been reviewed at all (a verdict token, or a prose verdict heading of either kind)",
+      "why": "Mode E, and Mode D's mirror: D is 'the content changed under the verdict', E is 'the world the content describes changed under it'. Seen live on 2026-09-01: #119 held a valid ACCEPT against d9293c23, then #121 merged and inverted the canary tier semantics in sinks.mjs, making two sentences #119 ADDS false against merged main -- while merge-tree stayed clean (they touch different files), CI stayed green on the reviewed head, and the verdict stayed untouched. The branch head never moved, so verdict-covers-head cannot see it and no rule keyed to the PR alone can. Read from the compare API's behind_by, because gh pr view's mergeStateStatus only reports BEHIND once the repository already requires up-to-date branches -- the very setting this argues for. It detects that a verdict was computed against a base that no longer exists; it cannot tell you WHETHER the moved base falsifies anything, which is a re-read. The enforcement half is GitHub's 'Require branches to be up to date before merging' (strict=true on required_status_checks), which makes every base advance force a re-integration and therefore a re-verdict."
     }
   ],
   "legacyProseHeuristic": {
     "pattern": "^#{1,6}\\s+.*\\breview\\b.*\\bREJECT\\b",
     "appliedTo": "the first non-empty line of a comment, with markdown bold markers stripped",
     "direction": "block-only",
-    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts."
+    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts.",
+    "verdictPattern": "^#{1,6}\\s+.*\\breview\\b.*\\b(?:REJECT|ACCEPT)\\b",
+    "verdictPatternPurpose": "The same heading shape but either verdict. It NEVER clears -- it answers only 'has anyone reviewed this at all', which base-current needs as its denominator on PRs predating the token, so raising a blocker from it is still block-only. Added after running the tool against #112: an ACCEPTed PR 43 commits behind main reported CLEAR, because its ACCEPT is prose and a token-only gate cannot see it -- the exact case Mode E exists for, missed by the rule meant to catch it."
   },
   "enforcement": {
     "today": "convention. scripts/merge-preflight.mjs is a preflight an orchestrator runs; nothing compels it to.",
@@ -346,7 +403,8 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
     "ghApi": [
       "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
       "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
-    ]
+    ],
+    "requireUpToDateBranches": "The 'strict=true' already present in the gh api line below IS GitHub's 'Require branches to be up to date before merging', and it is the enforcement half of Mode E: it makes every advance of protocol/main force each open PR to re-integrate, which moves its head and therefore trips verdict-covers-head, forcing a re-verdict. Its cost is a rebase treadmill proportional to how often the base moves, which in this swarm is often -- so it is a deliberate owner decision, not a default. Without it, base-current still reports the drift; nothing compels anyone to act on it."
   },
   "conventions": {
     "statePerFileResolutions": "When a PR resolves a non-trivial conflict, the PR body should state, per conflicted file, WHICH SIDE was taken and WHY. This detects nothing by itself. It is the only thing that makes an otherwise invisible edit into a claim a reviewer can check, and it is a CONVENTION -- do not describe it as a gate. Note also that 'the conflict is only .gas-snapshot, so regenerate it' is not a general strategy: #115 and #117 conflicted on real content."

--- a/scripts/lib/merge-policy.json
+++ b/scripts/lib/merge-policy.json
@@ -1,0 +1,88 @@
+{
+  "version": 1,
+  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
+  "tokens": {
+    "roster": {
+      "form": "<!-- REVIEW-ROSTER reviewers=Name1,Name2 -->",
+      "postedBy": "the orchestrator, when it spawns reviewers",
+      "purpose": "makes 'assigned but not yet posted' a computable state. The roster is the denominator; verdicts are the numerator."
+    },
+    "verdict": {
+      "form": "<!-- REVIEW-VERDICT reviewer=Name verdict=ACCEPT|REJECT -->",
+      "postedBy": "each reviewer, inside its existing '## Adversarial review — VERDICT' comment",
+      "purpose": "the ONLY thing that may CLEAR a PR. Prose can never clear."
+    }
+  },
+  "invariants": [
+    "A structured token is the only thing that may CLEAR a blocker. Prose is never sufficient, so 'satisfy the check by writing the word ACCEPT' is impossible by construction.",
+    "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
+    "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
+    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around."
+  ],
+  "rules": [
+    {
+      "id": "pr-open",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "the PR must be OPEN",
+      "blocksWhen": "state is MERGED or CLOSED, or the PR is a draft",
+      "why": "Mode C. A freshly-merged branch is indistinguishable from a live one by git divergence -- 'git rev-list --left-right --count' reports 0 behind / N ahead for both. GitHub reopens no PR on push, creates no CI run, and still accepts comments onto the closed PR, so the work looks landed and is silently stranded. This cost PR #107's entire fixer pass on 2026-09-01."
+    },
+    {
+      "id": "no-standing-reject",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "no reviewer's latest verdict may be REJECT",
+      "blocksWhen": "any reviewer's latest REVIEW-VERDICT token is REJECT, or a legacy prose REJECT heading is not followed by a later ACCEPT token",
+      "why": "Mode A. #107 merged 8 minutes after a REJECT was standing in writing on the PR; #92 merged 29 minutes after one. This is a policy failure, not a visibility one: the standing self-merge rule had no clause about an open REJECT, so an agent following it as written merges correctly and lands a HIGH."
+    },
+    {
+      "id": "ci-matches-head",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "a successful CI run must exist for THIS head SHA",
+      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid",
+      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion."
+    },
+    {
+      "id": "roster-declared",
+      "modes": [
+        "strict"
+      ],
+      "title": "a review roster must have been declared",
+      "blocksWhen": "no REVIEW-ROSTER token appears on the PR",
+      "why": "Mode B, half one. Without a declared roster there is no denominator, so 'nobody has objected' and 'nobody has looked' are the same observation. #109 merged 5.5 minutes before its review existed."
+    },
+    {
+      "id": "roster-resolved",
+      "modes": [
+        "strict"
+      ],
+      "title": "every rostered reviewer must have posted a verdict",
+      "blocksWhen": "any name in the roster has no REVIEW-VERDICT token",
+      "why": "Mode B, half two. #98 merged at 22:30:54Z holding exactly one verdict -- an ACCEPT from reviewer 1 of 2 -- and its reviewer-2 REJECT posted 25 seconds later. A rule of 'at least one verdict and it is not REJECT' passes #98 and lands its finding. The property is not 'a review exists'; it is 'the declared complement has reported and every report is resolved'."
+    }
+  ],
+  "legacyProseHeuristic": {
+    "pattern": "^#{1,6}\\s+.*\\breview\\b.*\\bREJECT\\b",
+    "appliedTo": "the first non-empty line of a comment, with markdown bold markers stripped",
+    "direction": "block-only",
+    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts."
+  },
+  "enforcement": {
+    "today": "convention. scripts/merge-preflight.mjs is a preflight an orchestrator runs; nothing compels it to.",
+    "toBecomeEnforcement": "branch protection on protocol/main requiring the 'merge-preflight' status context, with enforce_admins true. That needs the repository owner; an agent cannot set it.",
+    "nativeReviewsUnavailable": "The whole swarm is one GitHub identity (SlumperSan) and every PR is authored by it, so GitHub refuses approve/request-changes on its own PRs: reviewDecision is permanently null and CHANGES_REQUESTED -- the state branch protection natively blocks on -- is unreachable. Zero native reviews exist in this repo's history. A second machine account is the only path to natively-enforced reviewer independence, and that is the owner's call.",
+    "requiredStatusContext": "merge-preflight",
+    "ghApi": [
+      "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
+      "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
+    ]
+  }
+}

--- a/scripts/lib/merge-policy.json
+++ b/scripts/lib/merge-policy.json
@@ -18,7 +18,8 @@
     "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
     "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
     "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around.",
-    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice."
+    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice.",
+    "A verdict is valid only against the base it was computed on. A PR can carry a genuine, current, unstale ACCEPT on an unmoved head and still be wrong to merge, because the base moved beneath it."
   ],
   "rules": [
     {
@@ -78,13 +79,25 @@
       "title": "every rostered reviewer must have posted a verdict",
       "blocksWhen": "any name in the roster has no REVIEW-VERDICT token",
       "why": "Mode B, half two. #98 merged at 22:30:54Z holding exactly one verdict -- an ACCEPT from reviewer 1 of 2 -- and its reviewer-2 REJECT posted 25 seconds later. A rule of 'at least one verdict and it is not REJECT' passes #98 and lands its finding. The property is not 'a review exists'; it is 'the declared complement has reported and every report is resolved'."
+    },
+    {
+      "id": "base-current",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "a verdict is only valid against the base it was computed on",
+      "blocksWhen": "the branch is behind its base branch and the PR has been reviewed at all (a verdict token, or a prose verdict heading of either kind)",
+      "why": "Mode E, and Mode D's mirror: D is 'the content changed under the verdict', E is 'the world the content describes changed under it'. Seen live on 2026-09-01: #119 held a valid ACCEPT against d9293c23, then #121 merged and inverted the canary tier semantics in sinks.mjs, making two sentences #119 ADDS false against merged main -- while merge-tree stayed clean (they touch different files), CI stayed green on the reviewed head, and the verdict stayed untouched. The branch head never moved, so verdict-covers-head cannot see it and no rule keyed to the PR alone can. Read from the compare API's behind_by, because gh pr view's mergeStateStatus only reports BEHIND once the repository already requires up-to-date branches -- the very setting this argues for. It detects that a verdict was computed against a base that no longer exists; it cannot tell you WHETHER the moved base falsifies anything, which is a re-read. The enforcement half is GitHub's 'Require branches to be up to date before merging' (strict=true on required_status_checks), which makes every base advance force a re-integration and therefore a re-verdict."
     }
   ],
   "legacyProseHeuristic": {
     "pattern": "^#{1,6}\\s+.*\\breview\\b.*\\bREJECT\\b",
     "appliedTo": "the first non-empty line of a comment, with markdown bold markers stripped",
     "direction": "block-only",
-    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts."
+    "evidence": "Validated against every comment on PRs #90-#120 on 2026-09-01: 15 matches, 15 correct. It catches all 13 real verdict headings and correctly skips '## Fixer pass -- Review92-B findings' and '## Fixer pass -- Review109 findings', both of which quote the word REJECT in their bodies and which a naive body grep flags as verdicts.",
+    "verdictPattern": "^#{1,6}\\s+.*\\breview\\b.*\\b(?:REJECT|ACCEPT)\\b",
+    "verdictPatternPurpose": "The same heading shape but either verdict. It NEVER clears -- it answers only 'has anyone reviewed this at all', which base-current needs as its denominator on PRs predating the token, so raising a blocker from it is still block-only. Added after running the tool against #112: an ACCEPTed PR 43 commits behind main reported CLEAR, because its ACCEPT is prose and a token-only gate cannot see it -- the exact case Mode E exists for, missed by the rule meant to catch it."
   },
   "enforcement": {
     "today": "convention. scripts/merge-preflight.mjs is a preflight an orchestrator runs; nothing compels it to.",
@@ -94,7 +107,8 @@
     "ghApi": [
       "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
       "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
-    ]
+    ],
+    "requireUpToDateBranches": "The 'strict=true' already present in the gh api line below IS GitHub's 'Require branches to be up to date before merging', and it is the enforcement half of Mode E: it makes every advance of protocol/main force each open PR to re-integrate, which moves its head and therefore trips verdict-covers-head, forcing a re-verdict. Its cost is a rebase treadmill proportional to how often the base moves, which in this swarm is often -- so it is a deliberate owner decision, not a default. Without it, base-current still reports the drift; nothing compels anyone to act on it."
   },
   "conventions": {
     "statePerFileResolutions": "When a PR resolves a non-trivial conflict, the PR body should state, per conflicted file, WHICH SIDE was taken and WHY. This detects nothing by itself. It is the only thing that makes an otherwise invisible edit into a claim a reviewer can check, and it is a CONVENTION -- do not describe it as a gate. Note also that 'the conflict is only .gas-snapshot, so regenerate it' is not a general strategy: #115 and #117 conflicted on real content."

--- a/scripts/lib/merge-policy.json
+++ b/scripts/lib/merge-policy.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
+  "why": "Four PRs (#92 #98 #107 #109) merged on 2026-09-01 across review verdicts that were never addressed, and a fifth (#121/#117) showed that a conflict resolution can introduce a defect no review ever sees. This file is the single machine-readable source of truth for when a PR may merge. scripts/merge-preflight.mjs reads it; docs/reviews/MERGE-POLICY.md embeds it verbatim and a test asserts the two are byte-identical, so the prose humans read cannot drift from the rules the program enforces.",
   "tokens": {
     "roster": {
       "form": "<!-- REVIEW-ROSTER reviewers=Name1,Name2 -->",
@@ -17,7 +17,8 @@
     "A structured token is the only thing that may CLEAR a blocker. Prose is never sufficient, so 'satisfy the check by writing the word ACCEPT' is impossible by construction.",
     "The legacy prose heuristic may only ADD a blocker, never remove one. Its fragility is therefore bounded to false alarms, which a reviewer clears by posting a token.",
     "The latest verdict per reviewer wins. Verdicts arrive out of band and a REJECT must be clearable, or no fixer pass could ever land.",
-    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around."
+    "The reviewer count is whatever the roster declares. It is never a hardcoded N: most PRs get one review, and a gate demanding two would be routed around.",
+    "A verdict grades content, not a pull request. If the head moves after a verdict is posted, what merges is not what was reviewed -- and the dangerous case is a conflict resolution, because the diff shows the result and never the choice."
   ],
   "rules": [
     {
@@ -39,6 +40,16 @@
       "title": "no reviewer's latest verdict may be REJECT",
       "blocksWhen": "any reviewer's latest REVIEW-VERDICT token is REJECT, or a legacy prose REJECT heading is not followed by a later ACCEPT token",
       "why": "Mode A. #107 merged 8 minutes after a REJECT was standing in writing on the PR; #92 merged 29 minutes after one. This is a policy failure, not a visibility one: the standing self-merge rule had no clause about an open REJECT, so an agent following it as written merges correctly and lands a HIGH."
+    },
+    {
+      "id": "verdict-covers-head",
+      "modes": [
+        "advisory",
+        "strict"
+      ],
+      "title": "every verdict must post-date the head commit",
+      "blocksWhen": "any reviewer's latest verdict is older than the PR's head commit",
+      "why": "Mode D. Modes A, B and C are all about WHEN a merge happens relative to a review; D is about WHAT A REVIEW CAN SEE AT ALL. A conflict resolution is an edit nobody reviews -- a PR diff shows the merged RESULT and never the CHOICE -- so a defect can enter after a correct verdict and ship under it. Seen live on 2026-09-01: a keep-ours resolution on #117 would have re-introduced the hand-maintained signal list that #121 exists to abolish, inside a PR whose own subject was unrelated, and it was caught only because a verifier ran merge-tree on a branch it did not own and read the conflict rather than the diff. This rule detects that the reviewed content is no longer the content that would merge; it cannot judge whether the resolution was CORRECT, which is a re-review and not automatable. Runs in BOTH modes, unlike the roster rules: it needs only a verdict token, which is the reviewer's own act rather than an orchestrator convention."
     },
     {
       "id": "ci-matches-head",
@@ -84,5 +95,8 @@
       "gh api -X PUT repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/required_status_checks -f strict=true -f 'contexts[]=merge-preflight'",
       "gh api -X POST repos/SlumperSan/agent-governed-vaults/branches/protocol%2Fmain/protection/enforce_admins"
     ]
+  },
+  "conventions": {
+    "statePerFileResolutions": "When a PR resolves a non-trivial conflict, the PR body should state, per conflicted file, WHICH SIDE was taken and WHY. This detects nothing by itself. It is the only thing that makes an otherwise invisible edit into a claim a reviewer can check, and it is a CONVENTION -- do not describe it as a gate. Note also that 'the conflict is only .gas-snapshot, so regenerate it' is not a general strategy: #115 and #117 conflicted on real content."
   }
 }

--- a/scripts/lib/verdicts.mjs
+++ b/scripts/lib/verdicts.mjs
@@ -11,7 +11,7 @@
  * addressed, landing two HIGHs on `protocol/main`. Nothing mechanically connected a verdict to
  * mergeability: `gh pr merge` does not read comments, and the review pattern is a convention.
  *
- * It was three distinct failure modes, and a defence against one is useless against the others:
+ * It was four distinct failure modes, and a defence against one is useless against the others:
  *
  *   - **Mode A — merged over a REJECT already standing in writing.** #107 by 8 minutes, #92 by 29.
  *     Not a visibility problem: a *policy* one. The standing self-merge rule had no clause about an
@@ -23,10 +23,14 @@
  *   - **Mode C — the branch pushed to was already dead.** `git rev-list --left-right --count`
  *     reports "0 behind / N ahead" for a freshly-merged branch exactly as for a live one.
  *     Divergence is not liveness.
+ *   - **Mode D — the reviewed content was replaced after the verdict.** A, B and C are all about
+ *     *when* a merge happens relative to a review; D is about *what a review can see at all*. A
+ *     conflict resolution is an edit nobody reviews — a PR diff shows the merged RESULT and never
+ *     the CHOICE — so a defect can enter after a correct verdict and ship under it.
  *
  * So the enforceable property is a conjunction, not an interval: **the declared complement of
- * reviewers has reported, and every report is resolved** — plus CI green on *this* head SHA, plus
- * the PR still being open.
+ * reviewers has reported, and every report is resolved, on the content that would actually merge**
+ * — plus CI green on *this* head SHA, plus the PR still being open.
  *
  * ## The one design decision that stops this being theatre
  *
@@ -49,6 +53,7 @@
  * @property {number} [number]
  * @property {string} state       'OPEN' | 'MERGED' | 'CLOSED'
  * @property {string} headRefOid  the commit CI must have run on
+ * @property {string} [headCommittedDate]  ISO; when the head commit landed, for Mode D
  * @property {string} [headRefName]
  * @property {boolean} [isDraft]
  *
@@ -264,6 +269,33 @@ export function evaluate({ pr, comments, runs, mode = 'strict' }) {
       blockers.push({
         ruleId: 'ci-matches-head',
         detail: `no successful run for head ${short(pr.headRefOid)} (${mine.length} run(s) present, none conclusive).`,
+      });
+    }
+  }
+
+  // --- verdict-covers-head (Mode D) — both modes ----------------------------------------------
+  // A verdict grades content, not a pull request. If the head moved after the verdict was posted,
+  // what merges is not what was reviewed — and the dangerous case is not a fixer's new commit
+  // (visible, expected) but a CONFLICT RESOLUTION, because a PR diff shows the merged RESULT and
+  // never the CHOICE. Seen live on #121/#117: a keep-ours resolution would have re-introduced the
+  // hand-maintained signal list that #121 exists to abolish, inside a PR whose subject is unrelated,
+  // under a verdict that was correct when it was written. The reviewer was competent, the review was
+  // right, and the defect enters afterwards in an edit nobody reads.
+  // Both modes, unlike the roster rules: this needs only a verdict token, which is the reviewer's
+  // own act, not an orchestrator convention. If a verdict exists at all, checking it against the
+  // head costs nothing and is never wrong to do.
+  if (pr.headCommittedDate) {
+    const stale = Object.entries(latest)
+      .filter(([, v]) => v.at < /** @type {string} */ (pr.headCommittedDate))
+      .map(([r, v]) => `${r} (verdict ${v.at})`);
+    if (stale.length > 0) {
+      blockers.push({
+        ruleId: 'verdict-covers-head',
+        detail:
+          `head ${short(pr.headRefOid)} was committed ${pr.headCommittedDate}, after: ${stale.join(', ')}. ` +
+          `Those verdicts graded content that is no longer what would merge. Re-confirm with a newer ` +
+          `REVIEW-VERDICT token. If the new commit is a conflict resolution, re-read the resolution ` +
+          `itself — the diff shows the result, never which side was chosen.`,
       });
     }
   }

--- a/scripts/lib/verdicts.mjs
+++ b/scripts/lib/verdicts.mjs
@@ -11,7 +11,7 @@
  * addressed, landing two HIGHs on `protocol/main`. Nothing mechanically connected a verdict to
  * mergeability: `gh pr merge` does not read comments, and the review pattern is a convention.
  *
- * It was four distinct failure modes, and a defence against one is useless against the others:
+ * It was five distinct failure modes, and a defence against one is useless against the others:
  *
  *   - **Mode A — merged over a REJECT already standing in writing.** #107 by 8 minutes, #92 by 29.
  *     Not a visibility problem: a *policy* one. The standing self-merge rule had no clause about an
@@ -27,6 +27,10 @@
  *     *when* a merge happens relative to a review; D is about *what a review can see at all*. A
  *     conflict resolution is an edit nobody reviews — a PR diff shows the merged RESULT and never
  *     the CHOICE — so a defect can enter after a correct verdict and ship under it.
+ *   - **Mode E — the base moved under the verdict.** D's mirror: D is "the content changed under
+ *     the verdict", E is "the world the content describes changed under it". #119 held a valid
+ *     ACCEPT on an UNMOVED head while `main` moved beneath it and falsified two sentences the PR
+ *     adds. Nothing about the PR changed, so no rule keyed to the PR can see it.
  *
  * So the enforceable property is a conjunction, not an interval: **the declared complement of
  * reviewers has reported, and every report is resolved, on the content that would actually merge**
@@ -54,6 +58,8 @@
  * @property {string} state       'OPEN' | 'MERGED' | 'CLOSED'
  * @property {string} headRefOid  the commit CI must have run on
  * @property {string} [headCommittedDate]  ISO; when the head commit landed, for Mode D
+ * @property {number} [behindBy]  commits the branch is behind its base, for Mode E
+ * @property {string} [baseRefName]
  * @property {string} [headRefName]
  * @property {boolean} [isDraft]
  *
@@ -93,10 +99,33 @@ const VERDICT_RE = /<!--\s*REVIEW-VERDICT\s+reviewer=([A-Za-z0-9_.\-]+)\s+verdic
  */
 const LEGACY_REJECT_RE = /^#{1,6}\s+.*\breview\b.*\bREJECT\b/i;
 
+/**
+ * The same heading shape, but either verdict. This does NOT clear anything — it answers only
+ * "has anyone reviewed this at all", which Mode E needs as its denominator on PRs that predate the
+ * token. Using it to raise `base-current` is still block-only, so the asymmetry holds.
+ *
+ * Found by running the tool against #112: an ACCEPTed PR 43 commits behind `main` reported CLEAR,
+ * because its ACCEPT is prose and a token-only gate cannot see it — the exact case Mode E exists
+ * for, missed by the rule meant to catch it.
+ */
+const LEGACY_VERDICT_RE = /^#{1,6}\s+.*\breview\b.*\b(?:REJECT|ACCEPT)\b/i;
+
 
 /** Exported so a test can pin it byte-for-byte against merge-policy.json, which is the single
  * source of truth for the rules. Two copies of a rule is how the doc and the enforcement drift. */
 export const LEGACY_REJECT_PATTERN = LEGACY_REJECT_RE.source;
+
+/** Likewise pinned against the policy file. */
+export const LEGACY_VERDICT_PATTERN = LEGACY_VERDICT_RE.source;
+
+/**
+ * Comments that look like a review verdict of EITHER kind. Never clears; only supplies Mode E's
+ * denominator on PRs written before the token existed.
+ * @param {Comment[]} comments
+ */
+export function parseLegacyVerdicts(comments) {
+  return comments.filter((c) => LEGACY_VERDICT_RE.test(firstHeadingLine(c.body)));
+}
 
 /** @param {string} body */
 function firstHeadingLine(body) {
@@ -298,6 +327,32 @@ export function evaluate({ pr, comments, runs, mode = 'strict' }) {
           `itself — the diff shows the result, never which side was chosen.`,
       });
     }
+  }
+
+  // --- base-current (Mode E) — both modes -----------------------------------------------------
+  // Mode D's mirror. Mode D is "the content changed under the verdict"; this is "the world the
+  // content describes changed under the verdict". A PR can carry a genuine, current, unstale ACCEPT
+  // on an UNMOVED head and still be wrong to merge, because `main` moved beneath it.
+  //
+  // Live on #119, 2026-09-01: it held a valid ACCEPT against `d9293c23`, then #121 merged and
+  // inverted the canary tier semantics in `sinks.mjs`. Two sentences #119 *adds* became false
+  // against merged main — while `merge-tree` stayed clean (they touch different files), CI stayed
+  // green on the reviewed head, and the verdict stayed untouched. `verdict-covers-head` cannot see
+  // it, because the branch head never moved.
+  //
+  // `behindBy > 0` means the branch's merge-base is not the base branch's tip, so any verdict on it
+  // was computed against a base that no longer exists. Gated on a verdict existing: without one the
+  // other rules already block, and reporting base drift there would be noise.
+  const reviewed = Object.keys(latest).length > 0 || parseLegacyVerdicts(comments).length > 0;
+  if (typeof pr.behindBy === 'number' && pr.behindBy > 0 && reviewed) {
+    blockers.push({
+      ruleId: 'base-current',
+      detail:
+        `the branch is ${pr.behindBy} commit(s) behind ${pr.baseRefName ?? 'the base branch'}, so every ` +
+        `verdict on it was computed against a base that has since moved. Merge the base in — which ` +
+        `also re-runs CI against the content that would really land — and have the reviewer ` +
+        `re-confirm. This cannot tell you WHETHER the moved base falsifies anything; only a re-read can.`,
+    });
   }
 
   // --- roster rules (Mode B) — strict only ----------------------------------------------------

--- a/scripts/lib/verdicts.mjs
+++ b/scripts/lib/verdicts.mjs
@@ -1,0 +1,320 @@
+// @ts-check
+/**
+ * Pure logic behind `scripts/merge-preflight.mjs`: given a PR's metadata, its comments and the
+ * workflow runs on its branch, decide whether it may merge. No network, no `gh`, no filesystem —
+ * so the test suite feeds it fixtures rebuilt from real PRs instead of needing an authenticated
+ * GitHub, and `npm run gate` stays runnable offline.
+ *
+ * ## Why this exists
+ *
+ * On 2026-09-01 four PRs — #92, #98, #107 and #109 — merged across review verdicts that were never
+ * addressed, landing two HIGHs on `protocol/main`. Nothing mechanically connected a verdict to
+ * mergeability: `gh pr merge` does not read comments, and the review pattern is a convention.
+ *
+ * It was three distinct failure modes, and a defence against one is useless against the others:
+ *
+ *   - **Mode A — merged over a REJECT already standing in writing.** #107 by 8 minutes, #92 by 29.
+ *     Not a visibility problem: a *policy* one. The standing self-merge rule had no clause about an
+ *     open REJECT, so an agent following it as written merges correctly and lands a HIGH.
+ *   - **Mode B — the review lost a race it could not see it was in.** #98's REJECT posted 25
+ *     seconds after its merge; #109's 5.5 minutes after, so the PR merged before its verdict
+ *     existed at all. An interval-based check ("did a merge race ahead of a posted verdict") cannot
+ *     catch #109, because there was no verdict to measure from.
+ *   - **Mode C — the branch pushed to was already dead.** `git rev-list --left-right --count`
+ *     reports "0 behind / N ahead" for a freshly-merged branch exactly as for a live one.
+ *     Divergence is not liveness.
+ *
+ * So the enforceable property is a conjunction, not an interval: **the declared complement of
+ * reviewers has reported, and every report is resolved** — plus CI green on *this* head SHA, plus
+ * the PR still being open.
+ *
+ * ## The one design decision that stops this being theatre
+ *
+ * A structured token is the ONLY thing that may CLEAR a blocker; the prose heuristic may only ADD
+ * one. A check satisfiable by writing the word ACCEPT would be theatre, and this asymmetry makes
+ * that impossible by construction. It also bounds the fragility of natural-language parsing to
+ * false alarms — a reviewer who writes "this is not a REJECT, but" gets blocked, and clears it by
+ * posting a token — which is the safe direction to be wrong in.
+ *
+ * The rules themselves live in `merge-policy.json`, which `docs/reviews/MERGE-POLICY.md` embeds
+ * verbatim, so the prose humans read cannot drift from what this file enforces.
+ *
+ * @typedef {'ACCEPT'|'REJECT'} Verdict
+ *
+ * @typedef {object} Comment
+ * @property {string} createdAt   ISO 8601; compared lexicographically, which is correct for ISO Z
+ * @property {string} body
+ *
+ * @typedef {object} PullRequest
+ * @property {number} [number]
+ * @property {string} state       'OPEN' | 'MERGED' | 'CLOSED'
+ * @property {string} headRefOid  the commit CI must have run on
+ * @property {string} [headRefName]
+ * @property {boolean} [isDraft]
+ *
+ * @typedef {object} Run
+ * @property {string} headSha
+ * @property {string} status      'completed' | 'in_progress' | 'queued' | ...
+ * @property {string|null} conclusion
+ * @property {string} [name]
+ *
+ * @typedef {object} Blocker
+ * @property {string} ruleId
+ * @property {string} detail
+ *
+ * @typedef {object} Decision
+ * @property {'advisory'|'strict'} mode
+ * @property {boolean} clear
+ * @property {Blocker[]} blockers
+ * @property {string[]} notes
+ * @property {string[]|null} roster
+ * @property {Record<string, {verdict: Verdict, at: string}>} latestVerdicts
+ */
+
+/** The orchestrator declares who is reviewing. Last declaration wins — reviewers can be added. */
+const ROSTER_RE = /<!--\s*REVIEW-ROSTER\s+reviewers=([^\s>]+)\s*-->/g;
+
+/** A reviewer's machine-readable verdict. The only thing that may clear a blocker. */
+const VERDICT_RE = /<!--\s*REVIEW-VERDICT\s+reviewer=([A-Za-z0-9_.\-]+)\s+verdict=(ACCEPT|REJECT)\s*-->/g;
+
+/**
+ * Legacy prose verdicts, for PRs written before the token existed. Block-only, by design.
+ *
+ * Applied to the FIRST NON-EMPTY LINE with bold markers stripped, not to the whole body — the
+ * difference is not cosmetic. Validated against every comment on PRs #90–#120 on 2026-09-01:
+ * 15 matches, 15 correct. It skips `## Fixer pass — Review92-B findings` and
+ * `## Fixer pass — Review109 findings`, both of which quote the word REJECT in their bodies and
+ * which a naive body-wide grep flags as verdicts.
+ */
+const LEGACY_REJECT_RE = /^#{1,6}\s+.*\breview\b.*\bREJECT\b/i;
+
+
+/** Exported so a test can pin it byte-for-byte against merge-policy.json, which is the single
+ * source of truth for the rules. Two copies of a rule is how the doc and the enforcement drift. */
+export const LEGACY_REJECT_PATTERN = LEGACY_REJECT_RE.source;
+
+/** @param {string} body */
+function firstHeadingLine(body) {
+  const line = body.split('\n').find((l) => l.trim()) ?? '';
+  return line.replace(/\*\*/g, '').trim();
+}
+
+/**
+ * @param {Comment[]} comments
+ * @returns {{reviewers: string[], at: string}|null}
+ */
+export function parseRoster(comments) {
+  /** @type {{reviewers: string[], at: string}|null} */
+  let found = null;
+  for (const c of comments) {
+    ROSTER_RE.lastIndex = 0;
+    let m;
+    while ((m = ROSTER_RE.exec(c.body)) !== null) {
+      const reviewers = m[1]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (reviewers.length > 0) found = { reviewers, at: c.createdAt };
+    }
+  }
+  return found;
+}
+
+/**
+ * @param {Comment[]} comments
+ * @returns {{reviewer: string, verdict: Verdict, at: string}[]}
+ */
+export function parseVerdicts(comments) {
+  /** @type {{reviewer: string, verdict: Verdict, at: string}[]} */
+  const out = [];
+  for (const c of comments) {
+    VERDICT_RE.lastIndex = 0;
+    let m;
+    while ((m = VERDICT_RE.exec(c.body)) !== null) {
+      out.push({ reviewer: m[1], verdict: /** @type {Verdict} */ (m[2]), at: c.createdAt });
+    }
+  }
+  return out;
+}
+
+/**
+ * Prose REJECT headings, for PRs predating the token.
+ * @param {Comment[]} comments
+ * @returns {{heading: string, at: string}[]}
+ */
+export function parseLegacyRejects(comments) {
+  const out = [];
+  for (const c of comments) {
+    const heading = firstHeadingLine(c.body);
+    if (LEGACY_REJECT_RE.test(heading)) out.push({ heading, at: c.createdAt });
+  }
+  return out;
+}
+
+/**
+ * Latest verdict per reviewer. Verdicts arrive out of band — #92 collected a second REJECT 42
+ * minutes after its merge — and a REJECT must be clearable, or no fixer pass could ever land.
+ *
+ * @param {{reviewer: string, verdict: Verdict, at: string}[]} verdicts
+ * @returns {Record<string, {verdict: Verdict, at: string}>}
+ */
+export function latestPerReviewer(verdicts) {
+  /** @type {Record<string, {verdict: Verdict, at: string}>} */
+  const latest = {};
+  for (const v of verdicts) {
+    const prev = latest[v.reviewer];
+    if (!prev || v.at >= prev.at) latest[v.reviewer] = { verdict: v.verdict, at: v.at };
+  }
+  return latest;
+}
+
+/**
+ * Runs belonging to THIS head SHA. `gh pr checks` reports the runs attached to a PR without
+ * surfacing which commit they belong to, and returned green for #107 from a run belonging to the
+ * previous head — so the SHA correspondence is made explicit here rather than inherited.
+ *
+ * @param {Run[]} runs
+ * @param {string} headSha
+ */
+export function runsForHead(runs, headSha) {
+  const head = (headSha ?? '').toLowerCase();
+  return runs.filter((r) => (r.headSha ?? '').toLowerCase() === head);
+}
+
+/**
+ * @param {object} input
+ * @param {PullRequest} input.pr
+ * @param {Comment[]} input.comments
+ * @param {Run[]} input.runs
+ * @param {'advisory'|'strict'} [input.mode]
+ * @returns {Decision}
+ */
+export function evaluate({ pr, comments, runs, mode = 'strict' }) {
+  /** @type {Blocker[]} */
+  const blockers = [];
+  /** @type {string[]} */
+  const notes = [];
+
+  // --- pr-open (Mode C) -----------------------------------------------------------------------
+  if (pr.state !== 'OPEN') {
+    blockers.push({
+      ruleId: 'pr-open',
+      detail:
+        `PR state is ${pr.state}, not OPEN. Do not merge, and do not push to ` +
+        `${pr.headRefName ?? 'this branch'}: GitHub reopens no PR on push, opens no CI run for the ` +
+        `new commits, and still accepts comments onto the closed PR, so the work looks landed and ` +
+        `is stranded. Open a NEW PR instead.`,
+    });
+  } else if (pr.isDraft) {
+    blockers.push({ ruleId: 'pr-open', detail: 'PR is a draft.' });
+  }
+
+  // --- verdicts -------------------------------------------------------------------------------
+  const roster = parseRoster(comments);
+  const verdicts = parseVerdicts(comments);
+  const latest = latestPerReviewer(verdicts);
+  const legacy = parseLegacyRejects(comments);
+  const lastVerdictAt = verdicts.reduce((acc, v) => (v.at > acc ? v.at : acc), '');
+
+  // --- no-standing-reject (Mode A) ------------------------------------------------------------
+  for (const [reviewer, v] of Object.entries(latest)) {
+    if (v.verdict === 'REJECT') {
+      blockers.push({
+        ruleId: 'no-standing-reject',
+        detail: `${reviewer}'s latest verdict is REJECT (${v.at}). Address the findings; the fixer or the reviewer then posts a newer REVIEW-VERDICT token.`,
+      });
+    }
+  }
+  for (const l of legacy) {
+    // Block-only: a prose REJECT is cleared solely by a LATER structured token, never by more prose.
+    if (!(lastVerdictAt && lastVerdictAt > l.at)) {
+      blockers.push({
+        ruleId: 'no-standing-reject',
+        detail: `unresolved prose REJECT at ${l.at}: "${l.heading}". Prose cannot clear itself — post a REVIEW-VERDICT token after addressing it (or, if this heading is a false alarm, post one saying so).`,
+      });
+    }
+  }
+
+  // --- ci-matches-head ------------------------------------------------------------------------
+  const mine = runsForHead(runs, pr.headRefOid);
+  const succeeded = mine.filter((r) => r.status === 'completed' && r.conclusion === 'success');
+  const failed = mine.filter(
+    (r) => r.status === 'completed' && r.conclusion !== 'success' && r.conclusion !== 'skipped',
+  );
+  const pending = mine.filter((r) => r.status !== 'completed');
+  if (mine.length === 0) {
+    blockers.push({
+      ruleId: 'ci-matches-head',
+      detail: `no workflow run exists for head ${short(pr.headRefOid)}. Any green you can see belongs to another commit — 'gh pr checks' does not say which SHA it ran on.`,
+    });
+  } else {
+    for (const r of failed) {
+      blockers.push({
+        ruleId: 'ci-matches-head',
+        detail: `run ${r.name ?? '(unnamed)'} on head ${short(pr.headRefOid)} concluded ${r.conclusion}.`,
+      });
+    }
+    for (const r of pending) {
+      blockers.push({
+        ruleId: 'ci-matches-head',
+        detail: `run ${r.name ?? '(unnamed)'} on head ${short(pr.headRefOid)} is ${r.status}, not completed.`,
+      });
+    }
+    if (succeeded.length === 0 && failed.length === 0 && pending.length === 0) {
+      blockers.push({
+        ruleId: 'ci-matches-head',
+        detail: `no successful run for head ${short(pr.headRefOid)} (${mine.length} run(s) present, none conclusive).`,
+      });
+    }
+  }
+
+  // --- roster rules (Mode B) — strict only ----------------------------------------------------
+  if (mode === 'strict') {
+    if (!roster) {
+      blockers.push({
+        ruleId: 'roster-declared',
+        detail:
+          'no REVIEW-ROSTER token on this PR. Without a declared roster there is no denominator, ' +
+          'so "nobody objected" and "nobody looked" are the same observation — which is exactly how ' +
+          '#109 merged 5.5 minutes before its review existed.',
+      });
+    } else {
+      const missing = roster.reviewers.filter((r) => !latest[r]);
+      if (missing.length > 0) {
+        blockers.push({
+          ruleId: 'roster-resolved',
+          detail: `rostered reviewer(s) with no verdict yet: ${missing.join(', ')}. Review in flight — this is not "nobody objected".`,
+        });
+      }
+    }
+  } else if (!roster) {
+    notes.push('advisory mode: no REVIEW-ROSTER token, so Mode B (a review still in flight) is NOT checked.');
+  }
+
+  // --- notes ----------------------------------------------------------------------------------
+  if (roster) {
+    const offRoster = Object.keys(latest).filter((r) => !roster.reviewers.includes(r));
+    if (offRoster.length > 0) {
+      notes.push(`verdict(s) from reviewer(s) not on the roster, counted anyway: ${offRoster.join(', ')}.`);
+    }
+  } else if (verdicts.length > 0) {
+    notes.push(`${verdicts.length} verdict token(s) present but no roster declared — the complement is unknown.`);
+  }
+  if (legacy.length > 0 && verdicts.length === 0) {
+    notes.push('this PR predates the REVIEW-VERDICT token; verdicts read by the block-only prose heuristic.');
+  }
+
+  return {
+    mode,
+    clear: blockers.length === 0,
+    blockers,
+    notes,
+    roster: roster ? roster.reviewers : null,
+    latestVerdicts: latest,
+  };
+}
+
+/** @param {string} sha */
+function short(sha) {
+  return (sha ?? '').slice(0, 8) || '(unknown)';
+}

--- a/scripts/merge-preflight.mjs
+++ b/scripts/merge-preflight.mjs
@@ -12,7 +12,7 @@
  *
  * WHY THIS EXISTS. On 2026-09-01 four PRs — #92, #98, #107 and #109 — merged across review verdicts
  * that were never addressed, putting two HIGHs on `protocol/main`. `gh pr merge` does not read
- * comments, so nothing connected a verdict to mergeability. The three failure modes and the rules
+ * comments, so nothing connected a verdict to mergeability. The four failure modes and the rules
  * that answer them are documented in `scripts/lib/verdicts.mjs` and specified in
  * `scripts/lib/merge-policy.json`, which is the single source of truth this reads.
  *

--- a/scripts/merge-preflight.mjs
+++ b/scripts/merge-preflight.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Merge preflight: ask, before merging or before pushing, whether a PR is actually mergeable.
+ *
+ *     node scripts/merge-preflight.mjs 119                  # strict (the merge question)
+ *     node scripts/merge-preflight.mjs 119 --advisory       # skip the roster rules
+ *     node scripts/merge-preflight.mjs 119 --json
+ *
+ * Exit 0 = clear, 1 = blocked, 2 = could not determine (no `gh`, no auth, no such PR). **Exit 2 is
+ * not a pass.** A preflight that cannot see is not a preflight that saw nothing wrong.
+ *
+ * WHY THIS EXISTS. On 2026-09-01 four PRs — #92, #98, #107 and #109 — merged across review verdicts
+ * that were never addressed, putting two HIGHs on `protocol/main`. `gh pr merge` does not read
+ * comments, so nothing connected a verdict to mergeability. The three failure modes and the rules
+ * that answer them are documented in `scripts/lib/verdicts.mjs` and specified in
+ * `scripts/lib/merge-policy.json`, which is the single source of truth this reads.
+ *
+ * WHAT THIS IS AND IS NOT. Run by hand or from the `merge-preflight` workflow, this is a
+ * **convention**: nothing compels an agent to run it, and an agent that skips it merges exactly as
+ * before. It becomes **enforcement** only when the repository owner requires the `merge-preflight`
+ * status context in branch protection on `protocol/main`, with `enforce_admins` on. Until then, do
+ * not describe it as a gate. See `docs/reviews/MERGE-POLICY.md` § "What this cannot catch".
+ *
+ * NO LOCAL STATE. It takes a PR number and reads only `gh`, so it behaves identically on a
+ * developer's machine, in a detached review worktree, and on a CI runner. The rule evaluation
+ * itself is pure and lives in `scripts/lib/verdicts.mjs`, tested against fixtures rebuilt from the
+ * four real PRs in `scripts/test/merge-preflight.test.mjs` — no network in the test suite.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluate } from './lib/verdicts.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO = 'SlumperSan/agent-governed-vaults';
+
+/** @param {string[]} args */
+function parseArgs(args) {
+  const out = {
+    /** @type {string|null} */ pr: null,
+    /** @type {'advisory'|'strict'} */ mode: /** @type {'strict'} */ ('strict'),
+    repo: process.env.MERGE_PREFLIGHT_REPO || DEFAULT_REPO,
+    json: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--advisory') out.mode = /** @type {'advisory'} */ ('advisory');
+    else if (a === '--strict') out.mode = /** @type {'strict'} */ ('strict');
+    else if (a === '--json') out.json = true;
+    else if (a === '--repo') out.repo = args[++i];
+    else if (/^\d+$/.test(a)) out.pr = a;
+  }
+  return out;
+}
+
+/**
+ * @param {string[]} args
+ * @returns {{ok: true, data: any} | {ok: false, err: string}}
+ */
+function gh(args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', shell: process.platform === 'win32' });
+  if (r.error) return { ok: false, err: `could not run gh: ${r.error.message}` };
+  if (r.status !== 0) return { ok: false, err: (r.stderr || r.stdout || '').trim() };
+  try {
+    return { ok: true, data: JSON.parse(r.stdout) };
+  } catch (e) {
+    return { ok: false, err: `gh returned unparseable JSON: ${String(e)}` };
+  }
+}
+
+/** @param {string} label */
+function rule(label) {
+  const policy = JSON.parse(readFileSync(path.join(HERE, 'lib', 'merge-policy.json'), 'utf8'));
+  return policy.rules.find((/** @type {any} */ r) => r.id === label);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (!opts.pr) {
+    process.stderr.write('usage: node scripts/merge-preflight.mjs <pr-number> [--advisory] [--json] [--repo owner/name]\n');
+    return 2;
+  }
+
+  const pr = gh([
+    'pr', 'view', opts.pr, '--repo', opts.repo,
+    '--json', 'number,state,isDraft,headRefName,headRefOid,comments',
+  ]);
+  if (!pr.ok) {
+    process.stderr.write(`merge-preflight: cannot read PR #${opts.pr}: ${pr.err}\n`);
+    return 2;
+  }
+
+  // The branch, not the PR, is what `gh run list` keys on — and keying on the branch is the whole
+  // point: it is the only way to get `headSha` back and check it ourselves.
+  const runs = gh([
+    'run', 'list', '--repo', opts.repo, '--branch', pr.data.headRefName,
+    '--limit', '30', '--json', 'headSha,status,conclusion,workflowName',
+  ]);
+  if (!runs.ok) {
+    process.stderr.write(`merge-preflight: cannot list runs for ${pr.data.headRefName}: ${runs.err}\n`);
+    return 2;
+  }
+
+  const decision = evaluate({
+    pr: {
+      number: pr.data.number,
+      state: pr.data.state,
+      isDraft: pr.data.isDraft,
+      headRefName: pr.data.headRefName,
+      headRefOid: pr.data.headRefOid,
+    },
+    comments: (pr.data.comments ?? []).map((/** @type {any} */ c) => ({ createdAt: c.createdAt, body: c.body })),
+    runs: (runs.data ?? []).map((/** @type {any} */ r) => ({
+      headSha: r.headSha, status: r.status, conclusion: r.conclusion, name: r.workflowName,
+    })),
+    mode: opts.mode,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ pr: pr.data.number, headRefOid: pr.data.headRefOid, ...decision }, null, 2) + '\n');
+    return decision.clear ? 0 : 1;
+  }
+
+  const head = String(pr.data.headRefOid).slice(0, 8);
+  process.stdout.write(`\nmerge-preflight #${pr.data.number} (${opts.mode}) — ${pr.data.headRefName} @ ${head}\n`);
+  process.stdout.write(`  roster:   ${decision.roster ? decision.roster.join(', ') : '(none declared)'}\n`);
+  const vs = Object.entries(decision.latestVerdicts);
+  process.stdout.write(`  verdicts: ${vs.length ? vs.map(([r, v]) => `${r}=${v.verdict}`).join(', ') : '(no tokens)'}\n\n`);
+
+  if (decision.clear) {
+    process.stdout.write('  CLEAR — no blocker found.\n');
+  } else {
+    process.stdout.write(`  BLOCKED — ${decision.blockers.length} blocker(s):\n`);
+    for (const b of decision.blockers) {
+      process.stdout.write(`\n  [${b.ruleId}] ${b.detail}\n`);
+      const r = rule(b.ruleId);
+      if (r) process.stdout.write(`      why: ${r.why}\n`);
+    }
+  }
+  for (const n of decision.notes) process.stdout.write(`\n  note: ${n}\n`);
+  process.stdout.write(
+    decision.clear
+      ? '\n  This is a preflight, not a gate: it is advisory until branch protection requires it.\n\n'
+      : '\n',
+  );
+  return decision.clear ? 0 : 1;
+}
+
+// Only run when invoked directly, so the test suite can import this module without executing it.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/scripts/merge-preflight.mjs
+++ b/scripts/merge-preflight.mjs
@@ -12,7 +12,7 @@
  *
  * WHY THIS EXISTS. On 2026-09-01 four PRs — #92, #98, #107 and #109 — merged across review verdicts
  * that were never addressed, putting two HIGHs on `protocol/main`. `gh pr merge` does not read
- * comments, so nothing connected a verdict to mergeability. The four failure modes and the rules
+ * comments, so nothing connected a verdict to mergeability. The five failure modes and the rules
  * that answer them are documented in `scripts/lib/verdicts.mjs` and specified in
  * `scripts/lib/merge-policy.json`, which is the single source of truth this reads.
  *
@@ -85,7 +85,7 @@ export function main(argv = process.argv.slice(2)) {
 
   const pr = gh([
     'pr', 'view', opts.pr, '--repo', opts.repo,
-    '--json', 'number,state,isDraft,headRefName,headRefOid,comments,commits',
+    '--json', 'number,state,isDraft,headRefName,headRefOid,baseRefName,comments,commits',
   ]);
   if (!pr.ok) {
     process.stderr.write(`merge-preflight: cannot read PR #${opts.pr}: ${pr.err}\n`);
@@ -103,6 +103,21 @@ export function main(argv = process.argv.slice(2)) {
     return 2;
   }
 
+  // Mode E: how far the branch's merge-base has fallen behind its base branch. `gh pr view` does
+  // not report it -- mergeStateStatus only says BEHIND when the repo already requires up-to-date
+  // branches, which is the setting we are trying to argue for -- so ask the compare API directly.
+  // `--jq` so we get back the one integer rather than the full compare payload, which carries every
+  // changed file and can run to megabytes on a branch this far along.
+  const cmp = gh([
+    'api', `repos/${opts.repo}/compare/${pr.data.baseRefName}...${pr.data.headRefName}`,
+    '--jq', '.behind_by',
+  ]);
+  if (!cmp.ok) {
+    const where = `${pr.data.baseRefName}...${pr.data.headRefName}`;
+    process.stderr.write(`merge-preflight: cannot compare ${where}: ${cmp.err}\n`);
+    return 2;
+  }
+
   const decision = evaluate({
     pr: {
       number: pr.data.number,
@@ -113,6 +128,8 @@ export function main(argv = process.argv.slice(2)) {
       // When the head commit landed. A merge/conflict-resolution commit gets a fresh committer
       // date, which is exactly the Mode D signal: content changed after a verdict was written.
       headCommittedDate: (pr.data.commits ?? []).at(-1)?.committedDate,
+      baseRefName: pr.data.baseRefName,
+      behindBy: cmp.data,
     },
     comments: (pr.data.comments ?? []).map((/** @type {any} */ c) => ({ createdAt: c.createdAt, body: c.body })),
     runs: (runs.data ?? []).map((/** @type {any} */ r) => ({

--- a/scripts/merge-preflight.mjs
+++ b/scripts/merge-preflight.mjs
@@ -85,7 +85,7 @@ export function main(argv = process.argv.slice(2)) {
 
   const pr = gh([
     'pr', 'view', opts.pr, '--repo', opts.repo,
-    '--json', 'number,state,isDraft,headRefName,headRefOid,comments',
+    '--json', 'number,state,isDraft,headRefName,headRefOid,comments,commits',
   ]);
   if (!pr.ok) {
     process.stderr.write(`merge-preflight: cannot read PR #${opts.pr}: ${pr.err}\n`);
@@ -110,6 +110,9 @@ export function main(argv = process.argv.slice(2)) {
       isDraft: pr.data.isDraft,
       headRefName: pr.data.headRefName,
       headRefOid: pr.data.headRefOid,
+      // When the head commit landed. A merge/conflict-resolution commit gets a fresh committer
+      // date, which is exactly the Mode D signal: content changed after a verdict was written.
+      headCommittedDate: (pr.data.commits ?? []).at(-1)?.committedDate,
     },
     comments: (pr.data.comments ?? []).map((/** @type {any} */ c) => ({ createdAt: c.createdAt, body: c.body })),
     runs: (runs.data ?? []).map((/** @type {any} */ r) => ({

--- a/scripts/test/merge-preflight.test.mjs
+++ b/scripts/test/merge-preflight.test.mjs
@@ -84,6 +84,12 @@ test('#98 at its merge instant: Mode B — one ACCEPT, one reviewer still out, R
   assert.equal(strict.clear, false);
   assert.deepEqual(ruleIds(strict.blockers), ['roster-resolved']);
   assert.match(strict.blockers[0].detail, /Review98b/, 'it must name the reviewer who has not reported');
+
+  // Precision about the fixture: the ROSTER token above is reconstructed, not historical — #98 had
+  // no such token, because the protocol did not exist. In the state #98 was actually in, strict
+  // blocks on roster-declared instead. Either way it does not merge; only the rule id differs.
+  const asItWas = [{ createdAt: '2026-09-01T20:05:45Z', body: '## Adversarial review 1 of 2 — **ACCEPT**, plus a finding bigger than the PR' }];
+  assert.deepEqual(ruleIds(evaluate({ pr, comments: asItWas, runs: greenOn('cccc3333'), mode: 'strict' }).blockers), ['roster-declared']);
 });
 
 test('#109 at its merge instant: Mode B at its worst — the PR merged before any verdict existed', () => {

--- a/scripts/test/merge-preflight.test.mjs
+++ b/scripts/test/merge-preflight.test.mjs
@@ -1,0 +1,312 @@
+// @ts-check
+/**
+ * Merge-preflight tests.
+ *
+ * The four fixtures below are the four PRs that merged across their own review verdicts on
+ * 2026-09-01 — #92, #98, #107 and #109 — each reconstructed as it stood **at its own merge
+ * instant**: only the comments that existed then, and the workflow runs that existed then.
+ * Timestamps and comment headings are the real ones, read from `gh pr view --json mergedAt,comments`.
+ * The suite's central claim is that every one of the four would have been BLOCKED, and — because a
+ * defence against one mode is useless against another — that they are blocked for *different*
+ * reasons.
+ *
+ * No network: `evaluate()` is pure, so `npm run gate` needs neither `gh` nor authentication.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluate, parseLegacyRejects, latestPerReviewer, LEGACY_REJECT_PATTERN } from '../lib/verdicts.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const POLICY = JSON.parse(readFileSync(path.join(ROOT, 'scripts', 'lib', 'merge-policy.json'), 'utf8'));
+
+/** A green CI run on the PR's own head — so CI is never the reason a fixture blocks. */
+const greenOn = (sha) => [{ headSha: sha, status: 'completed', conclusion: 'success', name: 'CI' }];
+
+/** @param {import('../lib/verdicts.mjs').Blocker[]} bs */
+const ruleIds = (bs) => [...new Set(bs.map((b) => b.ruleId))].sort();
+
+// ---------------------------------------------------------------------------------------------
+// The four real merges
+// ---------------------------------------------------------------------------------------------
+
+test('#107 at its merge instant: Mode A — a REJECT standing 8 minutes, in writing, on the PR', () => {
+  const d = evaluate({
+    pr: { number: 107, state: 'OPEN', headRefOid: 'aaaa1111', headRefName: 'feat/indexer-exit-fee-governance-abis' },
+    comments: [{ createdAt: '2026-09-01T22:35:29Z', body: '## Adversarial review — **REJECT**\n\nF1 HIGH: deserializeState spreads legacy vault records.' }],
+    runs: greenOn('aaaa1111'),
+    mode: 'strict',
+  });
+  assert.equal(d.clear, false);
+  assert.ok(ruleIds(d.blockers).includes('no-standing-reject'), 'the standing REJECT must block on its own');
+  // And it blocks in advisory mode too — Mode A needs no convention adoption to be caught.
+  const adv = evaluate({
+    pr: { number: 107, state: 'OPEN', headRefOid: 'aaaa1111', headRefName: 'b' },
+    comments: [{ createdAt: '2026-09-01T22:35:29Z', body: '## Adversarial review — **REJECT**\n\nbody' }],
+    runs: greenOn('aaaa1111'),
+    mode: 'advisory',
+  });
+  assert.deepEqual(ruleIds(adv.blockers), ['no-standing-reject']);
+});
+
+test('#92 at its merge instant: Mode A, and the fixer comment that quotes REJECT is not a verdict', () => {
+  const comments = [
+    { createdAt: '2026-08-30T02:56:26Z', body: '## Adversarial review 1 of 2 — **REJECT**\n\nthe operational lane' },
+    { createdAt: '2026-09-01T18:19:00Z', body: '## Fixer pass — all eight findings addressed\n\nGate green.' },
+    { createdAt: '2026-09-01T22:16:21Z', body: '## Adversarial review — fresh, post-#103 — **REJECT**\n\nHIGH 1, HIGH 2.' },
+  ];
+  const d = evaluate({
+    pr: { number: 92, state: 'OPEN', headRefOid: 'bbbb2222', headRefName: 'fix/aggregator-swap-drift-rebased' },
+    comments,
+    runs: greenOn('bbbb2222'),
+    mode: 'strict',
+  });
+  assert.equal(d.clear, false);
+  assert.equal(parseLegacyRejects(comments).length, 2, 'two verdicts, not three — the fixer pass is not one');
+});
+
+test('#98 at its merge instant: Mode B — one ACCEPT, one reviewer still out, REJECT 25 s later', () => {
+  // At 22:30:54Z exactly one verdict existed and it was an ACCEPT from reviewer 1 of 2.
+  const atMerge = [
+    { createdAt: '2026-09-01T20:05:45Z', body: '## Adversarial review 1 of 2 — **ACCEPT**, plus a finding bigger than the PR\n\n<!-- REVIEW-VERDICT reviewer=Review98a verdict=ACCEPT -->' },
+    { createdAt: '2026-09-01T20:05:45Z', body: '<!-- REVIEW-ROSTER reviewers=Review98a,Review98b -->' },
+  ];
+  const pr = { number: 98, state: 'OPEN', headRefOid: 'cccc3333', headRefName: 'test/guard-depth' };
+
+  // THE DISCRIMINATING PAIR. A rule of "a verdict exists and it is not REJECT" — the brief's own
+  // first formulation — clears #98 and lands its finding. Only the roster rule blocks it.
+  const advisory = evaluate({ pr, comments: atMerge, runs: greenOn('cccc3333'), mode: 'advisory' });
+  assert.equal(advisory.clear, true, 'advisory mode genuinely clears #98 — this is why Mode B needs the roster');
+
+  const strict = evaluate({ pr, comments: atMerge, runs: greenOn('cccc3333'), mode: 'strict' });
+  assert.equal(strict.clear, false);
+  assert.deepEqual(ruleIds(strict.blockers), ['roster-resolved']);
+  assert.match(strict.blockers[0].detail, /Review98b/, 'it must name the reviewer who has not reported');
+});
+
+test('#109 at its merge instant: Mode B at its worst — the PR merged before any verdict existed', () => {
+  const pr = { number: 109, state: 'OPEN', headRefOid: 'dddd4444', headRefName: 'feat/canary-tiered-sinks-deadman' };
+  // No verdict, and no interval to measure from: the REJECT arrived 5.5 minutes AFTER the merge.
+  const roster = [{ createdAt: '2026-09-01T22:10:00Z', body: '<!-- REVIEW-ROSTER reviewers=Review109 -->' }];
+  const strict = evaluate({ pr, comments: roster, runs: greenOn('dddd4444'), mode: 'strict' });
+  assert.equal(strict.clear, false);
+  assert.deepEqual(ruleIds(strict.blockers), ['roster-resolved']);
+
+  // With no roster at all — the state #109 was actually in — strict still blocks, on roster-declared.
+  const noRoster = evaluate({ pr, comments: [], runs: greenOn('dddd4444'), mode: 'strict' });
+  assert.deepEqual(ruleIds(noRoster.blockers), ['roster-declared']);
+
+  // And the honest limit, asserted rather than claimed: advisory mode CANNOT catch #109.
+  const adv = evaluate({ pr, comments: [], runs: greenOn('dddd4444'), mode: 'advisory' });
+  assert.equal(adv.clear, true, 'advisory mode cannot see a review that does not exist yet — Mode B needs the roster convention');
+});
+
+// ---------------------------------------------------------------------------------------------
+// Mode C, and CI that belongs to somebody else's commit
+// ---------------------------------------------------------------------------------------------
+
+test('Mode C: a MERGED PR blocks, and the message says open a new PR rather than push', () => {
+  const d = evaluate({
+    pr: { number: 107, state: 'MERGED', headRefOid: 'eeee5555', headRefName: 'feat/indexer-exit-fee-governance-abis' },
+    comments: [{ createdAt: '2026-09-01T22:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' }],
+    runs: greenOn('eeee5555'),
+    mode: 'strict',
+  });
+  assert.deepEqual(ruleIds(d.blockers), ['pr-open']);
+  assert.match(d.blockers[0].detail, /NEW PR/);
+});
+
+test('green CI belonging to the previous head does not count as green', () => {
+  const base = {
+    pr: { number: 107, state: 'OPEN', headRefOid: 'newhead0', headRefName: 'b' },
+    comments: [{ createdAt: '2026-09-01T22:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' }],
+    mode: /** @type {'strict'} */ ('strict'),
+  };
+  const stale = evaluate({ ...base, runs: [{ headSha: 'oldhead0', status: 'completed', conclusion: 'success', name: 'CI' }] });
+  assert.deepEqual(ruleIds(stale.blockers), ['ci-matches-head']);
+  assert.match(stale.blockers[0].detail, /belongs to another commit/);
+
+  // Boundary: the same run, moved onto this head, clears — so the SHA comparison is load-bearing.
+  const fresh = evaluate({ ...base, runs: [{ headSha: 'newhead0', status: 'completed', conclusion: 'success', name: 'CI' }] });
+  assert.equal(fresh.clear, true);
+
+  // A run on this head that has not finished is not green either — and it must say so, because
+  // "still running" and "no conclusive run" call for different actions from whoever reads it.
+  const running = evaluate({ ...base, runs: [{ headSha: 'newhead0', status: 'in_progress', conclusion: '', name: 'CI' }] });
+  assert.deepEqual(ruleIds(running.blockers), ['ci-matches-head']);
+  assert.match(running.blockers[0].detail, /in_progress/);
+});
+
+test('a red run on this head blocks, and names the conclusion', () => {
+  const d = evaluate({
+    pr: { number: 1, state: 'OPEN', headRefOid: 'newhead0', headRefName: 'b' },
+    comments: [{ createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' }],
+    runs: [{ headSha: 'newhead0', status: 'completed', conclusion: 'failure', name: 'CI' }],
+    mode: 'strict',
+  });
+  assert.deepEqual(ruleIds(d.blockers), ['ci-matches-head']);
+  assert.match(d.blockers[0].detail, /concluded failure/);
+  // A skipped run is neither a pass nor a failure: it must not be reported as red.
+  const skipped = evaluate({
+    pr: { number: 1, state: 'OPEN', headRefOid: 'newhead0', headRefName: 'b' },
+    comments: [{ createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' }],
+    runs: [{ headSha: 'newhead0', status: 'completed', conclusion: 'skipped', name: 'CI' }],
+    mode: 'strict',
+  });
+  assert.equal(skipped.clear, false, 'a skipped run is not a green run either');
+  assert.doesNotMatch(skipped.blockers[0].detail, /concluded/);
+});
+
+test('a draft PR is not mergeable, whatever its verdicts say', () => {
+  const d = evaluate({
+    pr: { number: 1, state: 'OPEN', isDraft: true, headRefOid: 'abc', headRefName: 'b' },
+    comments: [{ createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' }],
+    runs: greenOn('abc'),
+    mode: 'strict',
+  });
+  assert.deepEqual(ruleIds(d.blockers), ['pr-open']);
+});
+
+// ---------------------------------------------------------------------------------------------
+// The anti-theatre property: prose may block, only tokens may clear
+// ---------------------------------------------------------------------------------------------
+
+test('writing the word ACCEPT in prose cannot clear anything', () => {
+  const pr = { number: 1, state: 'OPEN', headRefOid: 'abc', headRefName: 'b' };
+  const d = evaluate({
+    pr,
+    runs: greenOn('abc'),
+    mode: 'strict',
+    comments: [
+      { createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->' },
+      { createdAt: '2026-09-01T11:00:00Z', body: '## Adversarial review — **REJECT**\n\nreal finding' },
+      { createdAt: '2026-09-01T12:00:00Z', body: '## Adversarial review — **ACCEPT**\n\nlooks fine to me now' },
+    ],
+  });
+  assert.equal(d.clear, false, 'a prose ACCEPT must not clear a prose REJECT');
+  assert.ok(ruleIds(d.blockers).includes('no-standing-reject'));
+  assert.ok(ruleIds(d.blockers).includes('roster-resolved'), 'and prose is not a verdict for roster purposes either');
+});
+
+test('a token REJECT is not cleared by prose, and is cleared by a later token', () => {
+  const pr = { number: 1, state: 'OPEN', headRefOid: 'abc', headRefName: 'b' };
+  const roster = { createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->' };
+  const rejected = { createdAt: '2026-09-01T11:00:00Z', body: 'findings\n<!-- REVIEW-VERDICT reviewer=R verdict=REJECT -->' };
+  const prose = { createdAt: '2026-09-01T12:00:00Z', body: 'I think this is fine now, ACCEPT.' };
+
+  assert.equal(evaluate({ pr, comments: [roster, rejected, prose], runs: greenOn('abc'), mode: 'strict' }).clear, false);
+
+  const token = { createdAt: '2026-09-01T13:00:00Z', body: 'fixes verified\n<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' };
+  assert.equal(evaluate({ pr, comments: [roster, rejected, prose, token], runs: greenOn('abc'), mode: 'strict' }).clear, true);
+});
+
+test('latest verdict per reviewer wins, in both directions', () => {
+  const a = { reviewer: 'R', verdict: /** @type {const} */ ('ACCEPT'), at: '2026-09-01T10:00:00Z' };
+  const r = { reviewer: 'R', verdict: /** @type {const} */ ('REJECT'), at: '2026-09-01T11:00:00Z' };
+  assert.equal(latestPerReviewer([a, r]).R.verdict, 'REJECT');
+  assert.equal(latestPerReviewer([r, a]).R.verdict, 'REJECT', 'order of the array must not matter — time does');
+  assert.equal(latestPerReviewer([r, { ...a, at: '2026-09-01T12:00:00Z' }]).R.verdict, 'ACCEPT');
+});
+
+test('a prose REJECT is cleared only by a STRICTLY later token — asserted at the boundary', () => {
+  const pr = { number: 1, state: 'OPEN', headRefOid: 'abc', headRefName: 'b' };
+  const at = '2026-09-01T11:00:00Z';
+  const legacy = { createdAt: at, body: '## Adversarial review — **REJECT**\n\nfinding' };
+  const run = (tokenAt) =>
+    evaluate({
+      pr,
+      runs: greenOn('abc'),
+      mode: 'advisory',
+      comments: [legacy, { createdAt: tokenAt, body: `<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->` }],
+    }).clear;
+
+  assert.equal(run('2026-09-01T10:59:59Z'), false, 'one second before: still blocked');
+  assert.equal(run(at), false, 'exactly equal: still blocked — a token in the same comment-second is not a response to it');
+  assert.equal(run('2026-09-01T11:00:01Z'), true, 'one second after: cleared');
+});
+
+// ---------------------------------------------------------------------------------------------
+// The prose heuristic, pinned to the corpus it was validated against
+// ---------------------------------------------------------------------------------------------
+
+test('the block-only prose heuristic classifies the real 2026-09-01 corpus exactly', () => {
+  // Every comment heading on PRs #90-#120 that contains the word REJECT anywhere in its body.
+  const verdicts = [
+    '## Adversarial review 1 of 2 — **REJECT**',
+    '## Adversarial review — fresh, post-#103 — **REJECT**',
+    '## Adversarial review 2 of 2 — **REJECT**',
+    '## Adversarial review — REJECT',
+  ];
+  const notVerdicts = [
+    '## Fixer pass — Review92-B findings',
+    '## Fixer pass — Review109 findings',
+    '## Adversarial review 1 of 2 — **ACCEPT**, plus a finding bigger than the PR',
+    '## Adversarial review — ACCEPT',
+    '### Follow-up to the review above — the F1 fix is safe against the *deployed* bytecode',
+    'Conflict with `main` resolved (snapshot regenerated, not merged textually)',
+  ];
+  for (const h of verdicts) {
+    assert.equal(parseLegacyRejects([{ createdAt: 't', body: `${h}\n\nbody` }]).length, 1, h);
+  }
+  for (const h of notVerdicts) {
+    // Body deliberately quotes the word, as the two real fixer passes do.
+    assert.equal(
+      parseLegacyRejects([{ createdAt: 't', body: `${h}\n\nThis PR merged 29 minutes after the REJECT above.` }]).length,
+      0,
+      h,
+    );
+  }
+});
+
+test('the heuristic reads the first NON-EMPTY line, not the raw body — GitHub bodies often start blank', () => {
+  // Mutation-found gap: with the regex applied to the whole body the ^ anchor fails on a leading
+  // newline, so a real REJECT posted with a blank first line would be silently missed — a false
+  // NEGATIVE in the one direction this design cannot afford.
+  const withBlank = [{ createdAt: 't', body: ['', '## Adversarial review — **REJECT**', '', 'finding'].join('\n') }];
+  assert.equal(parseLegacyRejects(withBlank).length, 1);
+  const withIndent = [{ createdAt: 't', body: ['   ', '  ## Adversarial review — REJECT', ''].join('\n') }];
+  assert.equal(parseLegacyRejects(withIndent).length, 1);
+});
+
+test('two verdicts from one reviewer at the SAME timestamp: the later one in the comment wins', () => {
+  // A reviewer correcting itself inside one comment, or two comments in the same second. Document
+  // order is the only tie-break available, and it must be the LAST token — otherwise a correction
+  // posted underneath the mistake it corrects is ignored.
+  const at = '2026-09-01T11:00:00Z';
+  assert.equal(latestPerReviewer([
+    { reviewer: 'R', verdict: 'REJECT', at },
+    { reviewer: 'R', verdict: 'ACCEPT', at },
+  ]).R.verdict, 'ACCEPT');
+  assert.equal(latestPerReviewer([
+    { reviewer: 'R', verdict: 'ACCEPT', at },
+    { reviewer: 'R', verdict: 'REJECT', at },
+  ]).R.verdict, 'REJECT');
+});
+
+// ---------------------------------------------------------------------------------------------
+// One source of truth: code, policy and doc cannot drift
+// ---------------------------------------------------------------------------------------------
+
+test('the heuristic in verdicts.mjs is byte-identical to the one merge-policy.json publishes', () => {
+  assert.equal(LEGACY_REJECT_PATTERN, POLICY.legacyProseHeuristic.pattern);
+});
+
+test('every rule the evaluator can emit is declared in merge-policy.json, and vice versa', () => {
+  const declared = POLICY.rules.map((/** @type {any} */ r) => r.id).sort();
+  const emitted = ['ci-matches-head', 'no-standing-reject', 'pr-open', 'roster-declared', 'roster-resolved'];
+  assert.deepEqual(declared, emitted, 'a rule with no policy entry has no stated reason, and a policy entry with no rule is a promise nothing keeps');
+});
+
+test('MERGE-POLICY.md embeds merge-policy.json verbatim', () => {
+  const doc = readFileSync(path.join(ROOT, 'docs', 'reviews', 'MERGE-POLICY.md'), 'utf8');
+  const raw = readFileSync(path.join(ROOT, 'scripts', 'lib', 'merge-policy.json'), 'utf8');
+  const m = doc.match(/```json\n([\s\S]*?)\n```/);
+  assert.ok(m, 'MERGE-POLICY.md must contain a ```json block holding the policy');
+  assert.equal(
+    m[1].replace(/\r\n/g, '\n').trimEnd(),
+    raw.replace(/\r\n/g, '\n').trimEnd(),
+    'the doc humans read has drifted from the rules the program enforces — regenerate it',
+  );
+});

--- a/scripts/test/merge-preflight.test.mjs
+++ b/scripts/test/merge-preflight.test.mjs
@@ -291,6 +291,47 @@ test('two verdicts from one reviewer at the SAME timestamp: the later one in the
   ]).R.verdict, 'REJECT');
 });
 
+test('Mode D: a head commit newer than the verdict invalidates it', () => {
+  // #121/#117, live on 2026-09-01: a keep-ours conflict resolution would have re-introduced the
+  // hand-maintained signal list that #121 exists to abolish, inside a PR whose subject was
+  // unrelated -- under a verdict that was correct when it was written. A PR diff shows the merged
+  // RESULT and never the CHOICE, so no review of the diff can see it.
+  const base = {
+    comments: [
+      { createdAt: '2026-09-01T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->' },
+      { createdAt: '2026-09-01T11:00:00Z', body: ['verified', '<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->'].join('\n') },
+    ],
+    runs: greenOn('abc'),
+    mode: /** @type {'strict'} */ ('strict'),
+  };
+  const prAt = (headCommittedDate) => ({ number: 1, state: 'OPEN', headRefOid: 'abc', headRefName: 'b', headCommittedDate });
+
+  // Boundary, asserted on all three sides: the merge commit lands one second before the verdict,
+  // in the same second, and one second after.
+  assert.equal(evaluate({ ...base, pr: prAt('2026-09-01T10:59:59Z') }).clear, true, 'reviewed content is the head: clear');
+  assert.equal(evaluate({ ...base, pr: prAt('2026-09-01T11:00:00Z') }).clear, true, 'same second: the verdict covers it');
+  const stale = evaluate({ ...base, pr: prAt('2026-09-01T11:00:01Z') });
+  assert.equal(stale.clear, false, 'one second later: what would merge is not what was reviewed');
+  assert.deepEqual(ruleIds(stale.blockers), ['verdict-covers-head']);
+  assert.match(stale.blockers[0].detail, /conflict resolution/);
+
+  // Re-confirming after the resolution clears it -- the action the message asks for must work.
+  const reconfirmed = evaluate({
+    ...base,
+    pr: prAt('2026-09-01T11:00:01Z'),
+    comments: [...base.comments, { createdAt: '2026-09-01T12:00:00Z', body: ['resolution re-read', '<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->'].join('\n') }],
+  });
+  assert.equal(reconfirmed.clear, true);
+
+  // And the honest limit: with no commit date available the rule cannot fire at all.
+  assert.equal(evaluate({ ...base, pr: prAt(undefined) }).clear, true, 'no commit date: Mode D is not checked, not silently passed as checked');
+
+  // Mode D runs in ADVISORY too, unlike the roster rules — it needs only a verdict token, which is
+  // the reviewer's own act rather than an orchestrator convention.
+  const adv = evaluate({ ...base, pr: prAt('2026-09-01T11:00:01Z'), mode: 'advisory' });
+  assert.deepEqual(ruleIds(adv.blockers), ['verdict-covers-head']);
+});
+
 // ---------------------------------------------------------------------------------------------
 // One source of truth: code, policy and doc cannot drift
 // ---------------------------------------------------------------------------------------------
@@ -301,8 +342,8 @@ test('the heuristic in verdicts.mjs is byte-identical to the one merge-policy.js
 
 test('every rule the evaluator can emit is declared in merge-policy.json, and vice versa', () => {
   const declared = POLICY.rules.map((/** @type {any} */ r) => r.id).sort();
-  const emitted = ['ci-matches-head', 'no-standing-reject', 'pr-open', 'roster-declared', 'roster-resolved'];
-  assert.deepEqual(declared, emitted, 'a rule with no policy entry has no stated reason, and a policy entry with no rule is a promise nothing keeps');
+  const emitted = ['ci-matches-head', 'no-standing-reject', 'pr-open', 'roster-declared', 'roster-resolved', 'verdict-covers-head'];
+  assert.deepEqual(declared.sort(), emitted.sort(), 'a rule with no policy entry has no stated reason, and a policy entry with no rule is a promise nothing keeps');
 });
 
 test('MERGE-POLICY.md embeds merge-policy.json verbatim', () => {

--- a/scripts/test/merge-preflight.test.mjs
+++ b/scripts/test/merge-preflight.test.mjs
@@ -17,7 +17,10 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { evaluate, parseLegacyRejects, latestPerReviewer, LEGACY_REJECT_PATTERN } from '../lib/verdicts.mjs';
+import {
+  evaluate, parseLegacyRejects, parseLegacyVerdicts, latestPerReviewer,
+  LEGACY_REJECT_PATTERN, LEGACY_VERDICT_PATTERN,
+} from '../lib/verdicts.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const POLICY = JSON.parse(readFileSync(path.join(ROOT, 'scripts', 'lib', 'merge-policy.json'), 'utf8'));
@@ -332,17 +335,75 @@ test('Mode D: a head commit newer than the verdict invalidates it', () => {
   assert.deepEqual(ruleIds(adv.blockers), ['verdict-covers-head']);
 });
 
+test('Mode E: a valid, unstale verdict on an UNMOVED head is still stale if the base moved', () => {
+  // #119, live on 2026-09-01: a valid ACCEPT against d9293c23, then #121 merged and inverted the
+  // canary tier semantics, falsifying two sentences #119 ADDS. merge-tree clean (different files),
+  // CI green on the reviewed head, verdict untouched, branch head NEVER MOVED.
+  const comments = [
+    { createdAt: '2026-09-01T22:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->' },
+    { createdAt: '2026-09-01T23:00:00Z', body: ['reviewed', '<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->'].join('\n') },
+  ];
+  const pr = (behindBy) => ({
+    number: 119, state: 'OPEN', headRefOid: 'd9293c23', headRefName: 'fix/aggregator-drift-review-repairs',
+    baseRefName: 'protocol/main',
+    // The head is OLDER than the verdict, so verdict-covers-head is satisfied — deliberately, to
+    // prove base-current is doing the work here and not Mode D leaking in.
+    headCommittedDate: '2026-09-01T21:00:00Z',
+    behindBy,
+  });
+  const base = { comments, runs: greenOn('d9293c23'), mode: /** @type {'strict'} */ ('strict') };
+
+  assert.equal(evaluate({ ...base, pr: pr(0) }).clear, true, 'up to date: clear');
+  const stale = evaluate({ ...base, pr: pr(1) });
+  assert.equal(stale.clear, false, 'one commit behind: the verdict was computed against a base that moved');
+  assert.deepEqual(ruleIds(stale.blockers), ['base-current']);
+  assert.match(stale.blockers[0].detail, /1 commit\(s\) behind protocol\/main/);
+
+  // Both modes, like Mode D — it needs only a verdict token.
+  assert.deepEqual(ruleIds(evaluate({ ...base, pr: pr(43), mode: 'advisory' }).blockers), ['base-current']);
+
+  // Gated on a verdict EXISTING. With none, roster-declared already blocks and base drift is noise.
+  const noVerdict = evaluate({ pr: pr(43), comments: [], runs: greenOn('d9293c23'), mode: 'strict' });
+  assert.deepEqual(ruleIds(noVerdict.blockers), ['roster-declared'], 'no verdict: base drift is not reported as its own blocker');
+
+  // And the honest limit: with no behindBy available the rule cannot fire at all.
+  assert.equal(evaluate({ ...base, pr: pr(undefined) }).clear, true, 'no behindBy: Mode E is not checked, not silently passed as checked');
+});
+
+test('#112: a PROSE ACCEPT counts as "reviewed" for Mode E, or the rule misses its own case', () => {
+  // Found by running the tool, not by reasoning about it. #112 is ACCEPTed, 43 commits behind main
+  // and on the owner's desk to merge — and the first version of base-current reported CLEAR,
+  // because #112's ACCEPT is prose and the gate required a TOKEN. Reading a prose ACCEPT to RAISE a
+  // blocker keeps the asymmetry: prose still never clears anything.
+  const prose = [{ createdAt: '2026-09-01T23:30:46Z', body: ['## Adversarial review — ACCEPT', '', 'all four SHAs re-resolved'].join('\n') }];
+  assert.equal(parseLegacyVerdicts(prose).length, 1, 'a prose ACCEPT is a review, even though it is not a clearance');
+  assert.equal(parseLegacyRejects(prose).length, 0, 'and it is still not a REJECT');
+
+  const pr = { number: 112, state: 'OPEN', headRefOid: '6c534f0a', headRefName: 'chore/supply-chain-pins', baseRefName: 'protocol/main', behindBy: 43 };
+  const d = evaluate({ pr, comments: prose, runs: greenOn('6c534f0a'), mode: 'advisory' });
+  assert.deepEqual(ruleIds(d.blockers), ['base-current']);
+  assert.match(d.blockers[0].detail, /43 commit/);
+
+  // Up to date, same prose ACCEPT: clear. So it is the base drift doing the work, not the heading.
+  assert.equal(evaluate({ pr: { ...pr, behindBy: 0 }, comments: prose, runs: greenOn('6c534f0a'), mode: 'advisory' }).clear, true);
+
+  // A comment that is not a verdict at all does not make a stale base blockable on its own.
+  const notAReview = [{ createdAt: '2026-09-01T23:30:46Z', body: ['## Fixer pass — addressed', '', 'quotes the word ACCEPT'].join('\n') }];
+  assert.equal(evaluate({ pr, comments: notAReview, runs: greenOn('6c534f0a'), mode: 'advisory' }).clear, true);
+});
+
 // ---------------------------------------------------------------------------------------------
 // One source of truth: code, policy and doc cannot drift
 // ---------------------------------------------------------------------------------------------
 
-test('the heuristic in verdicts.mjs is byte-identical to the one merge-policy.json publishes', () => {
+test('the heuristics in verdicts.mjs are byte-identical to the ones merge-policy.json publishes', () => {
   assert.equal(LEGACY_REJECT_PATTERN, POLICY.legacyProseHeuristic.pattern);
+  assert.equal(LEGACY_VERDICT_PATTERN, POLICY.legacyProseHeuristic.verdictPattern);
 });
 
 test('every rule the evaluator can emit is declared in merge-policy.json, and vice versa', () => {
   const declared = POLICY.rules.map((/** @type {any} */ r) => r.id).sort();
-  const emitted = ['ci-matches-head', 'no-standing-reject', 'pr-open', 'roster-declared', 'roster-resolved', 'verdict-covers-head'];
+  const emitted = ['base-current', 'ci-matches-head', 'no-standing-reject', 'pr-open', 'roster-declared', 'roster-resolved', 'verdict-covers-head'];
   assert.deepEqual(declared.sort(), emitted.sort(), 'a rule with no policy entry has no stated reason, and a policy entry with no rule is a promise nothing keeps');
 });
 


### PR DESCRIPTION
## What this is

A merge preflight that connects a review verdict to mergeability, plus the policy it enforces, in a
form a program can read.

**It is a CONVENTION, not a gate.** Nothing here can stop `gh pr merge` today. It becomes
enforcement only when the owner requires the `merge-preflight` status context in branch protection
with `enforce_admins` on — the exact steps are in the doc, and I have flagged them for him. Please do
not describe this as a gate until those are taken.

## The problem, precisely

Four PRs — #92, #98, #107 and #109 — merged on 2026-09-01 across review verdicts that were never
addressed, putting two HIGHs on `protocol/main`. It was **five distinct failure modes, and a
defence against one is useless against the others**:

| mode | what happened | evidence | rule |
|---|---|---|---|
| **A — policy** | merged over a REJECT already standing, in writing | #107 by 8 min, #92 by 29 min | `no-standing-reject` |
| **B — race** | the review lost a race it could not see it was in | #98's REJECT **+25 s**; #109's +5.5 min, so it merged before its verdict existed | `roster-declared`, `roster-resolved` |
| **C — orientation** | pushed to a branch whose PR had merged | #107's fixer pass, rescued by hand as #120 | `pr-open` |
| **D — invisibility** | the reviewed content was replaced *after* a correct verdict | a keep-ours resolution on #117 would have re-introduced the list #121 exists to abolish | `verdict-covers-head` |
| **E — staleness** | the *base* moved under a verdict whose head never did | #119's valid ACCEPT was falsified by #121 merging, with its own branch untouched | `base-current` |

Three things follow, and each kills an obvious design:

- an in-flight marker cannot catch Mode A — the verdict was there and was overridden;
- a REJECT-parser cannot catch Mode B — for #98 there was nothing to parse;
- **an interval-based check cannot catch #109 at all**, because no verdict existed to measure from.
  A check built to that wording would have passed the worst case and failed its own purpose.

So the property is a conjunction, not an interval: **the declared complement of reviewers has
reported and every report is resolved, on the content that would actually merge**, plus CI green on
*this* head SHA, plus the PR still open.

**Mode D is a different kind of thing**, and it was added after the first three were already built,
which is why it is worth calling out. A, B and C are about *when* a merge happens relative to a
review. D is about **what a review can see at all**: a conflict resolution is an edit nobody reviews,
because a PR diff shows the merged *result* and never the *choice*. `verdict-covers-head` blocks when
a reviewer's latest verdict predates the head commit — detecting that the reviewed content is no
longer the content that would merge. It **cannot** judge whether a resolution was *correct*; that is
a re-review and no check can do it, so the doc proposes the cheap convention that makes the choice
reviewable at all — state, per conflicted file, which side was taken and why — and labels it a
convention, not a gate.

**Mode E is D's mirror and defeats every rule keyed to the PR.** #119 held a valid ACCEPT against
`d9293c23`; #121 then merged and inverted the canary tier semantics, falsifying two sentences #119
*adds* — while `merge-tree` stayed clean, CI stayed green on the reviewed head, the verdict stayed
untouched, and **the branch head never moved**. `base-current` reads `behind_by` from the compare API
(not `mergeStateStatus`, which only reports `BEHIND` once the repo *already* requires up-to-date
branches — it cannot be the detector for its own absence). Its enforcement half is that branch-
protection setting, which was already sitting in this repo's policy file as `strict=true` and
**explained nowhere**; step 1 of the owner instructions now names it and prices it.

## The one workflow change beyond the tokens, stated because it decides whether this is usable

**A fixer pass does not clear a verdict.** The normal sequence is: reviewer REJECTs → fixer pushes →
fixer posts "all findings addressed" → *nobody re-verdicts*. Under these rules that PR carries **two**
blockers — the standing REJECT and `verdict-covers-head` from the push — and **only a reviewer can
clear either**, with the token posted **after** the fix lands. That is the discipline being argued
for rather than a malfunction, but a rule that mysteriously blocks everything gets routed around, so
it is in `docs/SWARM.md` §3 where reviewers read it, not only here.

## The convention decision, settled before the parser was written

A REJECT is unmarked English prose today, so a checker either parses natural language (fragile) or
requires a structured token (robust, but changes every reviewer's workflow). I settled it this way:

> **A structured token is the only thing that may CLEAR a blocker. The prose heuristic may only ADD one.**

That asymmetry does three things: prose can never clear, so "write ACCEPT to get through" does not
exist; the fragility of NL parsing is bounded to false alarms a reviewer clears by posting a token;
and **Modes A and C are caught on PRs that have adopted nothing**, including every PR open right now.

Two decisions that shape it:

- **The roster IS the Mode B mechanism**, not a second defence beside the verdicts — it is their
  denominator. Without it "nobody objected" and "nobody looked" are the same observation.
- **The reviewer count is whatever the roster declares, never a hardcoded two.** Most PRs tonight got
  one review; a check demanding two makes most PRs unmergeable and gets routed around.

**Why not GitHub's own reviews:** the whole swarm is one identity (`SlumperSan`) and every PR is
authored by it, so GitHub refuses approve/request-changes on its own PRs — `reviewDecision` is
permanently `null` and `CHANGES_REQUESTED` is unreachable. Verified: `viewerDidAuthor: true`, and
**zero** native reviews exist in this repo's history. Not overlooked; structurally impossible under
one account.

## Evidence

**Live, against real PRs:**

- `merge-preflight 120` → **BLOCKED**, `roster-declared`. Green CI on its *own* head (`686690b8`,
  matched by `headSha`) and a 9/9 local gate — and an assigned-but-unposted review. The check reaches
  the same conclusion #120's author reached by hand and unprompted. *(Run at commit `4268afd2`,
  before `verdict-covers-head` existed, so it demonstrates the roster rule and not the full set.)*
- `merge-preflight 107 --advisory` → **BLOCKED** on `pr-open` (MERGED) *and* `no-standing-reject`
  (the real 22:35:29Z prose REJECT), on a PR that adopted nothing.
- `merge-preflight 106 --advisory` → **BLOCKED** on the standing REJECT while its fixer is mid-pass.
  This is the live instance of the sequence below, and it is why that rule had to be written down.

**Heuristic, against the real corpus:** classified every comment on PRs #90–#120 — 15 matches, 15
correct **on that corpus**. It skips `## Fixer pass — Review92-B findings` and
`## Fixer pass — Review109 findings`, which quote the word REJECT in their bodies and which a naive
body grep flags as verdicts. That is a statement about the corpus, not about all inputs: mutation
testing later found a shape the corpus did not contain (a body starting with a blank line), which is
now pinned separately.

**21 tests, fixtures rebuilt from the real PRs at their real merge instants.** Four are
deliberately *negative*: they assert that advisory mode **clears** #98 and #109, and that Modes D
and E cannot fire without a commit date / a `behind_by` — the honest limits, tested rather than
claimed.

**Mutation matrix: 20/20 killed**, over four rounds. Each round found something the previous
suite did not discriminate:

- **M5** — the heuristic reading the whole body instead of the first non-empty line survived, because
  the regex is `^`-anchored without `/m` so both reject a quoted REJECT on a later line. The case that
  separates them is a body that **starts with a blank line**, which GitHub bodies routinely do:
  whole-body matching then fails the anchor and **silently misses a real REJECT** — a false negative
  in the one direction this design cannot afford.
- **M8** — two verdicts from one reviewer at the same timestamp. Document order is the only tie-break
  and must favour the last token, or a correction posted under the mistake it corrects is ignored.
- **M16** — restricting Mode D to strict mode survived, and **the surviving mutant was the better
  design, not a missing test**: `verdict-covers-head` needs only a verdict token, which is a
  reviewer's own act rather than an orchestrator convention, so it now runs in advisory too.

And one flaw that mutation testing could *not* have found, because it was in the rule's premise
rather than its logic: **`base-current` first gated on a verdict TOKEN, and against #112 — ACCEPTed,
43 commits behind `main`, on the owner's desk to merge — it reported CLEAR**, because #112's ACCEPT
is prose. The rule written for Mode E missed the clearest live instance of Mode E. Found by running
it, not by reasoning about it. "Reviewed at all" now includes a prose verdict of either kind, which
keeps the asymmetry: reading a prose ACCEPT to *raise* a blocker is still block-only.

`npm run gate` **9/9 from my worktree**; the long builds are machine saturation, and slither is
advisory as always. No `contracts/src` change, so no EIP-170 movement.

**One thing I could not verify before merge, stated rather than glossed:** the workflow checks out
`protocol/main` by design (the policy must never be supplied by the PR under test), and the script
is not on `protocol/main` yet, so the guard skips every run and **the `gh` path — including the
`actions: read` permission the `ci-matches-head` rule needs — cannot execute until this merges.**
After merge, `gh workflow run merge-preflight.yml -f pr=<n>` on any open PR should post a
`merge-preflight` status of `success` or `failure`; if it posts `error` / "could not determine", the
permission is wrong. That one command is the verification.

## One source of truth

`scripts/lib/merge-policy.json` holds the rules; `docs/reviews/MERGE-POLICY.md` embeds it **verbatim**
and a test asserts byte identity, that the published regex is the one the code runs, and that every
rule the evaluator can emit is declared and vice versa. A rule cannot drift from its documentation
without a red test.

That drift is the general form of the underlying failure, and it is worth saying plainly:
**a gate nobody can read from a fresh clone is not an interlock.** `docs/vault/auto-merge.md` still
says merges land "once CI is green", unqualified, while every correction made tonight lives in a
machine-local memory file that no fresh clone, no other machine and no CI check can read.

## What I deliberately did NOT touch (SWARM §4)

`docs/vault/auto-merge.md` and `docs/SWARM.md` **§8** are **Fix107's**, per Ops4, and are untouched.
This PR edits **§3** — the review pattern — because the verdict token *is* a §3 change, and because
Key Decisions records that the enforcement surface is `docs/SWARM.md` plus the auto-loaded memories,
not the vault and not `docs/`. Different section, so the two edits do not conflict; Ops4 has this to
sequence them.

Action pins reuse #112's already-verified SHAs (`actions/checkout@fbc6f39`, `actions/setup-node@a0853c2`),
independently re-resolved against the canonical repos, so #112 has nothing to sweep here.

## What this cannot catch

Stated in the doc, and repeated because failing to state a mechanism's blind spots is the failure
this exercise exists to prevent: a reviewer that posts ACCEPT without reviewing; an agent that simply
does not run it (the largest hole, and the owner's to close); a duplicated or invented reviewer name
(self-declared under one identity); a verdict arriving after a *legitimate* merge — #92's +42 min —
which needs a post-merge sweep, a different tool, not built; labels and comments being removable by
whoever can merge; and the quality of CI itself.

---

**Dogfood note for the orchestrator:** this PR has no `REVIEW-ROSTER` token, because the author is not
the one who should declare it. Posting one here would be the first real use of the protocol.
