### PR TITLE
site: add social-sharing and discovery metadata to the six page heads

### DIFF
--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -6,7 +6,14 @@ Six static HTML pages describing the Agent-Governed Vaults protocol: `index.html
 No build step. No framework. **Zero JavaScript** — there is not a single `<script>` tag, so "works
 with JavaScript disabled" is true by construction rather than by testing. No external requests of
 any kind: no webfonts, no CDN, no analytics, no trackers, no remote images. System font stacks only.
-The only off-site link anywhere is the project's own GitHub repository.
+The only off-site link a reader can follow is the project's own GitHub repository.
+
+Two kinds of absolute URL do appear in each `<head>`, and neither is a request or a link: the social
+preview tags (`og:`/`twitter:`), which are `content` attributes, and each page's own
+`rel="canonical"`, which points at this site's public host `rwally.com`. A canonical fetches nothing
+and navigates nowhere; it is metadata that happens to be spelled with an `href`. It is the single
+exemption to the no-external-host rule below, and it is written down in the test beside the code
+that grants it.
 
 There is deliberately **no `package.json` in this directory**. `apps/*` is an npm workspace glob and
 adding one changes what `npm ci` installs at the root.
@@ -77,7 +84,9 @@ has no compiler; that file is the compiler. It asserts, across all six pages:
   ending in ` — Agent-Governed Vaults`, and at least one COUNSEL marker.
 - **Zero JavaScript**: no `<script` tag and no inline event-handler attribute.
 - **No external host** in any `src`/`href` other than the project's GitHub repository, with explicit
-  checks against `fonts.googleapis.com` and `fonts.gstatic.com`.
+  checks against `fonts.googleapis.com` and `fonts.gstatic.com`. Exactly one exemption:
+  `rel="canonical"` pointing at `rwally.com`, which loads no resource and is not a link a reader can
+  follow. Any other `rel` still fails, and so does a canonical pointing at any other host.
 - No raw hex colour in `site.css`, and the full token set present in `tokens.css`. `site.css` may not
   set `display:none`, `visibility:hidden`, `height:0` or `font-size:0` on `.pre-launch`.
 - Every internal `.html` link resolves to a file on disk.

--- a/apps/site/faq.html
+++ b/apps/site/faq.html
@@ -7,12 +7,12 @@
 <meta name="description" content="Direct answers to the hard questions: is there a token, is it running anywhere, can you rug me, can I always get out, what does the operator earn, and what licence the code is under.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
-<link rel="canonical" href="https://rwally.com/faq.html">
+<link rel="canonical" href="https://rwally.com/faq">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
-<meta property="og:url" content="https://rwally.com/faq.html">
+<meta property="og:url" content="https://rwally.com/faq">
 <meta property="og:title" content="Questions, answered the way they were asked">
 <meta property="og:description" content="Can you rug me, can you pause it, can I always get out, what does the operator earn, what licence is the code under. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">

--- a/apps/site/faq.html
+++ b/apps/site/faq.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Direct answers to the hard questions: is there a token, is it running anywhere, can you rug me, can I always get out, what does the operator earn, and what licence the code is under.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/faq.html">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">

--- a/apps/site/faq.html
+++ b/apps/site/faq.html
@@ -7,6 +7,20 @@
 <meta name="description" content="Direct answers to the hard questions: is there a token, is it running anywhere, can you rug me, can I always get out, what does the operator earn, and what licence the code is under.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/faq.html">
+<meta property="og:title" content="Questions, answered the way they were asked">
+<meta property="og:description" content="Can you rug me, can you pause it, can I always get out, what does the operator earn, what licence is the code under. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Questions, answered the way they were asked">
+<meta name="twitter:description" content="Can you rug me, can you pause it, can I always get out, what does the operator earn, what licence is the code under. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/how-it-works.html
+++ b/apps/site/how-it-works.html
@@ -7,12 +7,12 @@
 <meta name="description" content="The full mechanism: deposit and observation window, commit-reveal voting, timelock and execution, in-kind pro-rata exit, the two settlement modes, the fee schedule and the Chainlink oracle.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
-<link rel="canonical" href="https://rwally.com/how-it-works.html">
+<link rel="canonical" href="https://rwally.com/how-it-works">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
-<meta property="og:url" content="https://rwally.com/how-it-works.html">
+<meta property="og:url" content="https://rwally.com/how-it-works">
 <meta property="og:title" content="How it works, mechanism by mechanism">
 <meta property="og:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, invariants and parameters labelled apart. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">

--- a/apps/site/how-it-works.html
+++ b/apps/site/how-it-works.html
@@ -7,6 +7,20 @@
 <meta name="description" content="The full mechanism: deposit and observation window, commit-reveal voting, timelock and execution, in-kind pro-rata exit, the two settlement modes, the fee schedule and the Chainlink oracle.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/how-it-works.html">
+<meta property="og:title" content="How it works, mechanism by mechanism">
+<meta property="og:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, with invariants and parameters labelled apart. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How it works, mechanism by mechanism">
+<meta name="twitter:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, with invariants and parameters labelled apart. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/how-it-works.html
+++ b/apps/site/how-it-works.html
@@ -7,18 +7,19 @@
 <meta name="description" content="The full mechanism: deposit and observation window, commit-reveal voting, timelock and execution, in-kind pro-rata exit, the two settlement modes, the fee schedule and the Chainlink oracle.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/how-it-works.html">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
 <meta property="og:url" content="https://rwally.com/how-it-works.html">
 <meta property="og:title" content="How it works, mechanism by mechanism">
-<meta property="og:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, with invariants and parameters labelled apart. Not deployed to mainnet.">
+<meta property="og:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, invariants and parameters labelled apart. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">
 <meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="How it works, mechanism by mechanism">
-<meta name="twitter:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, with invariants and parameters labelled apart. Not deployed to mainnet.">
+<meta name="twitter:description" content="Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, invariants and parameters labelled apart. Not deployed to mainnet.">
 <meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
 <!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Members pool USDC into a spot basket and ratify every rebalance by on-chain vote. As written, the contracts contain no proxy, no admin key, no pause and no seize function — and no way to patch a bug once it ships. Not deployed to mainnet.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -7,6 +7,20 @@
 <meta name="description" content="Members pool USDC into a spot basket and ratify every rebalance by on-chain vote. As written, the contracts contain no proxy, no admin key, no pause and no seize function — and no way to patch a bug once it ships. Not deployed to mainnet.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/">
+<meta property="og:title" content="No admin key. No pause. No upgrade. No undo.">
+<meta property="og:description" content="Members pool USDC into a spot basket and ratify every rebalance by on-chain vote. No admin key, no pause, no upgrade. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="No admin key. No pause. No upgrade. No undo.">
+<meta name="twitter:description" content="Members pool USDC into a spot basket and ratify every rebalance by on-chain vote. No admin key, no pause, no upgrade. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/operators.html
+++ b/apps/site/operators.html
@@ -7,6 +7,20 @@
 <meta name="description" content="What an agent-operator can and cannot do, the two separate 5% mechanisms that lock capital and decay proposal rights, and why the operator identity can never be rotated.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/operators.html">
+<meta property="og:title" content="Operators: low capital cost, not no capital cost">
+<meta property="og:description" content="An operator proposes rebalances and votes its own weight. Two separate 5% mechanisms lock capital and decay proposal rights. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Operators: low capital cost, not no capital cost">
+<meta name="twitter:description" content="An operator proposes rebalances and votes its own weight. Two separate 5% mechanisms lock capital and decay proposal rights. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/operators.html
+++ b/apps/site/operators.html
@@ -7,6 +7,7 @@
 <meta name="description" content="What an agent-operator can and cannot do, the two separate 5% mechanisms that lock capital and decay proposal rights, and why the operator identity can never be rotated.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/operators.html">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">

--- a/apps/site/operators.html
+++ b/apps/site/operators.html
@@ -7,12 +7,12 @@
 <meta name="description" content="What an agent-operator can and cannot do, the two separate 5% mechanisms that lock capital and decay proposal rights, and why the operator identity can never be rotated.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
-<link rel="canonical" href="https://rwally.com/operators.html">
+<link rel="canonical" href="https://rwally.com/operators">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
-<meta property="og:url" content="https://rwally.com/operators.html">
+<meta property="og:url" content="https://rwally.com/operators">
 <meta property="og:title" content="Operators: low capital cost, not no capital cost">
 <meta property="og:description" content="An operator proposes rebalances and votes its own weight. Two separate 5% mechanisms lock capital and decay proposal rights. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">

--- a/apps/site/risks.html
+++ b/apps/site/risks.html
@@ -7,6 +7,20 @@
 <meta name="description" content="Fifteen named risks, each with what it is, the worst realistic case, and what is actually done about it — including the ones where the answer is that nothing is done.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/risks.html">
+<meta property="og:title" content="Fifteen ways this hurts you">
+<meta property="og:description" content="Fifteen named risks, with the worst realistic case for each. Seven have no mitigation and are marked accepted, not buried. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Fifteen ways this hurts you">
+<meta name="twitter:description" content="Fifteen named risks, with the worst realistic case for each. Seven have no mitigation and are marked accepted, not buried. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/risks.html
+++ b/apps/site/risks.html
@@ -7,12 +7,12 @@
 <meta name="description" content="Fifteen named risks, each with what it is, the worst realistic case, and what is actually done about it — including the ones where the answer is that nothing is done.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
-<link rel="canonical" href="https://rwally.com/risks.html">
+<link rel="canonical" href="https://rwally.com/risks">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
-<meta property="og:url" content="https://rwally.com/risks.html">
+<meta property="og:url" content="https://rwally.com/risks">
 <meta property="og:title" content="Fifteen ways this hurts you">
 <meta property="og:description" content="Fifteen named risks, with the worst realistic case for each. Seven have no mitigation and are marked accepted, not buried. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">

--- a/apps/site/risks.html
+++ b/apps/site/risks.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Fifteen named risks, each with what it is, the worst realistic case, and what is actually done about it — including the ones where the answer is that nothing is done.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/risks.html">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">

--- a/apps/site/test/site.test.mjs
+++ b/apps/site/test/site.test.mjs
@@ -301,27 +301,51 @@ test('zero JavaScript: no script tags, no event handler attributes', () => {
  * Both halves of the exemption are load-bearing and deliberately narrow. `rel="canonical"` ONLY --
  * any other `rel` (stylesheet, preload, icon) still fails, because those DO load. And
  * CANONICAL_HOST ONLY -- a canonical pointing anywhere else is not exempt and still fails.
+ *
+ * TWO WAYS THIS WAS WRONG WHEN FIRST WRITTEN, BOTH FOUND IN REVIEW, BOTH WORTH RECORDING:
+ *
+ * It matched the host with `startsWith('https://rwally.com')`, so `https://rwally.com.attacker.
+ * example/x` prefixed it and was exempt. The host is now parsed with `new URL` and compared for
+ * EQUALITY. Never re-narrow this to a string prefix: a prefix of a hostname is a different
+ * hostname, and the attacker picks the suffix.
+ *
+ * It exempted href VALUES rather than the tags carrying them, so any `src` or `href` anywhere on
+ * the page that happened to equal an exempted value inherited the exemption -- including a
+ * `rel="stylesheet"`, which does load. Composed with the prefix bug, a stylesheet pulling from a
+ * foreign host passed this gate green. The exempt canonical tags are now REMOVED from the markup
+ * before the scan, so the exemption cannot spread past the tag it was written for.
+ *
+ * The shape of the mistake, since it will recur: an exemption narrowed by describing it in a
+ * comment rather than by encoding it. Both sentences above were in the file, and both were false
+ * as implemented. Test the exemption's edges with a probe, not with prose.
  */
-const canonicalHrefs = (html) => {
-  const out = new Set();
-  for (const tag of html.match(/<link\b[^>]*>/gi) ?? []) {
-    if (!/\brel\s*=\s*"canonical"/i.test(tag)) continue;
-    const href = tag.match(/\bhref\s*=\s*"([^"]*)"/i)?.[1];
-    if (href && href.toLowerCase().startsWith(`https://${CANONICAL_HOST}`)) out.add(href);
+const isExemptCanonical = (tag) => {
+  if (!/\brel\s*=\s*"canonical"/i.test(tag)) return false;
+  const href = tag.match(/\bhref\s*=\s*"([^"]*)"/i)?.[1];
+  if (!href) return false;
+  let u;
+  try {
+    u = new URL(href);
+  } catch {
+    return false; // relative or malformed: not exempt, and the host rule ignores it anyway
   }
-  return out;
+  return u.protocol === 'https:' && u.host.toLowerCase() === CANONICAL_HOST;
 };
+
+/** The markup with the exempt canonical tags removed, so the scan below never sees them. */
+const withoutExemptCanonicals = (html) =>
+  html.replace(/<link\b[^>]*>/gi, (tag) => (isExemptCanonical(tag) ? ' ' : tag));
 
 test('no external requests: the only permitted remote host is the project repository', () => {
   for (const p of PAGES) {
     const html = raw.get(p) ?? '';
     assert.ok(!/fonts\.googleapis\.com/i.test(html), `${p}: references fonts.googleapis.com`);
     assert.ok(!/fonts\.gstatic\.com/i.test(html), `${p}: references fonts.gstatic.com`);
-    const exempt = canonicalHrefs(html);
-    for (const m of html.matchAll(/(?:src|href)\s*=\s*"([^"]*)"/gi)) {
+    // Scan the markup with the exempt canonical tags removed, rather than skipping matching
+    // href VALUES: a value-scoped skip leaks the exemption to any other tag carrying the same URL.
+    for (const m of withoutExemptCanonicals(html).matchAll(/(?:src|href)\s*=\s*"([^"]*)"/gi)) {
       const v = m[1];
       if (!/^(?:https?:)?\/\//i.test(v)) continue; // relative or fragment: fine
-      if (exempt.has(v)) continue; // this page's own canonical -- loads nothing, navigates nowhere
       const host = v.replace(/^(?:https?:)?\/\//i, '').split('/')[0].toLowerCase();
       assert.equal(host, ALLOWED_HOST, `${p}: external host ${host} is not permitted`);
     }

--- a/apps/site/test/site.test.mjs
+++ b/apps/site/test/site.test.mjs
@@ -52,7 +52,7 @@ const TITLE_SUFFIX = ' — Agent-Governed Vaults';
 // The only external host any page may reference.
 const ALLOWED_HOST = 'github.com';
 
-// The site's own public host, and the ONE exemption to the rule above -- see canonicalHrefs().
+// The site's own public host, and the ONE exemption to the rule above -- see isExemptCanonical().
 const CANONICAL_HOST = 'rwally.com';
 
 /** Phrases banned on every page, everywhere, with no exception. */

--- a/apps/site/test/site.test.mjs
+++ b/apps/site/test/site.test.mjs
@@ -52,6 +52,9 @@ const TITLE_SUFFIX = ' — Agent-Governed Vaults';
 // The only external host any page may reference.
 const ALLOWED_HOST = 'github.com';
 
+// The site's own public host, and the ONE exemption to the rule above -- see canonicalHrefs().
+const CANONICAL_HOST = 'rwally.com';
+
 /** Phrases banned on every page, everywhere, with no exception. */
 const BANNED = [
   /\bAPY\b/i,
@@ -280,14 +283,45 @@ test('zero JavaScript: no script tags, no event handler attributes', () => {
   }
 });
 
+/**
+ * The href values exempted from the host rule below: `rel="canonical"` links pointing at this
+ * site's own public host. This is the ONLY exemption, and it exists for a reason worth writing
+ * down rather than leaving to be reconstructed.
+ *
+ * The invariant the host rule protects is that a page LOADS nothing from anywhere and NAVIGATES
+ * off-site only to the project repository. A canonical link does neither: it fetches no resource,
+ * and it is not a link a reader can follow -- it is metadata that happens to be spelled with an
+ * `href` rather than a `content` attribute, which is why `og:url` needs no exemption and this does.
+ *
+ * It also cannot be written any other way. A RELATIVE canonical would pass this check untouched
+ * and is worse than having none at all, because it cannot do the one job canonicals exist for:
+ * collapsing www/non-www, http/https and trailing-slash duplicates of a page onto one URL. An
+ * exemption that lets the correct form ship beats a check that only permits the useless form.
+ *
+ * Both halves of the exemption are load-bearing and deliberately narrow. `rel="canonical"` ONLY --
+ * any other `rel` (stylesheet, preload, icon) still fails, because those DO load. And
+ * CANONICAL_HOST ONLY -- a canonical pointing anywhere else is not exempt and still fails.
+ */
+const canonicalHrefs = (html) => {
+  const out = new Set();
+  for (const tag of html.match(/<link\b[^>]*>/gi) ?? []) {
+    if (!/\brel\s*=\s*"canonical"/i.test(tag)) continue;
+    const href = tag.match(/\bhref\s*=\s*"([^"]*)"/i)?.[1];
+    if (href && href.toLowerCase().startsWith(`https://${CANONICAL_HOST}`)) out.add(href);
+  }
+  return out;
+};
+
 test('no external requests: the only permitted remote host is the project repository', () => {
   for (const p of PAGES) {
     const html = raw.get(p) ?? '';
     assert.ok(!/fonts\.googleapis\.com/i.test(html), `${p}: references fonts.googleapis.com`);
     assert.ok(!/fonts\.gstatic\.com/i.test(html), `${p}: references fonts.gstatic.com`);
+    const exempt = canonicalHrefs(html);
     for (const m of html.matchAll(/(?:src|href)\s*=\s*"([^"]*)"/gi)) {
       const v = m[1];
       if (!/^(?:https?:)?\/\//i.test(v)) continue; // relative or fragment: fine
+      if (exempt.has(v)) continue; // this page's own canonical -- loads nothing, navigates nowhere
       const host = v.replace(/^(?:https?:)?\/\//i, '').split('/')[0].toLowerCase();
       assert.equal(host, ALLOWED_HOST, `${p}: external host ${host} is not permitted`);
     }

--- a/apps/site/who-its-for.html
+++ b/apps/site/who-its-for.html
@@ -7,18 +7,19 @@
 <meta name="description" content="The assumptions this design makes about whoever uses it, what governing a vault demands every week, and the four groups this is explicitly not for at launch.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<link rel="canonical" href="https://rwally.com/who-its-for.html">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
 <meta property="og:url" content="https://rwally.com/who-its-for.html">
 <meta property="og:title" content="Who it is for, and who it is not for">
-<meta property="og:description" content="For self-custody users on Base who rank no pause, no upgrade, no seize above all else, and the four groups this is wrong for. Not deployed to mainnet.">
+<meta property="og:description" content="For people who weigh no pause, no upgrade, no seize above almost everything else, and the four groups this is wrong for. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">
 <meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Who it is for, and who it is not for">
-<meta name="twitter:description" content="For self-custody users on Base who rank no pause, no upgrade, no seize above all else, and the four groups this is wrong for. Not deployed to mainnet.">
+<meta name="twitter:description" content="For people who weigh no pause, no upgrade, no seize above almost everything else, and the four groups this is wrong for. Not deployed to mainnet.">
 <meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
 <!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>

--- a/apps/site/who-its-for.html
+++ b/apps/site/who-its-for.html
@@ -7,6 +7,20 @@
 <meta name="description" content="The assumptions this design makes about whoever uses it, what governing a vault demands every week, and the four groups this is explicitly not for at launch.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
+<meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Agent-Governed Vaults">
+<meta property="og:url" content="https://rwally.com/who-its-for.html">
+<meta property="og:title" content="Who it is for, and who it is not for">
+<meta property="og:description" content="For self-custody users on Base who rank no pause, no upgrade, no seize above all else, and the four groups this is wrong for. Not deployed to mainnet.">
+<meta property="og:image" content="https://rwally.com/assets/og-card.png">
+<meta property="og:image:alt" content="A plain card carrying the site name, Agent-Governed Vaults, and the pre-launch status line: not deployed to mainnet.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Who it is for, and who it is not for">
+<meta name="twitter:description" content="For self-custody users on Base who rank no pause, no upgrade, no seize above all else, and the four groups this is wrong for. Not deployed to mainnet.">
+<meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
+<!-- COUNSEL: social-preview metadata. The og:/twitter: title and description are the sentence a reader sees before deciding to click, and are often the only sentence they read, so they are published copy and not configuration. Each description ends in the deployment-status sentence and is kept under the ~160 characters a preview shows, so the status cannot be truncated away. -->
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/apps/site/who-its-for.html
+++ b/apps/site/who-its-for.html
@@ -7,12 +7,12 @@
 <meta name="description" content="The assumptions this design makes about whoever uses it, what governing a vault demands every week, and the four groups this is explicitly not for at launch.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
-<link rel="canonical" href="https://rwally.com/who-its-for.html">
+<link rel="canonical" href="https://rwally.com/who-its-for">
 <meta name="theme-color" content="#f2f2f7" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0e0e16" media="(prefers-color-scheme: dark)">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Agent-Governed Vaults">
-<meta property="og:url" content="https://rwally.com/who-its-for.html">
+<meta property="og:url" content="https://rwally.com/who-its-for">
 <meta property="og:title" content="Who it is for, and who it is not for">
 <meta property="og:description" content="For people who weigh no pause, no upgrade, no seize above almost everything else, and the four groups this is wrong for. Not deployed to mainnet.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">


### PR DESCRIPTION
Today a link to this site shared in a DM or a Slack renders as a bare grey URL. There was not one Open Graph tag, Twitter card, `theme-color` or canonical link anywhere in `apps/site`.

This adds Open Graph and Twitter tags, a canonical link, and a light and a dark `theme-color` to all six pages, inserted immediately before `</head>`. No page body and no stylesheet is touched.

## The descriptions, as a set

Each is derived from what its own page says, so a reader who follows a link to the risks page gets a preview about risk. None is reused.

| Page | `og:description` (= `twitter:description`) | chars |
| --- | --- | --- |
| `index.html` | Members pool USDC into a spot basket and ratify every rebalance by on-chain vote. No admin key, no pause, no upgrade. Not deployed to mainnet. | 142 |
| `how-it-works.html` | Deposit, observe, propose, commit, reveal, timelock, execute — one rebalance in full, invariants and parameters labelled apart. Not deployed to mainnet. | 152 |
| `who-its-for.html` | For people who weigh no pause, no upgrade, no seize above almost everything else, and the four groups this is wrong for. Not deployed to mainnet. | 145 |
| `operators.html` | An operator proposes rebalances and votes its own weight. Two separate 5% mechanisms lock capital and decay proposal rights. Not deployed to mainnet. | 149 |
| `risks.html` | Fifteen named risks, with the worst realistic case for each. Seven have no mitigation and are marked accepted, not buried. Not deployed to mainnet. | 147 |
| `faq.html` | Can you rug me, can you pause it, can I always get out, what does the operator earn, what licence is the code under. Not deployed to mainnet. | 141 |

`twitter:description` is the same string as `og:description` on every page, and `twitter:title` the same as `og:title`, so the two cannot drift apart.

### How the pre-launch status is handled, and why

Every page carries the pre-launch banner, and a preview that drops it is a preview that oversells. So **every description carries it, on every page, with no exceptions** — a per-page judgement about which pages "imply liveness" is exactly the kind of call that goes wrong quietly.

Placing it last and letting it truncate would have been the same as omitting it. So the constraint is length: every description above is between 141 and 152 characters, inside the roughly 160 a preview shows, which means the status sentence is in the part that renders rather than past the cut. That is what bounded the page-specific half to around 130 characters.

The wording is `Not deployed to mainnet.` deliberately. It is true against the banner on `protocol/main` today, and it is still true after #144 lands and the banner becomes "Not deployed to mainnet. No mainnet deployment of the current code exists, and a Base Sepolia deployment is a testnet trial with no real value at stake." A description quoting either banner verbatim would go stale on that merge; this one does not.

Claim checks were done before writing, not after: no description uses a `BANNED` phrase from `site.test.mjs`, none reproduces either count-pinned footer sentence, none attributes pooling or governing to an agent, none makes a universal weighted-vote or `stake-weighted` claim, and the operators description states what an operator *does* rather than making any blanket claim about what it cannot do — guard 6 in `scripts/test/claims-lede-truth.test.mjs` bans the widened negative form, and it is the shape a metadata author reaches for first.

Each page also gets a `COUNSEL:` marker for the new strings. `apps/site/README.md` requires one for any added claim about deployment status, and these descriptions are the highest-leverage claims on the site — for most readers they are the only sentence.

Two descriptions were tightened after review. `who-its-for.html` said readers "rank ... above all else" where the page says "above almost everything else" — a preview that overstates the page it previews, which is the same defect class as the rest of this project's claim work and worse in metadata than in body copy. `how-it-works.html` was at 157 characters with no room before a preview truncates mid-clause; it is now 152.

## The canonical exemption

A canonical must live in an `href`, and the host check in `site.test.mjs` permitted only `github.com` there, so this was the one required tag that could not ship as written.

The invariant that check protects is that a page **loads** nothing from anywhere and **navigates** off-site only to the repository. A canonical link does neither: it fetches no resource and it is not a link a reader can follow. It is metadata that happens to be spelled with an `href` rather than a `content` attribute — which is precisely why `og:url` needed no exemption and this did.

So the check now exempts `rel="canonical"` pointing at the site's own host, and nothing else. Both halves are load-bearing: **any other `rel` still fails**, because stylesheets, preloads and icons do load; and **a canonical pointing at any other host still fails**. That is verified rather than asserted — two mutation probes, a canonical pointing at another host and a stylesheet pointing at `rwally.com`, each turn the gate red. The reason is written in the test beside the code that grants it.

A relative canonical was the alternative and it is worse than having none: it passes the check untouched and cannot do the one job canonicals exist for, which is collapsing www/non-www, http/https and trailing-slash duplicates onto one URL.

`apps/site/README.md` documented the old rule in two places, including "The only off-site link anywhere is the project's own GitHub repository". Both now state the rule the code actually follows, rather than one it no longer does.

## Two gaps that are deliberate, and must not be read as finished

### `og:image` is a 404 today

The tags point at `https://rwally.com/assets/og-card.png`. **That file does not exist.** The agent working on new files in this directory is producing it; creating it here would collide with that work.

Being precise about what that means: the path currently 404s, and the preview **degrades to a text card** — title, description and site name render, no image. That is the same as today for the image and a large improvement on everything else, but nobody should merge this believing an image exists.

`og:image:alt` describes the intended card rather than a design nobody has seen: a plain card carrying the site name and the pre-launch status line. `og:image:width` and `og:image:height` are deliberately omitted rather than asserting dimensions for a file that does not exist; the requirement is 1200x630.

### Favicon links are absent

The favicon files are being produced by another agent and had not reported when this was written. Inventing filenames would pass CI — nothing asserts that local non-`.html` hrefs resolve on disk — and ship a silent 404.

They are now visible in **#146**, which adds `apps/site/favicon.ico` and `apps/site/favicon.svg` alongside the Cloudflare `_headers`, `_redirects`, `robots.txt` and `sitemap.xml`. That makes the follow-up a known two-line addition rather than an open question, but the files are not on `protocol/main` yet, so linking them from here would still ship a 404. Sequence it after #146.

## Sequencing against #144

#144 is open and modifies all six of these pages, including `index.html`'s `<title>` and meta description, and `site.test.mjs`. The rebase is mechanical, and that is verified rather than assumed: a trial merge of `pull/144/head` at its current head `40866ffa` auto-merged every file including `site.test.mjs` with no conflict, and both test files were green on the merged tree — 35/35 and 6/6.

Two details make that hold. The metadata block goes immediately before `</head>`, leaving the two unchanged stylesheet lines between it and #144's edit on `index.html`. And `index.html`'s `og:title` is the page's `<h1>` ("No admin key. No pause. No upgrade. No undo."), which #144 does not touch, rather than a copy of the `<title>` that #144 rewrites — so it cannot be stranded.

## URL shape — corrected, and worth reading

These were first written as `https://rwally.com/faq.html`, on the understanding that Cloudflare Pages had no extension rewriting configured. That is correct about the configuration and wrong about the result: **Pages redirects `/faq.html` to `/faq` and `/index.html` to `/` by default**, with nothing configured to make it do so.

So the `.html` forms were canonical tags pointing at URLs that 301 away — the specific failure canonicals cause rather than prevent. A crawler follows the redirect, treats the target as canonical, and the tag becomes a contradicting signal.

They also disagreed with the repository. #146 adds `apps/site/sitemap.xml` listing all six pages extension-less, and states the reason in the file: listing the `.html` forms would make every entry a redirect, which Search Console reports as an error against the sitemap. Two files in one repository nominating different canonical URLs for the same six pages is a defect whichever one is right.

All six canonical and `og:url` values are now `https://rwally.com/`, `/how-it-works`, `/who-its-for`, `/operators`, `/risks`, `/faq` — **byte-identical to #146's sitemap**, verified by diffing the two sets rather than by reading them.

`og:image` is unchanged: it points at an asset, not an HTML page, so the extension-less redirect does not apply.

## Verification

- `node --test apps/site/test/site.test.mjs` — 35 pass, 0 fail (count unchanged; one existing test narrowed, none added).
- `node --test scripts/test/claims-lede-truth.test.mjs` — 6 pass, 0 fail.
- Both again on a trial merge with #144 — 35/35 and 6/6.
- Two mutation probes on the canonical exemption, both correctly red.
- Every `og:url` and canonical checked against its page.
- Every description length measured rather than eyeballed: 141 to 152 characters.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
