### PR TITLE
ops(gate7): re-drill the restore under Docker — steps 1/6 literal, atomicity proven, 3 new defects

### DIFF
--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -506,3 +506,281 @@ unscriptable Windows platform limit rather than an artifact of one tool's `kill`
 half of the drill (everything except steps 1/6) is now independently reproduced twice; and Docker
 Desktop is not a from-scratch install for the owner — it is already on this machine, one reboot
 from usable.
+
+---
+
+## 10. Re-drill 2026-09-02 — Docker present, steps 1 and 6 run LITERALLY
+
+**Date:** 2026-09-02 · **Chain:** Base Sepolia (84532) · **Base:** `bab5ee90` (`protocol/main`) ·
+**Engine:** Docker Desktop 4.88.1, server 29.7.2, **OSType `linux`**, driver overlayfs, Compose
+v5.4.0 · **Gate:** [7 — ops runbook exercised](LAUNCH-READINESS.md)
+
+The condition §9 named is met: a real POSIX kernel is available. This re-drill runs the procedure
+in [`RUNTIME.md` §8.3](RUNTIME.md) with **steps 1 and 6 as the literal `docker compose stop/start`
+the runbook prints**, and then closes four of the five items §6 listed as untested.
+
+> **Steps 1 and 6 were literal this time.** `docker compose -p gate7drill stop indexer` and
+> `docker compose -p gate7drill start indexer`, against the real Compose stack built from this
+> repo's `Dockerfile` and `docker-compose.yml`. The `-p` flag scopes the project to a throwaway
+> volume so a concurrent session's state could not be touched; it changes the project *name*, not
+> stop/start semantics, so the step is literal for the purposes of this row.
+
+**All six steps ran against the shipped Compose stack — `indexer`, `api` and `canary` all three
+up.** The API was running as a live reader throughout, which §6 listed as never having been
+observed.
+
+| Drill | Verdict | The one-line result |
+| --- | --- | --- |
+| A — indexer, steps 1/6 literal | **PASS** | live file truncated → restored from the **15-minute-aged `.3`** rung byte-identically → `docker compose start` resumed with `knownVaults:3` **from the restored file**, closed a **452-block** rewind in one 0.68s batch, counts identical |
+| B — canary, steps 1/6 literal | **PASS** | restored from its aged `.3` → reloaded **48 tracked signals**, **zero re-pages** for the 6 standing not-OK signals |
+| C — atomicity under a kill **during a write** | **PROVEN** | 6 SIGKILLs landed *inside* the write window by construction; live snapshot parsed **OK all 6 times**. See §10.3 |
+| D — production-scale restore | **PASS** | **59,855,231 bytes / 7 vaults / 1,050,000 holders** restored byte-identically; daemon reseeded `knownVaults:7` |
+| E — off-host volume tar | **PASS on the corrected command; the printed one is broken** | see finding 8 |
+| F — graceful shutdown | **FAILS — new blocking defect** | `docker compose stop` never runs the shutdown hooks. See finding 7 |
+
+**Gate 7 assessment: the restore path is now proven far past what the row asked for, but this
+drill found a defect that did not exist on the record before, and it is in the runbook's own
+promises rather than in the restore.** The row's *stated* condition ("re-run steps 1/6 under
+Compose") **is met**. Four of the five §6 gaps are closed. But running literally surfaced three
+places where the printed procedure does not do what it says (findings 6, 7, 8), one of which —
+graceful shutdown — is contradicted for **all three services**. Recommendation in §10.6.
+
+### 10.1 Step-by-step: literal or substituted
+
+| Step | Runbook text | Literal? | Measured result |
+| --- | --- | --- | --- |
+| 1 | `docker compose stop indexer` | **LITERAL** | returned in **1.10s** (grace period 45s never approached). **No `shutdown.complete`** — see finding 7 |
+| 2 | `node …/index-runner.mjs verify ./data/indexer-state.json` | **SUBSTITUTED — the printed form is broken under Docker** | run inside a one-off container against `/data/…`. See finding 6 |
+| 3 | `mv … .bad-$(date +%s)` | **SUBSTITUTED** (same reason — container-side path) | bad file preserved; did **not** consume a ring slot |
+| 4 | `cp ./data/indexer-state.json.1 …` | **SUBSTITUTED** (same reason), **and deliberately took `.3`, not `.1`** | restored file **sha256-identical** to the rung: `b1a9f75e9d197b433fe7bfeefc4ef994d880700c1fdcd82596ba9c286b02730d` |
+| 5 | `verify` the restored file | **SUBSTITUTED** (same reason) | `OK`, exit 0, cursor `lastBlock=46303007` |
+| 6 | `docker compose start indexer` | **LITERAL** | returned in **0.59s**; `resumed at block 46303007 (3 vaults)` |
+
+So: **2 of 6 literal, 4 substituted — but the substitution is the opposite of last time.** In
+2026-08-30 steps 1/6 were impossible and 2–5 ran as printed. Here steps 1/6 ran exactly as
+printed and **2–5 could not**, because the paths they name do not exist on the host under the
+Docker deployment the same document prescribes. That is finding 6, and it is new.
+
+### 10.2 Drill A — the aged rung, at the full documented horizon
+
+Ring left at **production defaults** this time (`SNAPSHOT_BACKUPS=3`,
+`SNAPSHOT_BACKUP_INTERVAL_MS=300000`) and allowed to run 20 minutes, so `.3` reached the
+documented 15-minute horizon instead of the 2026-08-30 run's 81 seconds:
+
+```
+indexer-state.json     18:53:37   lastBlock=46303459
+indexer-state.json.1   18:48:52   lastBlock=46303309
+indexer-state.json.2   18:43:51   lastBlock=46303160
+indexer-state.json.3   18:38:46   lastBlock=46303007   <- restored from THIS
+```
+
+`.3` was **14m50s old** when the writer was stopped and **16m17s old** when it was copied into
+place. Truncating the live file to 900 bytes gave `UNUSABLE — Unterminated string in JSON at
+position 900`, exit **1**, with all three healthy rungs still summarised.
+
+After the literal `docker compose start indexer`:
+
+```
+{"event":"indexer.progress","msg":"resumed at block 46303007 (3 vaults)"}
+{"event":"starting","knownVaults":3,"resumeBlock":46303008,"backups":3}
+{"event":"indexer.progress","msg":"indexed [46303008..46303507] — 0 events, now at 46303507"}
+```
+
+`knownVaults:3` seeded **from the restored file** — the load-bearing line. **452 blocks (~15
+minutes of chain) rewound and closed in a single 0.68s batch**, well inside one `BATCH_BLOCKS`
+window. Counts identical across the whole exercise: `vaults=3 operators=1 proposals=4
+shareBooks=3 holders=2 activeProposals=2 adapters=1`. **Stop → caught up: 87.3s**, nearly all of
+it the operator running steps 2–5.
+
+**The API was watching, which §6 said had never been tested.** During the outage
+`vault_api_snapshot_reload_failures_total` climbed 0 → 2 → 4 → 6 while
+`vault_indexer_last_block` **stayed frozen at the last good value** and `/vaults` kept answering
+(HTTP 402, i.e. alive and challenging normally). After the restore the counter stopped climbing
+and `last_block` advanced to 46303520. **§8.3's stale-serving claim holds under a real reader**,
+and the copy-not-rename discipline never left the reader without a file.
+
+### 10.3 Drill C — a kill *during* a write. This is the §6 item that was open.
+
+The 2026-08-30 drill could not answer this: its kill landed 2.4s after a completed write. The
+window was **measured** first rather than guessed. With a 59.8MB snapshot being rewritten
+back-to-back, a tight sampling loop found `indexer-state.json.tmp` present in **515 of 63,557
+samples = 0.81% of wall time** (~6ms per write). That is why randomly-timed kills miss: roughly
+1 in 123.
+
+Two design corrections were needed, and both are worth recording because they invalidate the
+obvious approach:
+
+1. **`docker kill` does not hit the writer.** PID 1 under `npm run start:indexer` is **npm**;
+   node is a grandchild. A signal to PID 1 lets the real writer run on. The probe therefore ran
+   node **as PID 1**.
+2. **Random timing cannot land a 6ms window.** Instead the container was **frozen**
+   (`docker pause`, cgroup freezer) at randomised instants and inspected while frozen. A `.tmp`
+   present at the freeze proves the process is between `writeFile()` and `rename()`; SIGKILL
+   there is a kill inside the write window *by construction*. A frozen-then-killed process leaves
+   exactly the on-disk state a crash at that instant leaves.
+
+```
+SUMMARY freezes=601 kills_landed_in_write_window=6 live_OK_after=6 live_CORRUPT_after=0
+        zero_length_rung=0 mid_rotation_freezes=26
+```
+
+The six landings caught the temp file at **18.3 MB, 28.3 MB, 33.0 MB, 57.7 MB and 59.77 MB** of
+59,855,231 — the last one **99.86% written, immediately before the rename**. In every case the
+live snapshot afterwards was `OK`, and the partial data was stranded in the `.tmp` where it
+belongs. **Atomicity of `atomicWriteFile` is proven under a kill in flight**, which §6 explicitly
+left open.
+
+**Still NOT proven: the ring rotation under a crash.** `rotateBackups` is *not* atomic
+(`rm .3`, `rename .2→.3`, `rename .1→.2`, `copyFile live→.1`) and its window is much wider — the
+probe observed it in **26 of 601 freezes (4.3%)** — but the probe only triggered its kill on the
+`.tmp` signature, so **no kill was ever landed inside a rotation**. The window is measured; the
+behaviour is not tested. Stated plainly rather than inferred from the `.tmp` result.
+
+### 10.4 Drill D — production scale
+
+§6 asked for materially more than 630 bytes / 1 vault. Built by scaling the **real chain-derived
+snapshot** — the vault and operator records are verbatim copies of the ones the live indexer
+folded from Base Sepolia; only the addresses and the holder book are synthetic — and
+round-tripped through the indexer's **own** `deserializeState`/`serializeState`, so what landed on
+disk is what the real writer produces, not hand-authored JSON.
+
+**59,855,231 bytes · 7 vaults · 1,050,000 holders** (the 2026-08-30 drill: 630 bytes, 1 vault):
+
+- `verify` parsed the live file **and all three 59.8MB rungs in 2.67s**, counts exact.
+- Truncated to 5,000,000 bytes → `UNUSABLE`; `mv` to `.bad-`; `cp .1` in → **sha256-identical**
+  (`d3a9b436ce3299fe150705fea799debd1d644e510f0fab8815416f916e870916`).
+- Restarted → `resumed at block 46111530 (7 vaults)`, `knownVaults:7` seeded from the restored
+  file, 13 batches indexed.
+
+**Scoped honestly:** this proves parse, fold, seed and restore at scale. The vault addresses are
+synthetic, so it does **not** prove anything about chain behaviour at 7 real vaults.
+
+### 10.5 Findings (continuing §5's numbering)
+
+**6. Steps 2–5 name host paths that do not exist under the Docker deployment the same procedure
+prescribes — and the failure is dangerously misleading.** Steps 1 and 6 are container commands;
+steps 2–5 are host commands against `./data/indexer-state.json`. Under Compose that state lives
+in the **named volume**, so there is no `./data` on the host at all. Run exactly as printed while
+the stack was healthy, step 2 said:
+
+```
+snapshot ./data/indexer-state.json: UNUSABLE — no snapshot at ./data/indexer-state.json — a fresh indexer would start from START_BLOCK
+  backups     none on disk (SNAPSHOT_BACKUPS=0, or none taken yet)
+EXIT=1
+```
+
+Both the live file and a **healthy 3-rung ring** were sitting safely in the volume at that moment.
+An operator following the runbook verbatim under incident pressure is told their snapshot is gone
+and their ring is empty, and is pointed at the "if every backup is bad, rebuild from
+`START_BLOCK`" path — a multi-hour re-index — when nothing was actually wrong. This is the
+highest-severity documentation defect the drill found. **Fix: give steps 2–5 their container
+forms** (`docker compose exec` / a one-off `docker run` against `/data/…`), as steps 1 and 6
+already assume.
+
+**7. `docker compose stop` never runs any shutdown hook, for any of the three services.** This is
+a code/config defect, not a documentation one, and it is new. `docker-compose.yml` sets
+`command: npm run start:indexer`, so **PID 1 is npm**; npm receives SIGTERM, dies with
+`npm error signal SIGTERM`, and **does not forward the signal** to the node child. A/B on the
+same image, same volume, same signal, same 45s grace:
+
+| PID 1 | `docker stop -t 45` took | Shutdown lines |
+| --- | --- | --- |
+| `npm run start:indexer` (**what ships**) | 917 ms | none — only `npm error signal SIGTERM` |
+| `node packages/indexer/src/index-runner.mjs` | 427 ms | `shutdown.begin` → `shutdown.step indexer.finish-batch-and-snapshot ok:true` → `shutdown.complete` |
+
+The hooks are **correct code that is never reached**. Consequences, all confirmed on the live
+stack:
+
+- The indexer does **not** finish its batch or take a final snapshot on stop. The ring was
+  **not** pushed along by one — §5 finding 3's untested note about a clean shutdown is now
+  testable and, as shipped, **does not happen**.
+- `stop_grace_period` (indexer 45s, api 30s, canary 60s) is **dead configuration**. Every stop
+  returned in ~1s.
+- The canary's `canary.flush-transitions` hook never runs (`docker compose stop canary`: 1.11s,
+  zero `shutdown.complete`). Bounded, though: `flush()` also runs after **every** sweep, so at
+  most one 30s sweep of transitions is lost — not the full re-page storm the hook exists to
+  prevent.
+- The API never drains in-flight responses.
+
+This also revises §5 finding 2 / §9 item 1. Their conclusion — the hooks are fine and merely
+unreachable **on Windows** — was half right. They are unreachable **under Docker on Linux too**,
+for an unrelated reason. **Fix: run the process directly** (`command: ["node", "packages/…"]`) or
+add an init that forwards signals.
+
+**8. The off-host volume backup command backs up nothing, and exits 0.** RUNTIME.md §8.3 prints a
+`docker run --rm -v vault-state:/data … alpine tar czf …` one-liner. Compose namespaces volumes as
+`<project>_<volume>`, and the project name defaults to the directory name — here
+`x402-gate7_vault-state`, never the bare `vault-state`. Docker happily **creates a new empty
+volume** with that name and tars it. Run verbatim, it produced an **87-byte archive containing one
+entry, `./`**, and **exit 0**. A backup that silently succeeds and contains nothing is worse than
+one that fails.
+
+Corrected to the real volume name, the command works and — tested beyond what the runbook asks —
+**is genuinely restorable**: the archive captured the live file, all three indexer rungs, both
+canary rungs and the heartbeats; extracted into a **fresh volume**, `verify` reported the indexer
+snapshot `OK` (exit 0, ring intact) and the canary state `OK` (exit 0, 48 signals). Taken while
+all three services were running, it was consistent — no `.tmp` was captured. **Fix: print the
+`<project>_vault-state` name, or `docker volume ls` to find it.**
+
+**9. `verify` OOMs on a very large snapshot under a small memory cap.** At 59.8MB, the shipped
+command works on an unconstrained host but dies under `-m 512m` with
+`FATAL ERROR: Ineffective mark-compacts near heap limit`. It parses the live file **plus all
+three rungs**, so peak heap is roughly four copies. **Bounded honestly:** at §8.3's own documented
+scale (7 vaults / 64 holders, and the 30.7KB equivalent here) it is fine under the same 512MB
+cap. This is a headroom note for a far-future deployment size, not a launch issue.
+
+**10. The indexer puts every known vault into one `eth_getLogs` filter, and it does not scale.**
+Surfaced by the scale work: with 200 known vaults the public RPC rejected every poll with
+`Invalid parameters were provided to the RPC method`, and the indexer **never advanced and never
+wrote a snapshot** — a permanent `poll.failed` loop, not a degraded mode. At 7 vaults it is fine.
+Not a restore finding and out of scope here, but it is a hard ceiling on vault count that should
+be its own issue.
+
+**11. A crash leaves an orphaned `.tmp` that nothing ever cleans up.** Each of the six landed
+kills left a `<state>.tmp` of up to 59.77MB behind. Nothing removes it on the next start. It does
+**not** corrupt anything or consume a ring slot (`listBackups` walks `.1..N` only), so this is
+hygiene, not correctness — but on a real snapshot size it is a silent disk leak after every crash.
+
+**12. `docker compose up` partially succeeded on a port collision.** With something already bound
+to `:8402`, `up -d` started `indexer` and `canary`, then failed on `api` — leaving a half-up stack
+and a non-zero exit. Worth an operator note; not a restore defect.
+
+### 10.6 What is proven, what is not, and what was not attempted
+
+**Proven by this drill (new):**
+- Steps 1 and 6 run **literally** under Compose on a real Linux engine — the row's stated condition.
+- Restore from a **15-minute-aged rung** at the documented production horizon (`.3`, 14m50s at stop).
+- Restore at **production scale** — 59.8MB, 7 vaults, 1,050,000 holders, byte-identical, reseeded.
+- **Atomicity under a kill in flight** — 6 SIGKILLs inside the write window, 6/6 live files `OK`.
+- The **off-host tar is restorable** into a fresh volume (with the corrected volume name).
+- The **API's behaviour during the outage** — stale-serving, failure counter climbing, still serving.
+- The canary restore at **48 signals** with zero re-pages (2026-08-30 proved it at 8).
+
+**NOT proven:**
+- **Graceful shutdown — and now known to be broken as shipped** (finding 7). This is the one §6
+  item that got *worse*, not better: it is no longer "untested", it is **tested and failing**.
+- **Ring rotation under a crash.** Window measured (4.3% of wall time); no kill was landed in it.
+- **Correctness of the projection.** `verify` is still only a parseability check; a wrongly-folded
+  state verifies clean. Unchanged from §6.
+- Anything adversarial. Unchanged.
+
+**Not attempted:**
+- The "every backup is bad" rebuild-from-`START_BLOCK` path (beyond incidental cold starts).
+- `docker compose down`/`restart` as distinct from `stop`/`start`.
+- Any mainnet or non-Sepolia behaviour.
+
+### 10.7 Discipline
+
+Read-only against Base Sepolia via `https://base-sepolia-rpc.publicnode.com`: **no key, no funded
+account, no `--broadcast`, no transaction**. All state lived in throwaway Compose volumes under
+`-p gate7drill` / `-p gate7kill`, never the repo's `./data/`, and every volume and container was
+destroyed afterwards. `.env` and `drill-scratch/` are untracked scratch. **No tracked file was
+modified to make this drill pass** — `git status` after the drill showed only untracked
+`drill-scratch/`. The only tracked change in this PR is this section.
+
+**On the gate 7 row itself: this report does not change it.** Changing a gate verdict is the
+owner's call. What this drill hands over is: the row's stated condition is met, four of five §6
+gaps are closed, and three defects in the runbook and Compose config (findings 6, 7, 8) are open
+and are the honest reason not to turn the row green on this evidence alone. Fixing those three is
+documentation and one `command:` line; the restore mechanics underneath them are now proven more
+thoroughly than the row ever asked for, so a re-drill should not be needed to close it afterwards.

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -624,8 +624,9 @@ SUMMARY freezes=601 kills_landed_in_write_window=6 live_OK_after=6 live_CORRUPT_
         zero_length_rung=0 mid_rotation_freezes=26
 ```
 
-The six landings caught the temp file at **18.3 MB, 28.3 MB, 33.0 MB, 57.7 MB and 59.77 MB** of
-59,855,231 — the last one **99.86% written, immediately before the rename**. In every case the
+The six landings caught the temp file at **14.2 MB, 18.3 MB, 28.3 MB, 33.0 MB, 57.7 MB and
+59.77 MB** of 59,855,231 — the largest **99.86% written, immediately before the rename**, the
+smallest less than a quarter in. In every case the
 live snapshot afterwards was `OK`, and the partial data was stranded in the `.tmp` where it
 belongs. **Atomicity of `atomicWriteFile` is proven under a kill in flight**, which §6 explicitly
 left open.

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -735,7 +735,10 @@ Surfaced by the scale work: with 200 known vaults the public RPC rejected every 
 `Invalid parameters were provided to the RPC method`, and the indexer **never advanced and never
 wrote a snapshot** — a permanent `poll.failed` loop, not a degraded mode. At 7 vaults it is fine.
 Not a restore finding and out of scope here, but it is a hard ceiling on vault count that should
-be its own issue.
+be its own issue. **Checked against current `protocol/main` (`0c196581`, after #120):** that PR
+adds `MAX_TRACKED_ADAPTERS` to bound the discovered *adapter* set, but the *vault* set feeding the
+same filter (`rpc.mjs`, `const vaults = new Set([...knownVaults]…)`) is still unbounded, so this
+finding stands on the current tree.
 
 **11. A crash leaves an orphaned `.tmp` that nothing ever cleans up.** Each of the six landed
 kills left a `<state>.tmp` of up to 59.77MB behind. Nothing removes it on the next start. It does


### PR DESCRIPTION
Docker Desktop (WSL2, **Linux** engine — server 29.7.2, overlayfs, Compose v5.4.0) is now working, which was the exact condition `docs/LAUNCH-READINESS.md` named for gate 7. This re-runs the `RUNTIME.md` §8.3 restore drill with **steps 1 and 6 as the literal `docker compose stop/start`**, against the shipped Compose stack with `indexer`, `api` and `canary` all up.

**Docs only.** No code changed, no gate row touched, read-only against Base Sepolia — no key, no funded account, no transaction.

## Steps 1 and 6 were literal

`docker compose -p gate7drill stop indexer` / `start indexer`. The `-p` scopes the project to a throwaway volume so a concurrent session's state could not be touched; it changes the project name, not stop/start semantics.

## Closes four of the five gaps §6 listed as untested

| §6 gap | Now |
| --- | --- |
| a 15-minute-aged rung | **Closed** — ring at production defaults for 20 min; restored from `.3` at **14m50s** old, byte-identical, 452-block rewind closed in one 0.68s batch |
| production-scale state | **Closed** — **59,855,231 bytes / 7 vaults / 1,050,000 holders**, restored sha256-identical, daemon reseeded `knownVaults:7` |
| atomicity under a kill in flight | **Closed — PROVEN** — see below |
| the off-host volume tar | **Closed** — restorable into a fresh volume (with the corrected volume name) |
| graceful shutdown | **Got worse: no longer untested, now tested and FAILING** — finding 7 |

### The atomicity kill, which the 2026-08-30 drill could not land

The write window was **measured** rather than guessed: `<state>.tmp` is present in **515 of 63,557 samples = 0.81% of wall time** (~6ms), so random kills miss ~122 times in 123. Two corrections made it landable — PID 1 under `npm run start:*` is **npm**, not the writer, so the probe ran node as PID 1; and instead of random timing the container was **frozen** (`docker pause`) at randomised instants and killed **only when `.tmp` was present**, which puts the kill inside the write window by construction.

**601 freezes → 6 kills landed inside the write window → live snapshot parsed `OK` all 6 times**, catching the temp file at 14.2 / 18.3 / 28.3 / 33.0 / 57.7 / **59.77 MB** of 59.86 MB (the last 99.86% written, immediately before the rename). Partial data stranded in `.tmp` every time.

## Three defects found by running literally — all new

1. **Steps 2–5 name host paths that do not exist under the Docker deployment the same procedure prescribes.** Steps 1/6 are container commands; 2–5 are host commands against `./data/…`, which under Compose lives in the named volume. Run verbatim on a **healthy** stack, step 2 reports `UNUSABLE — no snapshot … a fresh indexer would start from START_BLOCK` and `backups none on disk`, exit 1 — while the live file and a healthy 3-rung ring sit safely in the volume. Under incident pressure that points the operator at a multi-hour rebuild for no reason. Highest-severity finding here.

2. **`docker compose stop` never runs a shutdown hook, for any of the three services.** `command: npm run start:*` makes **npm** PID 1, and npm does not forward SIGTERM. A/B on the same image, volume, signal and 45s grace:

   | PID 1 | stop took | Shutdown lines |
   | --- | --- | --- |
   | `npm run start:indexer` (**ships**) | 917 ms | none — only `npm error signal SIGTERM` |
   | `node packages/indexer/…` | 427 ms | `shutdown.begin` → `shutdown.step … ok:true` → `shutdown.complete` |

   The hooks are correct code that is never reached. `stop_grace_period` (45/30/60s) is dead config; no final snapshot; the ring is **not** pushed along by one. This also revises §5 finding 2 / §9 item 1 — their "the hooks are fine, just unreachable **on Windows**" was half right; they are unreachable under Docker on Linux too, for an unrelated reason.

3. **The off-host tar command backs up nothing and exits 0.** It names the bare `vault-state`, but Compose namespaces volumes `<project>_<volume>`. Docker creates a new empty volume and tars it: an **87-byte archive containing one entry, `./`**, exit 0.

Plus three adjacent notes (`verify` OOMs at 59.8 MB under `-m 512m`; the indexer puts every known vault in one `eth_getLogs` filter and dies at 200 vaults — **still unbounded after #120, which capped adapters but not vaults**; and a crash leaves an orphaned `.tmp` nothing cleans up).

## Gate 7

The row's **stated** condition — re-run steps 1/6 under Compose — **is met**, and the restore mechanics are now proven well past what it asked for. But running literally exposed findings 1–3 above, so I am **not** claiming the row should go green on this evidence alone, and I have deliberately left the row unchanged. Fixing those three is documentation plus one `command:` line; the mechanics under them are proven, so closing the row afterwards should not need another full drill.

**This needs a fresh independent verdict — I am not self-merging.**
