### PR TITLE
ops(cc): report CI per open PR, matched to the exact head SHA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ skills-lock.json
 # Local pre-merge gate result (scripts/gate.mjs). Describes THIS machine last run,
 # not a property of the branch, so it is never committed.
 .gate-state.json
+# Per-head CI verdicts for `npm run cc`. Keyed by head SHA, so it cannot outlive its subject.
+.cc-ci-cache.json

--- a/scripts/dashboard.mjs
+++ b/scripts/dashboard.mjs
@@ -17,6 +17,12 @@
  */
 import { createServer } from 'node:http';
 import { collect } from './lib/project-status.mjs';
+import { CI_STATES, describeCiState } from './lib/pr-ci-status.mjs';
+
+// render() runs in the BROWSER, inside the PAGE template below, so it cannot import the module.
+// Inject the vocabulary instead of restating it: one definition, three renderers, no drift.
+const CI_VOCAB = JSON.stringify(Object.fromEntries(CI_STATES.map((s) => [s, describeCiState(s)])));
+const CI_ORDER = JSON.stringify(CI_STATES);
 
 const argv = process.argv.slice(2);
 const flag = (name, dflt) => {
@@ -26,6 +32,7 @@ const flag = (name, dflt) => {
 };
 const PORT = Number(flag('port', 4270));
 const NO_GH = argv.includes('--no-gh');
+const NO_CI = argv.includes('--no-ci');
 const HOST = '127.0.0.1';
 
 // Collecting shells out to git and gh, so a page that gathered on every request would hammer both
@@ -33,11 +40,22 @@ const HOST = '127.0.0.1';
 let cache = { at: 0, data: null };
 const TTL_MS = 4000;
 
-function snapshot(force = false) {
+// collect() fans out to `gh` for the per-head CI column, so it is async. In flight, requests share
+// the SAME promise rather than each starting their own fan-out.
+let inFlight = null;
+async function snapshot(force = false) {
   const now = Date.now();
   if (!force && cache.data && now - cache.at < TTL_MS) return cache.data;
-  cache = { at: now, data: collect({ gh: !NO_GH }) };
-  return cache.data;
+  if (inFlight) return inFlight;
+  inFlight = collect({ gh: !NO_GH, ci: !NO_CI })
+    .then((data) => {
+      cache = { at: Date.now(), data };
+      return data;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
 }
 
 const esc = (s) =>
@@ -185,10 +203,31 @@ function render(d){
   }
 
   // --- github
+  // Worst first, in the order the shared module defines -- two renderers, one ranking.
+  const CI_VOCAB = ${CI_VOCAB}, CI_ORDER = ${CI_ORDER};
+  const rank = (s)=>{ const i = CI_ORDER.indexOf(s); return i<0? CI_ORDER.length : i; };
+  const ciRows = [...(d.github.ci||[])].sort((a,b)=>rank(a.ci.state)-rank(b.ci.state) || b.number-a.number);
+  const prTitle = new Map((d.github.prs||[]).map(p=>[p.number, p.title||'']));
   S.push(sec('GitHub', d.github.up
     ? row('open PRs', d.github.prs.length? d.github.prs.map(p=>'#'+p.number).join(' ') : '<span class="go">none</span>')
       + row('open issues', d.github.issues.length? d.github.issues.map(i=>'#'+i.number).join(' ') : '<span class="go">none</span>')
-    : '<div class="note warn">gh unavailable (not installed, not authenticated, or offline).</div>'));
+      + (ciRows.length
+        ? '<h2 style="margin-top:14px">CI at the exact head SHA</h2>'
+          + '<div class="scroll"><table><thead><tr><th>PR</th><th>Head</th><th>CI</th><th>Detail</th></tr></thead><tbody>'
+          + ciRows.map(e=>{
+              const s = CI_VOCAB[e.ci.state] || { label: e.ci.state, tone: 'idle' };
+              return '<tr><td title="'+esc(prTitle.get(e.number)||'')+'">#'+e.number+'</td>'
+                + '<td class="mono">'+esc((e.headSha||'').slice(0,7) || '???????')+'</td>'
+                + '<td class="'+s.tone+'">'+esc(s.label)+'</td>'
+                + '<td class="muted">'+esc(e.ci.detail||'')+'</td></tr>';
+            }).join('')
+          + '</tbody></table></div>'
+          // Restated here because the board travels and the rule does not.
+          + '<div class="note muted">Read per commit (<span class="mono">gh run list --commit</span>), never '
+          + '<span class="mono">gh pr checks</span> — docs/RELEASE-CHECKLIST.md §2.3. '
+          + '<b>none</b> and <b>unknown</b> are UNVERIFIED, not passes; <b>outage</b> is a zero-step run that never executed.</div>'
+        : '')
+    : '<div class="note warn">gh unavailable (not installed, not authenticated, or offline).</div>'), 'wide'));
 
   // --- deployments
   if(d.deployments.length){
@@ -234,9 +273,16 @@ tick(); setInterval(tick, 5000);
 const server = createServer((req, res) => {
   const url = new URL(req.url ?? '/', `http://${HOST}:${PORT}`);
   if (url.pathname === '/api/status') {
-    const body = JSON.stringify(snapshot(url.searchParams.has('force')));
-    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
-    return res.end(body);
+    return snapshot(url.searchParams.has('force')).then(
+      (data) => {
+        res.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+        res.end(JSON.stringify(data));
+      },
+      (e) => {
+        res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: String(e) }));
+      }
+    );
   }
   if (url.pathname === '/') {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' });
@@ -259,5 +305,5 @@ server.listen(PORT, HOST, () => {
   console.log(`\n  Command center  ->  http://${HOST}:${PORT}`);
   console.log(`  refreshes every 5s · Ctrl+C to stop${NO_GH ? ' · --no-gh' : ''}\n`);
   // Warm the cache so the first page load is instant rather than waiting on git and gh.
-  snapshot(true);
+  snapshot(true).catch(() => {});
 });

--- a/scripts/lib/pr-ci-status.mjs
+++ b/scripts/lib/pr-ci-status.mjs
@@ -1,0 +1,318 @@
+// @ts-check
+/**
+ * "Is THIS head verified?" — per-PR CI state, matched to the exact head SHA.
+ *
+ * WHY THIS EXISTS. The standing rule in docs/RELEASE-CHECKLIST.md §2.3 is `green-belongs-to-a-
+ * commit`: CI green must be matched by `headSha`, never read off `gh pr checks`, which reports runs
+ * attached to a PR without saying which commit they ran on (it returned green for #107 from a
+ * previous head — that is why the rule exists). The same section forbids the workaround people
+ * reach for instead: a hand-written list of which branches are green. Such a list is stale the
+ * moment anyone pushes, and during an Actions outage — exactly when people reach for one — it is
+ * stale and load-bearing at the same time. On 2026-09-02 one was published to six concurrent
+ * sessions and was wrong within the hour.
+ *
+ * So the board answers the question per head, on every run, instead of anybody remembering it.
+ *
+ * THE FIVE STATES ARE NOT COLLAPSIBLE. Collapsing them is the bug this module exists to fix:
+ *
+ *   green    a run at this SHA, completed, success            → verified
+ *   red      completed, not success, and it really executed   → a defect in the candidate
+ *   pending  a run exists at this SHA but is not completed    → not yet evidence
+ *   none     NO run exists for this SHA                       → UNVERIFIED, not a pass
+ *   unknown  we could not ask GitHub (gh failed / offline)    → UNVERIFIED, not a pass
+ *   outage   completed red, but zero-step: it never executed  → not about the candidate
+ *
+ * `none` and `unknown` must never render as anything resembling a pass. A head with no run is not
+ * a green head; it is a head nobody has checked. `outage` must never render as `red`: this repo
+ * lost ~72h to exhausted Actions minutes on 2026-08-29 and again from ~04:56Z on 2026-09-02, and
+ * during such a window gate 8 cannot be earned by any candidate, so the red is not a verdict on
+ * the code.
+ *
+ * Everything above the fetch layer is pure and takes plain objects, so scripts/test/pr-ci-status.
+ * test.mjs exercises every state with `gh` stubbed rather than whatever the org's runners happen to
+ * be doing this minute.
+ *
+ * @typedef {object} Run
+ * @property {string} [workflowName]
+ * @property {string} [status]        'completed' | 'in_progress' | 'queued' | ...
+ * @property {string} [conclusion]    'success' | 'failure' | 'skipped' | ... ('' while running)
+ * @property {number} [databaseId]
+ * @property {string} [event]
+ * @property {string} [createdAt]
+ * @property {string} [updatedAt]
+ *
+ * @typedef {'green'|'red'|'pending'|'none'|'unknown'|'outage'} CiState
+ *
+ * @typedef {object} CiVerdict
+ * @property {CiState} state
+ * @property {Run[]} runs      the deduped, newest-per-workflow runs the verdict was read from
+ * @property {Run[]} failing   the completed non-success runs among them
+ * @property {string} detail   short human phrase, e.g. '3 workflow(s)' or 'CI, merge-preflight'
+ */
+
+/** Conclusions that are neither a pass nor a failure — they carry no evidence either way. */
+const NON_BLOCKING = new Set(['skipped', 'neutral']);
+
+/**
+ * A completed red this fast did not run anything. Only a PREFILTER for spending one extra
+ * `gh run view`; `steps.length === 0` is the authoritative test. Deliberately generous: the
+ * 2026-09-02 outage produced 3s, 5s AND 10s reds, and the asymmetry is one-sided — a loose
+ * prefilter costs one extra API call, a tight one reports a capacity outage as a code defect,
+ * which is precisely the mistake this module exists to prevent.
+ */
+export const OUTAGE_PROBE_MAX_MS = 30_000;
+
+/** @param {Run} r */
+function runMs(r) {
+  const a = Date.parse(r.createdAt ?? '');
+  const b = Date.parse(r.updatedAt ?? '');
+  return Number.isFinite(a) && Number.isFinite(b) ? b - a : Infinity;
+}
+
+/** @param {Run} r */
+function runOrder(r) {
+  const t = Date.parse(r.createdAt ?? '');
+  return [Number.isFinite(t) ? t : 0, r.databaseId ?? 0];
+}
+
+/**
+ * Keep only the newest run per `workflowName|event`.
+ *
+ * A SHA can carry SEVERAL runs of the same workflow — a re-run, or a workflow that fires on both
+ * `push` and `pull_request`. `bab5ee90` carried four `merge-preflight` runs. Without this, a head
+ * that was re-run green would render `red` forever off the superseded attempt, which is the same
+ * class of lie as reading `gh pr checks`. Sorted explicitly rather than trusting API order.
+ *
+ * @param {Run[]} runs
+ * @returns {Run[]}
+ */
+export function latestRunPerWorkflow(runs) {
+  /** @type {Map<string, Run>} */
+  const best = new Map();
+  for (const r of runs ?? []) {
+    const key = `${r.workflowName ?? '?'}|${r.event ?? '?'}`;
+    const prev = best.get(key);
+    if (!prev) {
+      best.set(key, r);
+      continue;
+    }
+    const [at, ai] = runOrder(r);
+    const [bt, bi] = runOrder(prev);
+    if (at > bt || (at === bt && ai > bi)) best.set(key, r);
+  }
+  return [...best.values()];
+}
+
+/**
+ * Read a verdict from the runs at one SHA.
+ *
+ * `ok` is separate from an empty list on purpose. `gh` returns nothing on rate-limit, timeout,
+ * auth failure and offline alike, and "GitHub is unreachable" is a different action from "this
+ * head was never pushed to CI" even though neither is green. Collapsing them would repeat, one
+ * level down, exactly the mistake this module exists to fix.
+ *
+ * Precedence, once superseded runs are dropped: a definite failure outranks a run still deciding,
+ * because a head with one red workflow is not going to become verified by the others finishing.
+ * All-non-blocking (every run `skipped`) yields `none` — a skip is the absence of evidence, and
+ * must never be counted toward green.
+ *
+ * @param {{ ok: boolean, runs?: Run[] }} fetched
+ * @returns {CiVerdict}
+ */
+export function classifyRuns(fetched) {
+  if (!fetched || fetched.ok !== true) {
+    return { state: 'unknown', runs: [], failing: [], detail: 'could not reach GitHub' };
+  }
+  const runs = latestRunPerWorkflow(fetched.runs ?? []);
+  if (!runs.length) return { state: 'none', runs, failing: [], detail: 'no run at this SHA' };
+
+  const completed = runs.filter((r) => r.status === 'completed');
+  const failing = completed.filter(
+    (r) => r.conclusion !== 'success' && !NON_BLOCKING.has(r.conclusion ?? '')
+  );
+  const passing = completed.filter((r) => r.conclusion === 'success');
+  const names = (rs) => rs.map((r) => r.workflowName ?? '?').join(', ');
+
+  if (failing.length) return { state: 'red', runs, failing, detail: names(failing) };
+  if (completed.length < runs.length) {
+    const running = runs.filter((r) => r.status !== 'completed');
+    return { state: 'pending', runs, failing: [], detail: names(running) };
+  }
+  if (passing.length) {
+    return { state: 'green', runs, failing: [], detail: `${passing.length} workflow(s)` };
+  }
+  // Everything completed, nothing failed, nothing passed: all skipped/neutral. No evidence.
+  return { state: 'none', runs, failing: [], detail: 'all runs skipped' };
+}
+
+/**
+ * Which failing runs are worth one `gh run view` to check for the capacity signature.
+ * @param {CiVerdict} verdict
+ * @returns {Run[]}
+ */
+export function outageProbeTargets(verdict) {
+  if (verdict.state !== 'red') return [];
+  return verdict.failing.filter((r) => runMs(r) <= OUTAGE_PROBE_MAX_MS);
+}
+
+/**
+ * The capacity signature: the job completed, but ran no steps and produced no logs.
+ * An empty `jobs` array is NOT the signature — that is a run we could not read.
+ * @param {{ steps?: unknown[] }[]} jobs
+ */
+export function isZeroStepJobSet(jobs) {
+  return Array.isArray(jobs) && jobs.length > 0 && jobs.every((j) => (j?.steps ?? []).length === 0);
+}
+
+/**
+ * Promote `red` to `outage` only when EVERY failing run at the SHA is zero-step.
+ *
+ * The composite matters: if one failing run has real steps, a real test failed, and a concurrent
+ * outage must not be allowed to hide it behind a "not your fault" label.
+ *
+ * @param {CiVerdict} verdict
+ * @param {Map<number, boolean>} zeroStepById  run id -> zero-step; absent = not probed / unreadable
+ * @returns {CiVerdict}
+ */
+export function applyOutageEvidence(verdict, zeroStepById) {
+  if (verdict.state !== 'red' || !verdict.failing.length) return verdict;
+  const all = verdict.failing.every((r) => zeroStepById.get(r.databaseId ?? -1) === true);
+  if (!all) return verdict;
+  return { ...verdict, state: 'outage', detail: `${verdict.detail} — 0 steps, never ran` };
+}
+
+/** Every state, worst first. The board's row order, so terminal and dashboard cannot disagree. */
+export const CI_STATES = /** @type {CiState[]} */ (['red', 'outage', 'unknown', 'none', 'pending', 'green']);
+
+/** @param {CiState} state */
+export function ciRank(state) {
+  const i = CI_STATES.indexOf(state);
+  return i < 0 ? CI_STATES.length : i;
+}
+
+/**
+ * Rendering vocabulary, shared by the terminal board, `--md` and the web dashboard so the three
+ * cannot drift. `tone` reuses the board's existing gate classes (go / warn / nogo / idle).
+ *
+ * `none` and `unknown` say "unverified" in words. They are never a dash and never blank: on a
+ * status board an em-dash reads as "nothing wrong", and a head nobody checked is not a head that
+ * is fine.
+ *
+ * @param {CiState} state
+ * @returns {{ label: string, tone: 'go'|'warn'|'nogo'|'idle' }}
+ */
+export function describeCiState(state) {
+  switch (state) {
+    case 'green':
+      return { label: 'green', tone: 'go' };
+    case 'red':
+      return { label: 'RED', tone: 'nogo' };
+    case 'outage':
+      return { label: 'outage', tone: 'warn' };
+    case 'pending':
+      return { label: 'pending', tone: 'warn' };
+    case 'none':
+      return { label: 'none · unverified', tone: 'warn' };
+    default:
+      return { label: 'unknown · unverified', tone: 'idle' };
+  }
+}
+
+/**
+ * Short git-style SHA. Deliberately NOT the board's `short()` helper, which elides the middle
+ * (`140734…8239`) — that shape reads as a contract address, and this is a commit.
+ * @param {string} sha
+ */
+export function shortSha(sha) {
+  return (sha ?? '').slice(0, 7) || '???????';
+}
+
+/** One line of the GITHUB block, without colour. @param {{number:number, headSha:string, ci:CiVerdict}} e */
+export function formatPrCiLine(e) {
+  const { label } = describeCiState(e.ci.state);
+  return `#${e.number} ${shortSha(e.headSha)} ${label}${e.ci.detail ? ` (${e.ci.detail})` : ''}`;
+}
+
+// ---------------------------------------------------------------- fetch orchestration
+
+/** Resolve `tasks` with at most `limit` in flight. @template T */
+async function pool(tasks, limit) {
+  /** @type {any[]} */
+  const out = new Array(tasks.length);
+  let i = 0;
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, tasks.length)) }, async () => {
+    while (i < tasks.length) {
+      const n = i++;
+      out[n] = await tasks[n]();
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Resolve the CI verdict for every PR, concurrently.
+ *
+ * 1 + N `gh` calls, not 2N: `gh pr list` already returns `headRefOid`, so no per-PR `gh pr view`
+ * is needed. The extra `gh run view` probes are spent only on fast reds, which are rare outside an
+ * outage — and inside one there are only as many as there are PRs.
+ *
+ * @param {{ number: number, headRefOid?: string }[]} prs
+ * @param {{
+ *   runList: (sha: string) => Promise<{ ok: boolean, runs?: Run[] }>,
+ *   runJobs: (id: number) => Promise<{ ok: boolean, jobs?: { steps?: unknown[] }[] }>,
+ *   concurrency?: number,
+ *   cacheGet?: (sha: string) => CiVerdict | null,
+ *   cachePut?: (sha: string, v: CiVerdict) => void,
+ * }} deps
+ * @returns {Promise<{ number: number, headSha: string, ci: CiVerdict }[]>}
+ */
+export async function resolvePrCi(prs, deps) {
+  const limit = deps.concurrency ?? 8;
+  const tasks = (prs ?? []).map((pr) => async () => {
+    const headSha = pr.headRefOid ?? '';
+    if (!headSha) {
+      return {
+        number: pr.number,
+        headSha: '',
+        ci: /** @type {CiVerdict} */ ({ state: 'unknown', runs: [], failing: [], detail: 'no head SHA' }),
+      };
+    }
+    const cached = deps.cacheGet?.(headSha);
+    if (cached) return { number: pr.number, headSha, ci: cached };
+
+    let verdict = classifyRuns(await deps.runList(headSha));
+    const probes = outageProbeTargets(verdict);
+    if (probes.length) {
+      /** @type {Map<number, boolean>} */
+      const zeroStep = new Map();
+      const results = await pool(
+        probes.map((r) => async () => [r.databaseId, await deps.runJobs(r.databaseId ?? -1)]),
+        limit
+      );
+      for (const [id, res] of results) {
+        if (res?.ok) zeroStep.set(id, isZeroStepJobSet(res.jobs ?? []));
+      }
+      verdict = applyOutageEvidence(verdict, zeroStep);
+    }
+    deps.cachePut?.(headSha, verdict);
+    return { number: pr.number, headSha, ci: verdict };
+  });
+  return pool(tasks, limit);
+}
+
+/**
+ * How long a verdict may be reused.
+ *
+ * The collector's design rule is "nothing is stored, so nothing can go stale on its own", and this
+ * is the one exemption. It holds because the cache is keyed by HEAD SHA: the fact being cached is
+ * a fact ABOUT that SHA, so the next push is a different key and the entry physically cannot
+ * outlive its subject. That is the precise property the hand-written list lacked.
+ *
+ * Terminal verdicts get a longer life than in-flight ones, which change under you by design.
+ *
+ * @param {CiState} state
+ */
+export function cacheTtlMs(state) {
+  return state === 'pending' || state === 'none' || state === 'unknown' ? 15_000 : 120_000;
+}

--- a/scripts/lib/project-status.mjs
+++ b/scripts/lib/project-status.mjs
@@ -43,7 +43,10 @@ function shAsync(cmd, args, timeout = 20_000) {
     let child;
     try {
       // shell:false, as everywhere else here -- see the shell policy in scripts/gate.mjs.
-      child = spawn(cmd, args, { cwd: REPO, encoding: 'utf8' });
+      // NOT `encoding: 'utf8'`: that is a spawnSync option and spawn silently ignores it, leaving
+      // the stream in buffer mode. Concatenating buffers happens to work until a chunk boundary
+      // splits a multi-byte character, and then JSON.parse throws and a head misreports.
+      child = spawn(cmd, args, { cwd: REPO });
     } catch {
       return finish(false, '');
     }
@@ -56,6 +59,7 @@ function shAsync(cmd, args, timeout = 20_000) {
       }
       finish(false, '');
     }, timeout);
+    child.stdout?.setEncoding('utf8');
     child.stdout?.on('data', (b) => {
       stdout += b;
     });
@@ -292,6 +296,9 @@ const CI_CACHE = path.join(REPO, '.cc-ci-cache.json');
  *
  * Six sessions may run `cc` against this checkout at once, so writes go through a temp file and a
  * rename, and EVERY failure degrades to a cache miss rather than breaking the board.
+ *
+ * It stores the whole verdict, `detail` prose included -- so if you reword a detail string, expect
+ * the old wording to survive one TTL rather than reaching for a debugger.
  */
 function ciCache() {
   let store = {};

--- a/scripts/lib/project-status.mjs
+++ b/scripts/lib/project-status.mjs
@@ -10,10 +10,11 @@
  * One collector, two renderers. A dashboard that drifts from the terminal board is worse than
  * having only one of them, because you then have to remember which is lying.
  */
-import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { cacheTtlMs, resolvePrCi } from './pr-ci-status.mjs';
 
 export const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -23,6 +24,50 @@ function sh(cmd, args, timeout = 10_000) {
   // cmd.exe would reinterpret arguments (see the shell policy in scripts/gate.mjs).
   const r = spawnSync(cmd, args, { cwd: REPO, encoding: 'utf8', timeout });
   return r.status === 0 ? (r.stdout || '').trim() : '';
+}
+
+/**
+ * The async twin of `sh`, for the only part of the board that fans out: the per-head CI lookups.
+ * `spawnSync` in a loop would cost ~13s for 18 PRs and `cc` is the cold-start tool. Returns
+ * `{ ok }` separately from the output, because "gh failed" and "gh said nothing" are different
+ * facts and the CI classifier must not collapse them (see scripts/lib/pr-ci-status.mjs).
+ */
+function shAsync(cmd, args, timeout = 20_000) {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (ok, out) => {
+      if (done) return;
+      done = true;
+      resolve({ ok, out });
+    };
+    let child;
+    try {
+      // shell:false, as everywhere else here -- see the shell policy in scripts/gate.mjs.
+      child = spawn(cmd, args, { cwd: REPO, encoding: 'utf8' });
+    } catch {
+      return finish(false, '');
+    }
+    let stdout = '';
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* already gone */
+      }
+      finish(false, '');
+    }, timeout);
+    child.stdout?.on('data', (b) => {
+      stdout += b;
+    });
+    child.on('error', () => {
+      clearTimeout(timer);
+      finish(false, '');
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      finish(code === 0, stdout.trim());
+    });
+  });
 }
 
 const jsonOr = (s, fallback) => {
@@ -233,12 +278,98 @@ function rightNow() {
   return { now: pick('Right now'), blocked: pick('Blocked on a human'), traps: pick('Traps that are not visible in the code') };
 }
 
+// ---------------------------------------------------------------- ci (per head SHA)
+
+const CI_CACHE = path.join(REPO, '.cc-ci-cache.json');
+
+/**
+ * A tiny on-disk cache of per-head CI verdicts.
+ *
+ * This is the ONE exemption to the "nothing is stored" rule at the top of this file, and it earns
+ * it by being keyed on the head SHA: the cached fact is a fact ABOUT that SHA, so the next push is
+ * a different key and an entry cannot outlive its subject. That is exactly the property the
+ * hand-written green-list lacked.
+ *
+ * Six sessions may run `cc` against this checkout at once, so writes go through a temp file and a
+ * rename, and EVERY failure degrades to a cache miss rather than breaking the board.
+ */
+function ciCache() {
+  let store = {};
+  try {
+    store = jsonOr(readFileSync(CI_CACHE, 'utf8'), {}) ?? {};
+  } catch {
+    /* no cache yet, or unreadable -- a miss, not an error */
+  }
+  const now = Date.now();
+  let dirty = false;
+  return {
+    get(sha) {
+      const e = store[sha];
+      if (!e || !e.ci || now - (e.at ?? 0) > cacheTtlMs(e.ci.state)) return null;
+      return e.ci;
+    },
+    put(sha, ci) {
+      store[sha] = { at: now, ci };
+      dirty = true;
+    },
+    flush() {
+      if (!dirty) return;
+      // Drop anything older than the longest TTL so the file cannot grow without bound.
+      for (const [k, v] of Object.entries(store)) {
+        if (now - (v?.at ?? 0) > 600_000) delete store[k];
+      }
+      const tmp = `${CI_CACHE}.${process.pid}.tmp`;
+      try {
+        writeFileSync(tmp, JSON.stringify(store), 'utf8');
+        renameSync(tmp, CI_CACHE);
+      } catch {
+        /* another session won the rename, or the tree is read-only -- both are fine */
+      }
+    },
+  };
+}
+
+/**
+ * Per-PR CI state, matched to the exact head SHA. The classification lives in
+ * scripts/lib/pr-ci-status.mjs (pure, tested); this only supplies `gh`.
+ *
+ * `gh run list --commit <sha>` is used deliberately instead of `gh pr checks`, which reports runs
+ * attached to a PR without saying which commit they ran on -- the rule in
+ * docs/RELEASE-CHECKLIST.md §2.3, written after a stale green passed for PR #107.
+ */
+async function prCi(prs) {
+  const cache = ciCache();
+  const rows = await resolvePrCi(prs, {
+    concurrency: 8,
+    cacheGet: (sha) => cache.get(sha),
+    cachePut: (sha, v) => cache.put(sha, v),
+    runList: async (sha) => {
+      const r = await shAsync(
+        'gh',
+        [
+          'run', 'list', '--commit', sha,
+          '--json', 'workflowName,conclusion,status,databaseId,event,createdAt,updatedAt',
+          '--limit', '40',
+        ],
+        25_000
+      );
+      return r.ok ? { ok: true, runs: jsonOr(r.out, []) } : { ok: false };
+    },
+    runJobs: async (id) => {
+      const r = await shAsync('gh', ['run', 'view', String(id), '--json', 'jobs'], 25_000);
+      return r.ok ? { ok: true, jobs: jsonOr(r.out, { jobs: [] })?.jobs ?? [] } : { ok: false };
+    },
+  });
+  cache.flush();
+  return rows;
+}
+
 // ---------------------------------------------------------------- collect
 
 /**
- * @param {{ gh?: boolean, vault?: string }} [opts]
+ * @param {{ gh?: boolean, ci?: boolean, vault?: string }} [opts]
  */
-export function collect(opts = {}) {
+export async function collect(opts = {}) {
   const useGh = opts.gh !== false;
   const vaultRoot = opts.vault ?? 'C:/Users/Micha/desktop/Obsidian Vault/Agent-Governed Vaults';
 
@@ -247,7 +378,9 @@ export function collect(opts = {}) {
   let ghUp = false;
   if (useGh) {
     // mergeable is computed asynchronously by GitHub, so it can legitimately come back UNKNOWN.
-    const p = sh('gh', ['pr', 'list', '--state', 'open', '--json', 'number,title,headRefName,mergeable', '--limit', '40'], 20_000);
+    // headRefOid comes back from THIS call: the per-head CI lookup below therefore costs 1 + N gh
+    // invocations, not 2N. Do not "restore" a per-PR `gh pr view --json headRefOid`.
+    const p = sh('gh', ['pr', 'list', '--state', 'open', '--json', 'number,title,headRefName,headRefOid,mergeable', '--limit', '40'], 20_000);
     const i = sh('gh', ['issue', 'list', '--state', 'open', '--json', 'number,title', '--limit', '40'], 20_000);
     if (p || i) {
       prs = jsonOr(p, []);
@@ -255,6 +388,11 @@ export function collect(opts = {}) {
       ghUp = true;
     }
   }
+
+  // The board's answer to "is this head verified?", asked per head on every run so that nobody
+  // has to keep the answer in their own head. See scripts/lib/pr-ci-status.mjs for why the five
+  // states are reported separately and why `none` is not a pass.
+  const ci = ghUp && opts.ci !== false && prs.length ? await prCi(prs) : [];
 
   return {
     at: new Date().toISOString(),
@@ -265,6 +403,6 @@ export function collect(opts = {}) {
     sprints: sprints(prs),
     departments: departments(vaultRoot),
     now: rightNow(),
-    github: { up: ghUp, prs, issues },
+    github: { up: ghUp, prs, issues, ci, ciAsked: ghUp && opts.ci !== false },
   };
 }

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -6,6 +6,7 @@
  *     npm run cc              # the board
  *     npm run cc -- --md      # same content as markdown (paste into Obsidian / a PR / a handoff)
  *     npm run cc -- --no-gh   # skip the GitHub lookups (offline, or when gh is slow)
+ *     npm run cc -- --no-ci   # keep the PR list, drop the per-head CI column (~3s colder)
  *     npm run cc:web          # the same data as a live dashboard in the browser
  *
  * This file is only the TERMINAL RENDERER. Every value comes from `collect()` in
@@ -16,12 +17,21 @@
  * DESIGN RULE (lives with the collector, restated here because it governs what belongs in this
  * file): report FACTS WE COMPUTE and POINT AT the prose we cannot. Nothing is stored, so nothing
  * can go stale on its own -- if a value is wrong, its SOURCE is wrong, which is the bug you want.
+ *
+ * The CI @ HEAD block is that rule applied to the question six concurrent sessions were each
+ * answering from memory: "is this PR's CURRENT head verified?" It is asked per head SHA on every
+ * run, so it cannot be the stale hand-written green-list that docs/RELEASE-CHECKLIST.md 2.3
+ * forbids. See scripts/lib/pr-ci-status.mjs for why `none` is not a pass and `outage` is not a red.
  */
 import { collect, gateClass } from './lib/project-status.mjs';
+import { describeCiState, shortSha } from './lib/pr-ci-status.mjs';
 
 const argv = process.argv.slice(2);
 const MD = argv.includes('--md');
 const NO_GH = argv.includes('--no-gh');
+// The per-head CI column costs 1 + N `gh` calls (~2s for 18 PRs, concurrent, SHA-keyed cache).
+// `--no-ci` drops it; `--no-gh` implies it.
+const NO_CI = argv.includes('--no-ci');
 
 const TTY = process.stdout.isTTY && !MD;
 const C = TTY
@@ -43,7 +53,7 @@ const ago = (ms) => {
   return h < 48 ? `${h}h ago` : `${Math.round(h / 24)}d ago`;
 };
 
-const d = collect({ gh: !NO_GH });
+const d = await collect({ gh: !NO_GH, ci: !NO_CI });
 const stamp = d.at.slice(0, 16).replace('T', ' ');
 
 if (MD) say(`# Command center — ${stamp}Z\n`);
@@ -166,10 +176,50 @@ if (d.deployments.length) {
 if (d.github.up) {
   const p = d.github.prs.length ? d.github.prs.map((x) => `#${x.number}`).join(' ') : 'none';
   const i = d.github.issues.length ? d.github.issues.map((x) => `#${x.number}`).join(' ') : 'none';
-  if (MD) say(`## GitHub\n\n- Open PRs: ${p}\n- Open issues: ${i}\n`);
-  else {
+  const titleOf = new Map(d.github.prs.map((x) => [x.number, x.title ?? '']));
+  // Worst first: the rows that need a decision should not be the ones below the fold.
+  const RANK = { red: 0, outage: 1, unknown: 2, none: 3, pending: 4, green: 5 };
+  const ci = [...(d.github.ci ?? [])].sort(
+    (a, b) => (RANK[a.ci.state] ?? 9) - (RANK[b.ci.state] ?? 9) || b.number - a.number
+  );
+  const tally = ci.reduce((m, e) => ((m[e.ci.state] = (m[e.ci.state] ?? 0) + 1), m), {});
+  const tallyLine = ['green', 'red', 'outage', 'pending', 'none', 'unknown']
+    .filter((k) => tally[k])
+    .map((k) => `${tally[k]} ${k}`)
+    .join(' · ');
+
+  if (MD) {
+    say(`## GitHub\n`);
+    say(`- Open PRs: ${p}\n- Open issues: ${i}\n`);
+    if (ci.length) {
+      say(`### CI at the exact head SHA\n`);
+      say('| PR | Head | CI | Detail | Title |');
+      say('|----|------|----|--------|-------|');
+      for (const e of ci) {
+        const { label } = describeCiState(e.ci.state);
+        say(`| #${e.number} | \`${shortSha(e.headSha)}\` | ${label} | ${e.ci.detail} | ${(titleOf.get(e.number) || '').slice(0, 54)} |`);
+      }
+      say(`\n${tallyLine}.`);
+      // Restated wherever the table is pasted, because the table travels and the rule does not.
+      say(`\n> Read with \`gh run list --commit\`, never \`gh pr checks\` (docs/RELEASE-CHECKLIST.md §2.3).`);
+      say(`> \`none\` and \`unknown\` are UNVERIFIED — not passes. \`outage\` is a zero-step run that never executed.\n`);
+    }
+  } else {
     say(`\n${C.b}GITHUB${C.x}    ${d.github.prs.length} open PR(s): ${C.d}${p}${C.x}`);
     say(`          ${d.github.issues.length} open issue(s): ${C.d}${i}${C.x}`);
+    if (ci.length) {
+      say(`\n${C.b}CI @ HEAD${C.x} ${C.d}per PR, matched to the exact head SHA · ${tallyLine}${C.x}`);
+      for (const e of ci) {
+        const { label, tone } = describeCiState(e.ci.state);
+        say(
+          `          ${pad(`#${e.number}`, 5)} ${C.d}${shortSha(e.headSha)}${C.x} ` +
+            `${COLOR[tone]}${pad(label, 19)}${C.x} ${C.d}${(e.ci.detail || '').slice(0, 44)}${C.x}`
+        );
+      }
+      say(`          ${C.d}none/unknown = UNVERIFIED, not a pass · outage = 0-step run, never executed${C.x}`);
+    } else if (d.github.prs.length && !d.github.ciAsked) {
+      say(`          ${C.d}CI at head not queried (--no-ci)${C.x}`);
+    }
   }
 } else if (!NO_GH && !MD) {
   say(`\n${C.b}GITHUB${C.x}    ${C.d}unavailable (gh not installed / not authenticated / offline)${C.x}`);

--- a/scripts/test/pr-ci-status.test.mjs
+++ b/scripts/test/pr-ci-status.test.mjs
@@ -1,0 +1,327 @@
+// @ts-check
+/**
+ * Pure-logic tests for scripts/lib/pr-ci-status.mjs -- the "why" is in that module's header. No
+ * `gh` is invoked; `runList`/`runJobs` are stubbed, so this exercises every state rather than
+ * whatever the org's runners happen to be doing this minute.
+ *
+ * The load-bearing assertions are the ones that check what is NOT green: `none`, `unknown` and
+ * `outage` all have to stay distinguishable from a pass, because collapsing them is the bug the
+ * module exists to fix.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyOutageEvidence,
+  cacheTtlMs,
+  ciRank,
+  classifyRuns,
+  describeCiState,
+  isZeroStepJobSet,
+  latestRunPerWorkflow,
+  outageProbeTargets,
+  resolvePrCi,
+  shortSha,
+} from '../lib/pr-ci-status.mjs';
+
+/** A completed run. `ms` is how long it took, which is the outage prefilter's input. */
+const run = (workflowName, conclusion, { id = 1, ms = 300_000, at = '2026-09-02T04:00:00Z', event = 'pull_request' } = {}) => ({
+  workflowName,
+  event,
+  status: 'completed',
+  conclusion,
+  databaseId: id,
+  createdAt: at,
+  updatedAt: new Date(Date.parse(at) + ms).toISOString(),
+});
+
+const running = (workflowName, { id = 9, at = '2026-09-02T04:00:00Z' } = {}) => ({
+  workflowName,
+  event: 'pull_request',
+  status: 'in_progress',
+  conclusion: '',
+  databaseId: id,
+  createdAt: at,
+  updatedAt: at,
+});
+
+// ---------------------------------------------------------------- the five states
+
+test('a completed successful run at this SHA -> green', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'success'), run('merge-preflight', 'success', { id: 2 })] });
+  assert.equal(v.state, 'green');
+  assert.equal(describeCiState(v.state).tone, 'go');
+});
+
+test('a completed failing run -> red', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'success'), run('merge-preflight', 'failure', { id: 2 })] });
+  assert.equal(v.state, 'red');
+  assert.deepEqual(v.failing.map((r) => r.workflowName), ['merge-preflight']);
+});
+
+test('a run that is not completed -> pending, never green', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'success'), running('merge-preflight')] });
+  assert.equal(v.state, 'pending');
+  assert.notEqual(v.state, 'green');
+});
+
+test('NO run at this SHA -> none, and none is not a pass', () => {
+  const v = classifyRuns({ ok: true, runs: [] });
+  assert.equal(v.state, 'none');
+  assert.notEqual(v.state, 'green');
+  // The label must say so in words: on a status board a dash reads as "nothing wrong".
+  const { label, tone } = describeCiState('none');
+  assert.match(label, /unverified/i);
+  assert.notEqual(tone, 'go');
+});
+
+test('gh failed -> unknown, distinct from none, and not a pass', () => {
+  const v = classifyRuns({ ok: false });
+  assert.equal(v.state, 'unknown');
+  assert.notEqual(v.state, 'none', 'unreachable GitHub is a different fact from an unpushed head');
+  assert.notEqual(v.state, 'green');
+  assert.match(describeCiState('unknown').label, /unverified/i);
+});
+
+test('a malformed/absent fetch result is unknown, never green', () => {
+  for (const bad of [undefined, null, {}, { ok: 'yes' }]) {
+    assert.equal(classifyRuns(/** @type {any} */ (bad)).state, 'unknown');
+  }
+});
+
+// ---------------------------------------------------------------- skipped is not evidence
+
+test('all runs skipped -> none, NOT green', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'skipped'), run('merge-preflight', 'skipped', { id: 2 })] });
+  assert.equal(v.state, 'none');
+  assert.notEqual(v.state, 'green');
+  assert.notEqual(v.state, 'red', 'a skip is the absence of evidence, not a failure');
+});
+
+test('some success + some skipped -> green', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'success'), run('merge-preflight', 'skipped', { id: 2 })] });
+  assert.equal(v.state, 'green');
+});
+
+test('a failure outranks a run still in flight', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'failure'), running('merge-preflight')] });
+  assert.equal(v.state, 'red', 'the other workflows finishing cannot make this head verified');
+});
+
+// ---------------------------------------------------------------- re-runs at the same SHA
+
+test('a newer success supersedes an older failure of the same workflow -> green', () => {
+  // Observed on protocol/main: bab5ee90 carried four merge-preflight runs at one SHA.
+  const v = classifyRuns({
+    ok: true,
+    runs: [
+      run('merge-preflight', 'failure', { id: 10, at: '2026-09-02T04:53:08Z' }),
+      run('merge-preflight', 'success', { id: 40, at: '2026-09-02T05:00:15Z' }),
+      run('merge-preflight', 'failure', { id: 20, at: '2026-09-02T04:56:24Z' }),
+    ],
+  });
+  assert.equal(v.state, 'green', 'a superseded attempt must not pin the head red forever');
+  assert.equal(v.runs.length, 1);
+});
+
+test('latestRunPerWorkflow keys on workflow AND event, and does not trust input order', () => {
+  const kept = latestRunPerWorkflow([
+    run('CI', 'success', { id: 2, at: '2026-09-02T05:00:00Z', event: 'push' }),
+    run('CI', 'failure', { id: 1, at: '2026-09-02T04:00:00Z', event: 'pull_request' }),
+    run('CI', 'failure', { id: 3, at: '2026-09-02T04:30:00Z', event: 'push' }),
+  ]);
+  assert.equal(kept.length, 2, 'push and pull_request are separate runs, not re-runs of each other');
+  assert.equal(kept.find((r) => r.event === 'push')?.databaseId, 2);
+});
+
+test('same createdAt breaks the tie on databaseId', () => {
+  const kept = latestRunPerWorkflow([
+    run('CI', 'failure', { id: 7, at: '2026-09-02T04:00:00Z' }),
+    run('CI', 'success', { id: 8, at: '2026-09-02T04:00:00Z' }),
+  ]);
+  assert.equal(kept[0].databaseId, 8);
+});
+
+// ---------------------------------------------------------------- the outage shape
+
+test('zero-step job set is the capacity signature; an empty job list is not', () => {
+  assert.equal(isZeroStepJobSet([{ steps: [] }, { steps: [] }]), true);
+  assert.equal(isZeroStepJobSet([{ steps: [] }, { steps: [{}, {}] }]), false);
+  assert.equal(isZeroStepJobSet([]), false, 'no jobs = a run we could not read, not a proven outage');
+  assert.equal(isZeroStepJobSet(/** @type {any} */ (undefined)), false);
+});
+
+test('a fast red whose jobs ran no steps -> outage, not red', () => {
+  const v = classifyRuns({ ok: true, runs: [run('merge-preflight', 'failure', { id: 5, ms: 5_000 })] });
+  assert.equal(v.state, 'red');
+  const out = applyOutageEvidence(v, new Map([[5, true]]));
+  assert.equal(out.state, 'outage');
+  assert.notEqual(describeCiState('outage').tone, 'nogo', 'an outage is not a verdict on the candidate');
+  assert.match(out.detail, /never ran/);
+});
+
+test('a 10s red is still probed -- the 2026-09-02 outage produced 3s, 5s and 10s reds', () => {
+  const v = classifyRuns({ ok: true, runs: [run('merge-preflight', 'failure', { id: 5, ms: 10_000 })] });
+  assert.equal(outageProbeTargets(v).length, 1);
+});
+
+test('a red that took minutes is not probed', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'failure', { id: 5, ms: 480_000 })] });
+  assert.deepEqual(outageProbeTargets(v), []);
+});
+
+test('one failing run with REAL steps keeps the whole SHA red, even beside a zero-step one', () => {
+  // Otherwise a live outage would hide a genuine test failure behind "not your fault".
+  const v = classifyRuns({
+    ok: true,
+    runs: [
+      run('merge-preflight', 'failure', { id: 5, ms: 4_000 }),
+      run('CI', 'failure', { id: 6, ms: 9_000 }),
+    ],
+  });
+  const out = applyOutageEvidence(v, new Map([[5, true], [6, false]]));
+  assert.equal(out.state, 'red');
+});
+
+test('an unreadable probe leaves the SHA red rather than excusing it as an outage', () => {
+  const v = classifyRuns({ ok: true, runs: [run('CI', 'failure', { id: 5, ms: 4_000 })] });
+  assert.equal(applyOutageEvidence(v, new Map()).state, 'red');
+});
+
+test('outage evidence never promotes a non-red verdict', () => {
+  for (const s of ['green', 'none', 'pending', 'unknown']) {
+    const v = { state: /** @type {any} */ (s), runs: [], failing: [], detail: '' };
+    assert.equal(applyOutageEvidence(v, new Map([[1, true]])).state, s);
+  }
+});
+
+// ---------------------------------------------------------------- orchestration
+
+test('resolvePrCi reads each PR at its own head SHA and never calls gh pr view', async () => {
+  /** @type {string[]} */
+  const asked = [];
+  const rows = await resolvePrCi(
+    [
+      { number: 133, headRefOid: 'aaaaaaaa1111' },
+      { number: 130, headRefOid: 'bbbbbbbb2222' },
+      { number: 128, headRefOid: 'cccccccc3333' },
+    ],
+    {
+      concurrency: 3,
+      runList: async (sha) => {
+        asked.push(sha);
+        if (sha === 'aaaaaaaa1111') return { ok: true, runs: [run('CI', 'success')] };
+        if (sha === 'bbbbbbbb2222') return { ok: true, runs: [run('merge-preflight', 'failure', { id: 5, ms: 3_000 })] };
+        return { ok: true, runs: [] };
+      },
+      runJobs: async () => ({ ok: true, jobs: [{ steps: [] }] }),
+    }
+  );
+  assert.deepEqual(asked.sort(), ['aaaaaaaa1111', 'bbbbbbbb2222', 'cccccccc3333']);
+  assert.deepEqual(
+    rows.map((r) => [r.number, r.ci.state, r.headSha]),
+    [
+      [133, 'green', 'aaaaaaaa1111'],
+      [130, 'outage', 'bbbbbbbb2222'],
+      [128, 'none', 'cccccccc3333'],
+    ]
+  );
+});
+
+test('a PR with no head SHA is unknown, and costs no gh call', async () => {
+  const rows = await resolvePrCi([{ number: 1 }], {
+    runList: async () => {
+      throw new Error('must not be called');
+    },
+    runJobs: async () => {
+      throw new Error('must not be called');
+    },
+  });
+  assert.equal(rows[0].ci.state, 'unknown');
+});
+
+test('a gh failure surfaces as unknown for that PR alone', async () => {
+  const rows = await resolvePrCi(
+    [
+      { number: 1, headRefOid: 'aaa' },
+      { number: 2, headRefOid: 'bbb' },
+    ],
+    {
+      runList: async (sha) => (sha === 'aaa' ? { ok: false } : { ok: true, runs: [run('CI', 'success')] }),
+      runJobs: async () => ({ ok: false }),
+    }
+  );
+  assert.deepEqual(rows.map((r) => r.ci.state), ['unknown', 'green']);
+});
+
+test('the cache is consulted per head SHA and skips the lookup entirely', async () => {
+  let calls = 0;
+  const rows = await resolvePrCi([{ number: 1, headRefOid: 'sha-a' }], {
+    cacheGet: (sha) => (sha === 'sha-a' ? { state: 'green', runs: [], failing: [], detail: 'cached' } : null),
+    runList: async () => {
+      calls++;
+      return { ok: true, runs: [] };
+    },
+    runJobs: async () => ({ ok: false }),
+  });
+  assert.equal(calls, 0);
+  assert.equal(rows[0].ci.state, 'green');
+});
+
+test('a fresh verdict is written back under its head SHA, so the next push is a different key', async () => {
+  /** @type {string[]} */
+  const written = [];
+  await resolvePrCi([{ number: 1, headRefOid: 'sha-b' }], {
+    cachePut: (sha) => written.push(sha),
+    runList: async () => ({ ok: true, runs: [run('CI', 'success')] }),
+    runJobs: async () => ({ ok: false }),
+  });
+  assert.deepEqual(written, ['sha-b']);
+});
+
+test('in-flight verdicts expire faster than settled ones', () => {
+  assert.ok(cacheTtlMs('pending') < cacheTtlMs('green'));
+  assert.ok(cacheTtlMs('none') < cacheTtlMs('red'));
+  assert.ok(cacheTtlMs('unknown') < cacheTtlMs('outage'));
+});
+
+test('resolvePrCi honours its concurrency limit', async () => {
+  let live = 0;
+  let peak = 0;
+  const prs = Array.from({ length: 12 }, (_, n) => ({ number: n, headRefOid: `sha${n}` }));
+  await resolvePrCi(prs, {
+    concurrency: 4,
+    runList: async () => {
+      live++;
+      peak = Math.max(peak, live);
+      await new Promise((r) => setTimeout(r, 5));
+      live--;
+      return { ok: true, runs: [] };
+    },
+    runJobs: async () => ({ ok: false }),
+  });
+  assert.ok(peak > 1, 'the lookups must actually overlap -- 18 sequential gh calls is ~13s');
+  assert.ok(peak <= 4);
+});
+
+// ---------------------------------------------------------------- rendering
+
+test('every state has a label, and only green reads as a pass', () => {
+  for (const s of ['green', 'red', 'outage', 'pending', 'none', 'unknown']) {
+    const { label, tone } = describeCiState(/** @type {any} */ (s));
+    assert.ok(label.trim().length, `${s} must render a word, never a dash or a blank`);
+    assert.equal(tone === 'go', s === 'green', `only green may render as a pass (${s})`);
+  }
+});
+
+test('the head is shown as a 7-char git prefix, not an elided address', () => {
+  assert.equal(shortSha('14073402efa5eb7056190a70db2ec571ea1e8239'), '1407340');
+  assert.doesNotMatch(shortSha('14073402efa5eb7056190a70db2ec571ea1e8239'), /…/);
+  assert.equal(shortSha(''), '???????');
+});
+
+test('ranking puts the rows that need a decision first', () => {
+  assert.ok(ciRank('red') < ciRank('pending'));
+  assert.ok(ciRank('outage') < ciRank('green'));
+  assert.ok(ciRank('none') < ciRank('green'), 'an unverified head outranks a verified one');
+  assert.equal(ciRank(/** @type {any} */ ('nonsense')), 6);
+});


### PR DESCRIPTION
## What

`npm run cc` listed open PRs by number only — `18 open PR(s): #133 #132 #131 #130 …` — and said nothing about whether any of them was verified. It now shows, per open PR, the **short head SHA** and the **CI conclusion for that exact SHA**.

```
CI @ HEAD per PR, matched to the exact head SHA · 15 green · 1 red · 2 outage
      #124  8ea1614 RED                 CI
      #132  f905620 outage              CI, merge-preflight — 0 steps, never ran
      #130  8a8ca8e outage              merge-preflight, CI — 0 steps, never ran
      #133  1407340 green               2 workflow(s)
      …
      none/unknown = UNVERIFIED, not a pass · outage = 0-step run, never executed
```

Worst first, so the rows that need a decision are not the ones below the fold.

## Why

`docs/RELEASE-CHECKLIST.md` §2.3 (PR #130) states the `green-belongs-to-a-commit` rule and, in the same section, forbids the workaround people reach for instead: *"do not keep a hand-written list of which branches are green … query per head instead."*

Because `cc` could not answer "is this head verified", six concurrent sessions each kept that list in their own head. On 2026-09-02 one was published to all of them and was stale within the hour. This makes the board do the querying, on every run, so nobody has to remember the answer.

Read with `gh run list --commit <sha>`, **never `gh pr checks`** — which reports runs attached to a PR without saying which commit they ran on (it returned green for #107 from a previous head; that is why the rule exists).

## Six states, deliberately not collapsed

| state | meaning |
|---|---|
| `green` | a run at this SHA, completed, success |
| `red` | completed, not success, and it really executed |
| `pending` | a run exists at this SHA but has not finished |
| `none` | **no run exists for this SHA** |
| `unknown` | we could not ask GitHub (gh failed / offline / rate-limited) |
| `outage` | completed red whose jobs ran **zero steps** |

`none` and `unknown` render the word *unverified* and never a dash — on a status board a dash reads as "nothing wrong", and a head nobody has checked is not a head that is fine. Only `green` gets the pass colour; a test asserts that for every state.

`outage` is separated from `red` because this repo lost ~72h to exhausted Actions minutes on 2026-08-29 and again from ~04:56Z on 2026-09-02. In such a window gate 8 cannot be earned by any candidate, so the red is not a verdict on the code. It is **proven, not guessed**: a fast red is only a prefilter for one `gh run view`, and `steps.length === 0` on *every* failing run is the authoritative test. If one failing run has real steps the SHA stays `red`, so a live outage can never mask a genuine test failure.

## Two things the brief did not anticipate — please don't "fix" them back

- **1 + N gh calls, not the estimated ~36.** `gh pr list` already returns `headRefOid`, so no per-PR `gh pr view` is needed. Noted in a comment at the call site.
- **A SHA can carry several runs of one workflow.** `bab5ee90` on `protocol/main` carried four `merge-preflight` runs. Runs are deduped newest-per-`workflowName|event` (sorted explicitly — API order is not trusted) before classifying. Without this, a head that was re-run green would render `red` forever off the superseded attempt, which is the same class of lie as reading `gh pr checks`.

Also handled: `skipped`/`neutral` carry no evidence — some-success-plus-some-skipped is `green`, but **all**-skipped is `none`, never `green`. Real `skipped` runs appear on `protocol/main` today.

## Speed

Lookups run 8-concurrent with a small on-disk cache **keyed by head SHA**. The collector's stated rule is *"nothing is stored, so nothing can go stale on its own"*; keying on the SHA is what earns the exemption — the cached fact is a fact *about* that SHA, so the next push is a different key and an entry cannot outlive its subject. That is precisely the property the hand-written list lacked.

Measured against the live repo, 18 open PRs: **6.7s cold, 2.7s warm**, against a 3.1s `--no-ci` baseline. `npm run cc -- --no-ci` drops the column; `--no-gh` still skips GitHub entirely. Cache writes go temp+rename and degrade to a miss on any error, because six sessions share this checkout. `.cc-ci-cache.json` is gitignored.

## Shape

- `scripts/lib/pr-ci-status.mjs` — new, pure logic + injected-`gh` orchestration.
- `scripts/lib/project-status.mjs` — supplies `gh`; `collect()` is now **async** (concurrency needs it).
- Three render sites all carry the column from one shared vocabulary, so terminal / `--md` / web cannot drift: `scripts/status.mjs` (both branches) and `scripts/dashboard.mjs`. `render()` there runs in the browser, so the vocabulary is injected into the page rather than restated.
- `scripts/test/pr-ci-status.test.mjs` — 29 `node:test` tests, `gh` stubbed. The load-bearing ones: `none`/`unknown`/`outage` are never green, all-skipped is `none`, a superseded failure does not outlive its re-run, and an unreadable probe leaves the SHA `red` rather than excusing it.

## Verification

- `node --test scripts/test/pr-ci-status.test.mjs` — 29/29.
- `npm run test:backend` — 966 tests, 0 fail.
- **`npm run gate` — PASSED (404.2s)**, 9/9 steps, slither advisory-only as usual. Run because Actions is red repo-wide right now with the zero-step signature (`protocol/main` @ `bab5ee90` included), so CI on this head may well come back `outage` rather than a verdict — which this PR now labels as such.
- Live end-to-end against 18 open PRs, plus `cc:web` API and page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
