### PR TITLE
fix(preflight): stop merge-preflight blocking on its own in-flight run

### DIFF
--- a/.github/workflows/merge-preflight.yml
+++ b/.github/workflows/merge-preflight.yml
@@ -88,6 +88,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # A BLOCKED VERDICT MUST NOT FAIL THIS STEP -- the decision is published by the next step,
+          # as a commit status, and that is load-bearing beyond tidiness. This run is itself a run on
+          # the PR head, and ci-matches-head excludes only the single IN-FLIGHT self-run, by
+          # GITHUB_RUN_ID (see excludeSelfRun in scripts/lib/verdicts.mjs). A finished preflight run
+          # is counted like any other run on that head, and reads as green only because this step
+          # does not exit non-zero. Make it fail on a block and two preflight runs on one head start
+          # blocking each other.
           set +e
           node scripts/merge-preflight.mjs "${{ steps.pr.outputs.number }}" --advisory | tee out.txt
           code=${PIPESTATUS[0]}

--- a/docs/reviews/MERGE-POLICY.md
+++ b/docs/reviews/MERGE-POLICY.md
@@ -355,8 +355,8 @@ check could ever read. **A gate nobody can read from a fresh clone is not an int
         "strict"
       ],
       "title": "a successful CI run must exist for THIS head SHA",
-      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid",
-      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion."
+      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid, counting every run on that head except the preflight's own run",
+      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion. The one exemption is the preflight run doing the evaluating, which is a run on the same head and is in_progress while it evaluates, so without it the check could never report green on any PR; it is excluded by run id (GITHUB_RUN_ID), never by workflow name, so a second preflight run on the same head still blocks."
     },
     {
       "id": "roster-declared",

--- a/scripts/lib/merge-policy.json
+++ b/scripts/lib/merge-policy.json
@@ -59,8 +59,8 @@
         "strict"
       ],
       "title": "a successful CI run must exist for THIS head SHA",
-      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid",
-      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion."
+      "blocksWhen": "no completed successful workflow run has headSha equal to the PR's headRefOid, counting every run on that head except the preflight's own run",
+      "why": "'gh pr checks' reports the runs attached to a PR without surfacing which SHA they belong to, and returned green for #107 from a run belonging to the previous head. Match headSha yourself: gh run list --branch <b> --json headSha,status,conclusion. The one exemption is the preflight run doing the evaluating, which is a run on the same head and is in_progress while it evaluates, so without it the check could never report green on any PR; it is excluded by run id (GITHUB_RUN_ID), never by workflow name, so a second preflight run on the same head still blocks."
     },
     {
       "id": "roster-declared",

--- a/scripts/lib/verdicts.mjs
+++ b/scripts/lib/verdicts.mjs
@@ -68,6 +68,7 @@
  * @property {string} status      'completed' | 'in_progress' | 'queued' | ...
  * @property {string|null} conclusion
  * @property {string} [name]
+ * @property {number|string} [id]  the run's databaseId, for the self-run exclusion below
  *
  * @typedef {object} Blocker
  * @property {string} ruleId
@@ -216,14 +217,55 @@ export function runsForHead(runs, headSha) {
 }
 
 /**
+ * The run doing the evaluating, removed from its own evidence.
+ *
+ * The preflight decides ci-matches-head from inside a workflow run that is itself a run on the PR
+ * head, and that run is necessarily `in_progress` for as long as it takes to decide — so before
+ * this, `ci-matches-head` pushed a blocker naming the preflight itself and no head could ever be
+ * clear. Seen on #130 @ bcb7a4e5 on 2026-09-02: CI completed green on the exact head, a re-run of
+ * the preflight reported one blocker, and it was "run merge-preflight on head bcb7a4e5 is
+ * in_progress, not completed". Advisory at the time, so nothing was stopped; step 1 of
+ * MERGE-POLICY.md § "Making this enforcement" would have made it unmergeable-forever for every PR.
+ *
+ * WHY BY RUN ID AND NOT BY WORKFLOW NAME. Excluding a workflow from a check is the fail-open shape
+ * this repo keeps getting bitten by, so the exclusion is exactly one run, identified by the id the
+ * runner itself reports (`GITHUB_RUN_ID`) — not a class of runs identified by a name that a rename
+ * silently changes. A second, concurrent preflight run on the same head is somebody else's run and
+ * still blocks. With no id — run by hand — nothing is excluded: a visible deadlock beats a silent
+ * pass, and guessing which run to drop would widen the exclusion precisely where the information
+ * is thinnest.
+ *
+ * Excluding only the in-flight run is enough because a BLOCKED VERDICT does not fail the job: the
+ * workflow's "Run preflight" step captures the exit code into an output and never exits non-zero,
+ * so a preflight job that reaches its steps concludes `success` whatever it decided, and a sibling
+ * preflight run that has finished lands in `succeeded`. If that step is ever changed to exit
+ * non-zero on a block, finished preflight runs start blocking each other and this reasoning must be
+ * redone. It is NOT a claim that a completed preflight run is always green: a run that never
+ * started — 33594624958, "the job was not started because recent account payments have failed" —
+ * concludes `failure` with zero steps, and blocks like any other failed run on the head, which is
+ * the right direction to be wrong in.
+ *
+ * @param {Run[]} runs
+ * @param {number|string} [selfRunId]
+ */
+export function excludeSelfRun(runs, selfRunId) {
+  if (selfRunId === undefined || selfRunId === null || selfRunId === '') return runs;
+  // GITHUB_RUN_ID is a string and gh's databaseId is a number; === between them is always false,
+  // which would leave the deadlock in place while every test written with matching types passed.
+  const self = String(selfRunId);
+  return runs.filter((r) => r.id === undefined || r.id === null || String(r.id) !== self);
+}
+
+/**
  * @param {object} input
  * @param {PullRequest} input.pr
  * @param {Comment[]} input.comments
  * @param {Run[]} input.runs
  * @param {'advisory'|'strict'} [input.mode]
+ * @param {number|string} [input.selfRunId]  the preflight's own run id, excluded from ci-matches-head
  * @returns {Decision}
  */
-export function evaluate({ pr, comments, runs, mode = 'strict' }) {
+export function evaluate({ pr, comments, runs, mode = 'strict', selfRunId }) {
   /** @type {Blocker[]} */
   const blockers = [];
   /** @type {string[]} */
@@ -270,7 +312,7 @@ export function evaluate({ pr, comments, runs, mode = 'strict' }) {
   }
 
   // --- ci-matches-head ------------------------------------------------------------------------
-  const mine = runsForHead(runs, pr.headRefOid);
+  const mine = excludeSelfRun(runsForHead(runs, pr.headRefOid), selfRunId);
   const succeeded = mine.filter((r) => r.status === 'completed' && r.conclusion === 'success');
   const failed = mine.filter(
     (r) => r.status === 'completed' && r.conclusion !== 'success' && r.conclusion !== 'skipped',

--- a/scripts/merge-preflight.mjs
+++ b/scripts/merge-preflight.mjs
@@ -96,7 +96,9 @@ export function main(argv = process.argv.slice(2)) {
   // point: it is the only way to get `headSha` back and check it ourselves.
   const runs = gh([
     'run', 'list', '--repo', opts.repo, '--branch', pr.data.headRefName,
-    '--limit', '30', '--json', 'headSha,status,conclusion,workflowName',
+    // databaseId so the run this is executing inside can be told apart from every other run on
+    // the same head -- see excludeSelfRun() in lib/verdicts.mjs.
+    '--limit', '30', '--json', 'headSha,status,conclusion,workflowName,databaseId',
   ]);
   if (!runs.ok) {
     process.stderr.write(`merge-preflight: cannot list runs for ${pr.data.headRefName}: ${runs.err}\n`);
@@ -133,8 +135,12 @@ export function main(argv = process.argv.slice(2)) {
     },
     comments: (pr.data.comments ?? []).map((/** @type {any} */ c) => ({ createdAt: c.createdAt, body: c.body })),
     runs: (runs.data ?? []).map((/** @type {any} */ r) => ({
-      headSha: r.headSha, status: r.status, conclusion: r.conclusion, name: r.workflowName,
+      headSha: r.headSha, status: r.status, conclusion: r.conclusion, name: r.workflowName, id: r.databaseId,
     })),
+    // Set by the Actions runner, so no YAML plumbing: under `merge-preflight.yml` this is the id
+    // of the run asking the question, and that run is in_progress until it has an answer. Unset
+    // when run by hand, where nothing is excluded.
+    selfRunId: process.env.GITHUB_RUN_ID,
     mode: opts.mode,
   });
 

--- a/scripts/test/merge-preflight.test.mjs
+++ b/scripts/test/merge-preflight.test.mjs
@@ -168,6 +168,114 @@ test('a red run on this head blocks, and names the conclusion', () => {
   assert.doesNotMatch(skipped.blockers[0].detail, /concluded/);
 });
 
+// ---------------------------------------------------------------------------------------------
+// The self-run exclusion: the preflight must not block on the run doing the evaluating
+// ---------------------------------------------------------------------------------------------
+
+/** A PR reviewed and cleared, so the self-run is the only thing that can be blocking it. */
+const REVIEWED = [
+  { createdAt: '2026-09-02T10:00:00Z', body: '<!-- REVIEW-ROSTER reviewers=R -->' },
+  { createdAt: '2026-09-02T10:00:01Z', body: '<!-- REVIEW-VERDICT reviewer=R verdict=ACCEPT -->' },
+];
+
+test('the evaluating run does not block itself, and only it is exempt', () => {
+  const pr = { number: 130, state: 'OPEN', headRefOid: 'bcb7a4e5', headRefName: 'docs/release-checklist' };
+  const base = { pr, comments: REVIEWED, mode: /** @type {'advisory'} */ ('advisory'), selfRunId: 33590000001 };
+
+  // Live on #130 @ bcb7a4e5, 2026-09-02: CI completed green, and the only blocker left was the
+  // preflight reporting its own in-flight run as not completed. Advisory then, so nothing was
+  // stopped; the day the context is required in branch protection it would stop every PR forever.
+  const selfOnly = evaluate({
+    ...base,
+    runs: [
+      { headSha: 'bcb7a4e5', status: 'completed', conclusion: 'success', name: 'CI', id: 33589402462 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+    ],
+  });
+  assert.deepEqual(ruleIds(selfOnly.blockers), [], 'the run asking the question is not evidence against itself');
+
+  // The exemption is by run id, one run, not by workflow: a SECOND preflight run on the same head
+  // is somebody else's run and still blocks. This is the narrowness the fix turns on — an exclusion
+  // keyed on the name 'merge-preflight' would pass the test above and silently green this one.
+  const sibling = evaluate({
+    ...base,
+    runs: [
+      { headSha: 'bcb7a4e5', status: 'completed', conclusion: 'success', name: 'CI', id: 33589402462 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000002 },
+    ],
+  });
+  assert.deepEqual(ruleIds(sibling.blockers), ['ci-matches-head']);
+  assert.equal(sibling.blockers.length, 1, 'exactly the sibling run, not both preflight runs');
+
+  // And an ordinary run still blocks while it is in flight — the whole point of ci-matches-head.
+  const ciRunning = evaluate({
+    ...base,
+    runs: [
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'CI', id: 33589402462 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+    ],
+  });
+  assert.deepEqual(ruleIds(ciRunning.blockers), ['ci-matches-head']);
+  assert.match(ciRunning.blockers[0].detail, /CI on head bcb7a4e5 is in_progress/);
+
+  // A red CI run is not exempted either, however green the preflight's own run turns out to be.
+  const ciRed = evaluate({
+    ...base,
+    runs: [
+      { headSha: 'bcb7a4e5', status: 'completed', conclusion: 'failure', name: 'CI', id: 33589402462 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+    ],
+  });
+  assert.deepEqual(ruleIds(ciRed.blockers), ['ci-matches-head']);
+  assert.match(ciRed.blockers[0].detail, /concluded failure/);
+});
+
+test('exempting the self-run is not a way to have no CI at all', () => {
+  // The fail-open shape of this fix: subtract the self-run and a head with NOTHING else on it must
+  // report "no workflow run exists", not fall through every loop and come out clear. So the
+  // subtraction happens before the emptiness check, not after it.
+  const d = evaluate({
+    pr: { number: 130, state: 'OPEN', headRefOid: 'bcb7a4e5', headRefName: 'b' },
+    comments: REVIEWED,
+    runs: [{ headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 }],
+    mode: 'advisory',
+    selfRunId: 33590000001,
+  });
+  assert.deepEqual(ruleIds(d.blockers), ['ci-matches-head']);
+  assert.match(d.blockers[0].detail, /no workflow run exists/);
+});
+
+test('GITHUB_RUN_ID arrives as a string and gh reports databaseId as a number', () => {
+  // The trap this fix dies of silently: `gh run list --json databaseId` yields a number, the
+  // workflow env var is a string, and `===` between them is false — so the exclusion never happens
+  // and the deadlock survives a passing test written with matching types.
+  const runs = [
+    { headSha: 'bcb7a4e5', status: 'completed', conclusion: 'success', name: 'CI', id: 33589402462 },
+    { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+  ];
+  const pr = { number: 130, state: 'OPEN', headRefOid: 'bcb7a4e5', headRefName: 'b' };
+  const d = evaluate({ pr, comments: REVIEWED, runs, mode: 'advisory', selfRunId: '33590000001' });
+  assert.deepEqual(ruleIds(d.blockers), [], 'string run id must match the numeric databaseId');
+});
+
+test('with no self-run id the preflight excludes nothing', () => {
+  // Run by hand, there is no self-run to subtract, and guessing which run to drop would widen the
+  // exclusion exactly where the information is thinnest. Absent an id, everything on the head
+  // counts — which is a visible deadlock at worst, never a silent pass.
+  const d = evaluate({
+    pr: { number: 130, state: 'OPEN', headRefOid: 'bcb7a4e5', headRefName: 'b' },
+    comments: REVIEWED,
+    runs: [
+      { headSha: 'bcb7a4e5', status: 'completed', conclusion: 'success', name: 'CI', id: 33589402462 },
+      { headSha: 'bcb7a4e5', status: 'in_progress', conclusion: null, name: 'merge-preflight', id: 33590000001 },
+    ],
+    mode: 'advisory',
+  });
+  assert.deepEqual(ruleIds(d.blockers), ['ci-matches-head']);
+  assert.match(d.blockers[0].detail, /merge-preflight on head bcb7a4e5 is in_progress/);
+});
+
 test('a draft PR is not mergeable, whatever its verdicts say', () => {
   const d = evaluate({
     pr: { number: 1, state: 'OPEN', isDraft: true, headRefOid: 'abc', headRefName: 'b' },


### PR DESCRIPTION
## The bug

`merge-preflight` could never post a green `merge-preflight` status — on any PR, at any head SHA. It blocked on its own run.

`ci-matches-head` ([scripts/lib/verdicts.mjs](scripts/lib/verdicts.mjs)) takes every run whose `headSha` equals `pr.headRefOid` and pushes a blocker for each one that is not `completed`. The preflight evaluates that rule from inside a workflow run that is *itself* a run on that head, and that run is `in_progress` for as long as it takes to decide.

**Verified on #130 @ `bcb7a4e5`, 2026-09-02.** First trigger: 2 blockers (`CI` in_progress, `merge-preflight` in_progress). After CI completed green on the exact head — run `33589402462`, all three jobs success — a re-run reported exactly one blocker:

```
[ci-matches-head] run merge-preflight on head bcb7a4e5 is in_progress, not completed.
```

It is advisory today, so nothing is blocked. The workflow's own STATUS header says it becomes binding the moment the owner requires the `merge-preflight` context in branch protection with `enforce_admins` — step 1–2 of MERGE-POLICY.md § "Making this enforcement". On that day, no PR in this repository could ever merge again.

## The fix

`excludeSelfRun(runs, selfRunId)` subtracts **one run, identified by id**, from the set `ci-matches-head` reasons over. `scripts/merge-preflight.mjs` adds `databaseId` to the `gh run list --json` fields and passes `process.env.GITHUB_RUN_ID` through. **No YAML plumbing** — the runner sets `GITHUB_RUN_ID` itself.

Excluding a workflow from a check is exactly the fail-open shape this repo has been bitten by (`Rules/fail-open-innermost.md`, `Rules/cheap-half-is-not-the-check.md`), so the exclusion is deliberately as narrow as it can be:

- **By run id, never by workflow name.** A rename cannot silently change an id. A name-keyed exclusion would also drop *every* preflight run, not one.
- **A second, concurrent preflight run on the same head still blocks.** It is somebody else's run.
- **With no `selfRunId` — run by hand — nothing is excluded.** Guessing which run to drop would widen the exclusion exactly where the information is thinnest. A visible deadlock beats a silent pass.
- **The subtraction happens before the "no run exists" check**, so a head carrying *only* the self-run reports no CI rather than falling clear through every loop.

Excluding only the *in-flight* run is sufficient because a blocked verdict does not fail the job: the "Run preflight" step captures the exit code into an output and never exits non-zero, so a preflight job that reaches its steps concludes `success` whatever it decided. That is now pinned in a comment on the step itself — change it to exit non-zero on a block and finished preflight runs start blocking each other.

## Tests

Four new tests in `scripts/test/merge-preflight.test.mjs`. **The three that describe the fix were red before it** and green after; the fourth (no `selfRunId` → nothing excluded) is green both sides, pinning the exclusion against being widened later.

| test | pins |
| --- | --- |
| the evaluating run does not block itself, and only it is exempt | the stated case, **plus** a sibling preflight run, an in_progress `CI`, and a red `CI` all still blocking |
| exempting the self-run is not a way to have no CI at all | self-run alone → `no workflow run exists`, not clear |
| `GITHUB_RUN_ID` arrives as a string and gh reports `databaseId` as a number | the coercion that would otherwise leave the deadlock in place under a fully passing suite |
| with no self-run id the preflight excludes nothing | the narrowness, against a future name-based fallback |

`scripts/lib/merge-policy.json`'s `ci-matches-head` entry states the exemption, and the embedded copy in `docs/reviews/MERGE-POLICY.md` was regenerated from the file (not hand-edited), so the byte-identity test still holds.

## Verification is LOCAL, and why

```
node --test scripts/test/*.test.mjs   →  164 tests, 163 pass, 0 fail
```

**CI on this PR will be red for reasons unrelated to this change.** Every workflow in the repository is currently failing at startup with zero steps executed. Annotation on run `33594624958`:

> The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings

`ci.yml` runs `33594624921`, `33594100575`, `33593907584` and the `merge-preflight` runs above all show `conclusion=failure, steps=0`. This needs the repository owner (Billing & plans); re-running achieves nothing.

## Three findings turned up here and deliberately NOT fixed

1. **A run that fails at startup blocks its head permanently.** It stays in `gh run list` forever, so `ci-matches-head` keeps reporting it; only a new commit clears it. Pre-existing, and applies to `CI` identically — the billing failure above is currently producing exactly this on several heads.
2. **A completed preflight run counts as a green run on the head**, so `ci-matches-head` can be satisfied on a head where `CI` itself never ran (path filters, a skipped workflow). Pre-existing and unchanged by this PR; the obvious remedy — requiring a run *named* `CI` — reintroduces the name-matching this fix deliberately avoids.
3. **#130 §2.3 goes stale when this lands.** Its sentence "The check that enforces this rule cannot currently pass" is true only until one of these two merges. Whichever merges second should fix the sentence.

Not self-merging.
