### PR TITLE
docs: sweep the stale gate-7 references PR #143 left downstream

### DIFF
--- a/docs/LAUNCH-READINESS.md
+++ b/docs/LAUNCH-READINESS.md
@@ -10,7 +10,7 @@
 >
 > **Gate 0 is GO (root-only):** all five original Criticals resolved — C-1 closed at launch (`allowSubVaults = false`, confirmed on the mainnet deploy path `Deploy.s.sol:79`), C-2/C-3/C-5 fixed with tests, **C-6 resolved by the pivot**, and the external audit found no majors.
 >
-> **What still blocks GO — all operational, all need a funded Base Sepolia key:** gates **2/3/6** (testnet full-lifecycle + soak + canary must be **re-run on the pivoted tree** — the Sepolia oracle config now exists and is on-chain-verified, PR #64, so this is unblocked and just needs a key). Gate **7** is now **GO**: the drill was re-run under Docker on a real Linux engine 2026-09-02 (`4619f17a`) with steps 1 and 6 **literal** — the condition it was CONDITIONAL on — and the three runbook/Compose defects that re-run surfaced are fixed (`adafdc7c`). **Nothing security-side remains.**
+> **What still blocks GO — all operational, all need a funded Base Sepolia key:** whichever of the operational gates **2/3/6** the checklist in §1 still shows short of GO — as of 2026-09-02, gate **3** (soak) and gate **6** (canary); gate **2**'s full lifecycle was re-earned on the pivoted tree 2026-09-01. §1 is the authority here, not this sentence. The Sepolia oracle config exists and is on-chain-verified (PR #64), so the re-runs are unblocked and just need a key. Gate **7** is now **GO**: the drill was re-run under Docker on a real Linux engine 2026-09-02 (`4619f17a`) with steps 1 and 6 **literal** — the condition it was CONDITIONAL on — and the three runbook/Compose defects that re-run surfaced are fixed (`adafdc7c`). **Nothing security-side remains.**
 >
 > ---
 > *Pre-pivot narrative (retained as history — the Phase-2 remediation record). Read it for the reasoning; trust the banner above for current status.*
@@ -321,18 +321,17 @@ snapshot parser (no live snapshot in a fresh checkout). Eleven further ABI-drift
 `contracts/out` is absent; the numbers above are from a run **after** `forge build`.
 ## 6. The path to GO
 
-### Current remaining path (2026-08-29) — security done; operational only
+### Current remaining path (updated 2026-09-02) — security done; operational only
 
-Every security item below (steps 1–4, 6 of the historical list) is now closed: C-1 decided, the oracle pivoted to Chainlink-direct and on-chain-verified, and the external audit completed (owner-attested, no majors). What remains needs a **funded Base Sepolia key** and is the owner's to trigger:
+Every security item below (steps 1–4, 6 of the historical list) is now closed: C-1 decided, the oracle pivoted to Chainlink-direct and on-chain-verified, and the external audit completed (owner-attested, no majors). **Gate 7 is also closed** — the drill was re-run under Docker with steps 1 and 6 literal (#139, `4619f17a`) and the three defects that re-run surfaced are fixed (#141, `adafdc7c`), so it is no longer on this path; it was historical step 7. What remains needs a **funded Base Sepolia key** and is the owner's to trigger:
 
-1. **Re-run testnet lifecycle + soak + canary on the pivoted tree (gates 2/3/6).** Deploy the current tree to Base Sepolia with the now-verified `chainlinkOracle` config (PR #64), then run the lifecycle + the drill battery + the canary. Unblocked — needs only the key. *(Step-by-step lives in [DEPLOYMENT.md](DEPLOYMENT.md); the maintainer will hand the owner an exact command list when the key is available.)*
-2. **Close gate 7** — the restore drill is **done and PASSED** (`docs/RESTORE-DRILL.md`). What remains is re-running its steps 1/6 under a real POSIX kernel — Docker Desktop (Compose, as the runbook prints), or WSL2 alone (cheaper; the bare-metal stop/start is now documented in RUNTIME.md §8.3/§8.6, confirmed genuinely unreachable on bare-metal Windows — RESTORE-DRILL.md §9). Needs the owner to install one of the two, not a key.
-3. **Then cut `v1.0.0-launch-candidate`** and proceed to the mainnet deploy sequence (owner's key).
+1. **Re-run the operational gates the checklist in §1 still shows short of GO on the pivoted tree — as of 2026-09-02 that is gate 3 (soak drills) and gate 6 (canary).** Gate 2's lifecycle was re-earned 2026-09-01; §1 is the authority on which of 2/3/6 currently stand, and this item means whichever of them it still marks STALE. Run the drill battery and the canary against the live C-6 Chainlink-direct deployment on Base Sepolia (`chainlinkOracle` config verified in PR #64), from a checkout at current `main`. Unblocked — needs only the key. *(Step-by-step lives in [DEPLOYMENT.md](DEPLOYMENT.md); the maintainer will hand the owner an exact command list when the key is available.)*
+2. **Then cut `v1.0.0-launch-candidate`** and proceed to the mainnet deploy sequence (owner's key).
 
 Mainnet deploy itself (singletons → blessed `ChainlinkOracle` → factory with `BLESSED_ORACLES` → first vault) is the final owner-key step, gated on the above.
 
 ---
-*Historical path (retained; steps 1–4 and 6 are now DONE — see the current path above and the top banner):*
+*Historical path (retained; steps 1–4, 6 and 7 are now DONE — step 7 closed 2026-09-02, see the current path above and the top banner):*
 
 Shorter than it was, and still not short.
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -19,7 +19,8 @@ work it describes.
 ## Right now
 
 - **Launch is NO-GO, but no longer for security reasons.** Every security gate is cleared. What
-  remains is operational (testnet re-runs, a restore drill), legal, and calendar-bound.
+  remains is operational (the soak and canary re-runs — the restore drill is done and gate 7 is
+  **GO** as of 2026-09-02), legal, and calendar-bound.
 - **The smoke lifecycle is RUNNING on Base Sepolia** (resumed 2026-09-01). It was parked at
   `activate` for three days on a mistyped keystore password, not a missing one — see "Blocked on a
   human" below, which was wrong about this. Past `activate` (5e18 shares minted), `propose` and
@@ -72,73 +73,20 @@ re-checked it. Re-check this list before repeating it.
    fabricated staleness events on a healthy oracle until #94 fixed it, so an older tree produces a
    soak result that is worse than useless. Start it **after** the smoke lifecycle finishes: track B
    drives the smoke vault.
-3. ~~**Recorded restore drill** — gate 7.~~ **DONE 2026-08-30, re-confirmed 2026-09-01** —
-   `docs/RESTORE-DRILL.md` (+ its 2026-09-01 §9 addendum). The restore genuinely works on both
-   state files, re-proven Docker-free and independently 2 days apart. Gate 7 stays CONDITIONAL for
-   one reason: steps 1 and 6 of the runbook (`docker compose stop/start`) need a real POSIX kernel
-   to deliver a real `SIGTERM`/`SIGINT`. **Checked 2026-09-01, three more scripted methods (none via
-   Docker or Git Bash): Node-native `child_process.kill('SIGINT')`, the same with a detached process
-   group, and `taskkill /PID` without `/F` — all three fail identically to the original Git-Bash
-   `kill` (Windows itself refuses the last one: "can only be terminated forcefully"). This is a
-   genuine, unscriptable Windows platform limit, not a tooling quirk — no further agent effort can
-   close this without a real POSIX kernel.** RUNTIME.md §8.3/§8.6 now document the Linux/macOS
-   bare-metal commands and this limitation explicitly.
-
-   **This is closer to done than "needs Docker" sounds — checked directly, not assumed, 2026-09-01
-   ~22:17Z: Docker Desktop 4.88.1 is already installed on this machine** (`docker.exe` at
-   `C:\Program Files\Docker\Docker\resources\bin\` runs, reports version 29.7.2, `docker compose`
-   v5.4.0 present; `Docker Desktop.exe`/`com.docker.backend.exe` are running). **The engine just
-   can't start yet** ("Docker Desktop is unable to start") because a coordinator ran
-   `wsl --install --no-distribution` elevated and it **needs a reboot to finish** — see [[Owner
-   Decisions 2026-09-01]] §7 for the full context. Two ways to finish this, Option A is faster if
-   the reboot already happened or happens anyway for other reasons; Option B needs nothing but the
-   reboot since the install itself is done:
-
-   **Option A — finish the Docker Desktop install already in progress (recommended, nothing left to download):**
-   1. **Reboot** Windows (finishes the pending WSL2 kernel install).
-   2. Start menu → **Docker Desktop** → open it. Accept the **Docker Subscription Service
-      Agreement** if prompted (free for personal/small-business use —
-      [terms](https://www.docker.com/legal/docker-subscription-service-agreement/)). Skip sign-in.
-      Wait for the whale icon to say "Engine running".
-   3. Open a **new** PowerShell window (existing ones won't have `docker` on PATH) and confirm:
-      ```powershell
-      docker --version
-      docker compose version
-      docker info | Select-String -Pattern "Server Version|OSType|WSL"
-      ```
-      If `docker` isn't found: `$env:Path += ";C:\Program Files\Docker\Docker\resources\bin"`, then
-      add it permanently via *Settings → System → About → Advanced system settings → Environment
-      Variables → Path*.
-   4. If `docker info` still errors on WSL: `wsl --status`, then `wsl --update`, and in Docker
-      Desktop *Settings → General* confirm "Use the WSL 2 based engine" is ticked.
-   5. From the repo root: `docker compose up --build` (RUNTIME.md §4), then run the restore
-      procedure exactly as `RUNTIME.md` §8.3 prints it — `docker compose stop indexer` /
-      `docker compose start indexer` — no substitution needed.
-   6. Update `docs/RESTORE-DRILL.md` and the gate 7 row in `docs/LAUNCH-READINESS.md` with the
-      result (PASS → GO, or whatever it actually shows).
-
-   **Option B — WSL2 alone, no Docker (cheaper if you'd rather not wait on Docker Desktop's engine):**
-   1. Open **PowerShell as Administrator** and run:
-      ```powershell
-      wsl --install
-      ```
-      (Installs WSL2 + the default Ubuntu distro. [Microsoft's WSL install docs](https://learn.microsoft.com/en-us/windows/wsl/install) if anything prompts unexpectedly.)
-   2. Reboot if prompted.
-   3. Launch **Ubuntu** from the Start menu once, and complete the first-run UNIX username/password
-      setup it asks for.
-   4. Inside that Ubuntu shell, install Node 24+:
-      ```bash
-      curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
-      sudo apt-get install -y nodejs
-      node --version   # confirm >= 24
-      ```
-   5. From that same shell, `cd` to the repo via its Windows path (e.g.
-      `cd /mnt/c/Users/Micha/desktop/x402`) and run `npm ci`.
-   6. Re-run `docs/RESTORE-DRILL.md` §7's reproduction steps verbatim — `kill -TERM $(pgrep -f
-      index-runner.mjs)` for step 1 and `node packages/indexer/src/index-runner.mjs` for step 6 are
-      now real signals, not substitutes. Confirm `shutdown.complete` appears in the logs (§8.6).
-   7. Update `docs/RESTORE-DRILL.md` and the gate 7 row in `docs/LAUNCH-READINESS.md` with the
-      result.
+3. ~~**Recorded restore drill** — gate 7.~~ **DONE. Gate 7 is GO as of 2026-09-02 and nothing here
+   is blocked on a human any more.** The drill was recorded Docker-free on 2026-08-30 and
+   re-confirmed 2026-09-01 (`docs/RESTORE-DRILL.md` §5–6 and its §9 addendum), then **re-run under
+   Docker on a real Linux engine** — Docker Desktop 4.88.1, server 29.7.2, OSType `linux` — with
+   **steps 1 and 6 literal** (`docker compose stop/start`), which was the one condition the row was
+   CONDITIONAL on: #139 (`4619f17a`), recorded in `docs/RESTORE-DRILL.md` §10. That run also closed
+   four of the five gaps §6 had listed as untested (aged rung, off-host tar, atomicity under a kill
+   in flight, production scale) and surfaced three defects in the printed procedure, all fixed in
+   #141 (`adafdc7c`) — RUNTIME.md §8.3 now carries both a Docker and a bare-metal column, every
+   Compose `command:` runs `node` at PID 1 so SIGTERM actually reaches the shutdown hooks, and the
+   off-host tar resolves the Compose-namespaced volume instead of silently creating an empty one.
+   **The Docker/WSL2 install instructions that stood here are obsolete and have been removed.** The
+   residuals that remain are named in the gate 7 row of `docs/LAUNCH-READINESS.md` and belong to
+   other gates, not to this one.
 4. **Launch parameter: `proposalThresholdBps = 500`.** Keep it or lower it — immutable per vault
    once shipped. See the trap below.
 

--- a/docs/RESTORE-DRILL.md
+++ b/docs/RESTORE-DRILL.md
@@ -2,6 +2,19 @@
 
 **Date:** 2026-08-30 · **Chain:** Base Sepolia (84532) · **Tree:** `132f837e` · **Gate:** [7 — ops runbook exercised](LAUNCH-READINESS.md)
 
+> **Correction added 2026-09-02 — read this before the verdict below.** Everything from here to §9
+> is the record of the 2026-08-30 run and its 2026-09-01 corroboration, and is left exactly as it
+> was written. **Its "gate 7 stays CONDITIONAL" verdict no longer describes the gate.** The
+> condition it named — steps 1 and 6 run literally as `docker compose stop/start` — was met on
+> **2026-09-02** in **§10** below (#139, `4619f17a`), the three runbook and Compose defects that
+> re-run surfaced were fixed in **#141 (`adafdc7c`)**, and the gate row moved to **GO** in
+> **#143 (`16050be0`)**. Where this
+> report and [LAUNCH-READINESS.md](LAUNCH-READINESS.md) §1 disagree about gate 7's status, the gate
+> row wins; this report is evidence, not the verdict. Note also that §10.1 records **2 of 6 steps
+> literal** for that run, for the opposite reason — steps 2–5 name host paths that do not exist
+> under the Compose deployment, which is finding 6. That is a statement about that run, not a
+> reopening of the gate.
+
 Sprint 13 shipped the backup ring and the `verify` subcommands with tests, and the Sprint-12 soak
 restarted services freely. Neither is a restore. This drill takes the procedure in
 [`RUNTIME.md` §8.3](RUNTIME.md) and executes it as written against **real artifacts produced by

--- a/docs/vault/current-state.md
+++ b/docs/vault/current-state.md
@@ -31,9 +31,10 @@ Every **security** gate is cleared ([[launch-readiness-gates]]):
   "audited" without that qualifier.**
 - **Gate 5 — mainnet oracle stack: GO with a named residual.** See below.
 
-What still blocks GO is operational and needs a funded key, not more code: gates **2/3/6** (testnet
-full lifecycle, soak, canary — must be re-run on the pivoted tree) and gate **7** (one recorded
-restore drill, ~30 min, no keys).
+What still blocks GO is operational and needs a funded key, not more code: whichever of the
+operational gates **2/3/6** (testnet full lifecycle, soak, canary) [[launch-readiness-gates]] and
+`docs/LAUNCH-READINESS.md` still show short of GO on the pivoted tree. **Gate 7 is closed** — GO as
+of 2026-09-02, the restore drill recorded and then re-run literally under Docker.
 
 ## The oracle, as it actually ships
 

--- a/docs/vault/go-to-market-plan.md
+++ b/docs/vault/go-to-market-plan.md
@@ -37,7 +37,7 @@ Deployer EOA has **no post-wiring authority** (no owner functions exist); operat
 
 ## Gate to GO
 
-Not yet. `v1.0.0-launch-candidate` is deliberately **not cut**. The path runs through [[open-items]]: settle C-6, commission the external audit, rebuild the mainnet config, re-run the STALE operational gates, record a restore drill.
+Not yet. `v1.0.0-launch-candidate` is deliberately **not cut**. The path runs through [[open-items]] — read the live list there rather than re-listing it here; as of 2026-09-02 what remains is re-running the STALE operational gates on the pivoted tree. The restore drill (gate 7) is done and that gate is GO.
 
 ## Links
 

--- a/docs/vault/launch-readiness-gates.md
+++ b/docs/vault/launch-readiness-gates.md
@@ -6,8 +6,9 @@ is now cleared and what remains is operational.
 
 > **⚠ [LAUNCH-READINESS.md](../LAUNCH-READINESS.md) is authoritative; this note is a mirror.** Rows
 > 0, 1 and 5 below were corrected on 2026-08-30 after the C-6 pivot shipped and the owner's audit
-> attestation landed. Rows 2/3/6/7 are directionally right but read the source document (and
-> `npm run cc`) for the live board.
+> attestation landed, and row 7 on 2026-09-02 when the gate closed. Rows 2/3/6 are directionally
+> right but read the source document (and `npm run cc`) for the live board — gate 2 in particular
+> has moved there since this mirror was last corrected.
 
 ## Why it matters
 
@@ -28,7 +29,7 @@ safety, and both are NO-GO.
 | 4 | Live x402 settlement | **GO** (unaffected) — x402 is off-chain plus a USDC `transferWithAuthorization`; touches no contract this branch changed. The one operational gate that survives intact. |
 | 5 | Mainnet oracle stack config verified | **GO with a NAMED RESIDUAL** — reshaped by the pivot. `base-mainnet.json.chainlinkOracle` prices each asset from **one genuine Chainlink Data Feed**: WETH←ETH/USD, cbBTC←BTC/USD, USDC pinned, plus the Base L2 sequencer uptime feed — verified on Base mainnet **12/12** and mirrored + verified on Base Sepolia **11/11**. No cbETH: Base has no cbETH/USD feed. The "5 sources at quorum 3" requirement and the NOT-DEPLOYABLE status described the removed aggregator and no longer apply. **Residual: single-provider dependency** — heartbeat + sane-price band + sequencer gate are the *only* defences against a bad answer, a feed failure fails that asset **closed with no fallback**, and there is no rotation lever (residual 12). |
 | 6 | Canary operational | **STALE** — read-only and unchanged, but its evidence came from watching superseded contracts; re-earns alongside gate 3. |
-| 7 | Ops runbook exercised (a restore performed) | **CONDITIONAL** — the backup ring shipped, but a deliberate restore drill (~30 min, no keys) has not been recorded. |
+| 7 | Ops runbook exercised (a restore performed) | **GO** — 2026-09-02. The drill is recorded in [docs/RESTORE-DRILL.md](../RESTORE-DRILL.md): first Docker-free 2026-08-30 (§5–6, addendum §9), then re-run under a real Linux Docker engine with **steps 1 and 6 literal** (`docker compose stop/start`) — the one condition this row was CONDITIONAL on — in #139 (`4619f17a`), §10. The three runbook/Compose defects that re-run surfaced are fixed in #141 (`adafdc7c`). Read the row in the source document for the residuals; each belongs to a different gate. |
 | 8 | All CI gates green | **GO** — `forge test` 252 pass / 0 fail; backend 553 (551 pass, 2 skip). Certifies the gates ran, not that the protocol is safe; `v1.0.0-launch-candidate` deliberately not cut. |
 
 ## Launch parameters (§2)
@@ -46,8 +47,9 @@ deposit overload, which spent 731 B. `VaultFactory` (~21,004 B spare) and `Chain
 
 C-1 decided (root-only) · C-6 resolved by the pivot · external audit commissioned (owner
 attestation, gate 1) · `base-mainnet.json.chainlinkOracle` populated and on-chain-verified ·
-**remaining:** re-run the testnet lifecycle, soak and canary on the pivoted tree (gates 2/3/6, need
-a funded key) and one recorded restore drill (gate 7). H-5/H-6 stay deferred with the sub-vault (H-9 was fixed in code 2026-09-01)
+**remaining:** re-run on the pivoted tree whichever of the operational gates 2/3/6 the source
+document still shows short of GO (they need a funded key). Gate 7 is closed — the restore drill is
+recorded and re-run literally under Docker. H-5/H-6 stay deferred with the sub-vault (H-9 was fixed in code 2026-09-01)
 feature — and with `VaultCore` at ~283 B of margin, anything VaultCore-shaped is now effectively
 closed.
 

--- a/docs/vault/open-items.md
+++ b/docs/vault/open-items.md
@@ -8,8 +8,9 @@ Gate 0 and gate 1 are the only rows that speak to safety, and both are NO-GO. Th
 
 ## Launch-blocking
 
-> **⚠ Items 1–3 are CLOSED** (corrected 2026-08-30). They are kept here because the reasoning is
-> still worth reading; the live list is items 4–6 plus [docs/NOW.md](../NOW.md).
+> **⚠ Items 1–3 are CLOSED** (corrected 2026-08-30) and **item 6 is CLOSED** (2026-09-02, gate 7).
+> They are kept here because the reasoning is still worth reading; the live list is items 4 and 5
+> plus [docs/NOW.md](../NOW.md).
 
 1. ~~**C-6 — settle the oracle mechanism.**~~ **DONE.** `ChainlinkOracle` shipped
    ([[chainlink-direct-pivot]]) *and* the factory oracle-gate landed (#50), so the retired
@@ -26,7 +27,7 @@ Gate 0 and gate 1 are the only rows that speak to safety, and both are NO-GO. Th
    — note the path: only `base-sepolia.json` lives under `config/deployments/`.
 4. **Re-run testnet lifecycle + soak + canary (gates 2, 3, 6).** STALE — earned against superseded bytecode. Redeploy testnet, re-run drills against the corrected contracts. See [[audit-reverification]].
 5. **VaultCore-headroom sprint (issue #40).** H-5/H-6 and M-15's exit-side need `VaultCore` bytes that do not exist (**~4,095 B** of margin since PR #90, up from ~283 B — corrected 2026-08-30; the 1,014 B previously recorded predates M-15's deposit overload, which spent 731 B, so this is *tighter* than the note claimed, not looser). Dormant-at-launch behind [[root-vaults-only]], but required before sub-vaults return.
-6. **One recorded restore drill (gate 7).** ~30 min, no keys, doable anytime — CONDITIONAL until performed.
+6. ~~**One recorded restore drill (gate 7).**~~ **DONE — gate 7 is GO as of 2026-09-02.** Recorded Docker-free 2026-08-30, then re-run under a real Linux Docker engine with steps 1 and 6 literal (`docker compose stop/start`) in #139 (`4619f17a`), `docs/RESTORE-DRILL.md` §10; the three runbook/Compose defects that re-run surfaced are fixed in #141 (`adafdc7c`). The residuals the drill named are in the gate 7 row of [LAUNCH-READINESS.md](../LAUNCH-READINESS.md) and belong to other gates.
 
 ## Open Highs / not-mitigated
 


### PR DESCRIPTION
`#143` (`16050be0`) moved gate 7 to **GO** in the §1 checklist row and the status banner, and deliberately left everything downstream alone to avoid collisions with the other work in flight. Two reviewers named the resulting inconsistency. This PR makes the downstream agree, and draws the line the repo already draws between a claim about today and a dated record.

## Live work lists — made true today

| File | What changed |
| --- | --- |
| `docs/LAUNCH-READINESS.md` §6 "Current remaining path" | Gate 7 dropped from the numbered list (3 items → 2) and folded into the preamble as closed; heading redated to 2026-09-02. **Item 1 fixed at the same time**: it asserted gates 2/3/6 were all outstanding, which was stale *before* #143 — gate 2's own row has read GO since 2026-09-01. It now defers to the §1 table and names 3 and 6 as of today, so the live testnet run re-earning 3 and 6 will not restale it. Renumbering one without the other would have made it worse. |
| `docs/LAUNCH-READINESS.md` status banner | The same 2/3/6 correction, phrased to defer to the table. |
| `docs/LAUNCH-READINESS.md` historical-path preamble | "steps 1–4 and 6 are now DONE" → "1–4, 6 and 7". The historical item 7 body is left as written — it sits under an explicit *retained history* marker, like steps 1–4 and 6 before it. |
| `docs/NOW.md` | The "what remains is operational" line no longer lists a restore drill. Item 3 collapses to a DONE entry: it still said the gate stays CONDITIONAL — contradicting its own first line, which already marked the drill done — and carried two obsolete Docker/WSL2 install procedures for a machine capability that has since been used. |
| `docs/vault/launch-readiness-gates.md` | Gate 7 row CONDITIONAL → GO; the mirror banner and the path-to-GO list updated with it. |
| `docs/vault/open-items.md` | Item 6 struck as closed, and the ⚠ banner naming the live list renumbered to match. |
| `docs/vault/current-state.md`, `docs/vault/go-to-market-plan.md` | The blocking sentences no longer list a restore drill as remaining work. |

## Dated records — corrected forward, not rewritten

`docs/RESTORE-DRILL.md` gets **one insertion and zero modifications**: a dated 2026-09-02 correction block after the header, saying the 2026-08-30 verdict below no longer describes the gate and pointing at §10 and the GO row. Untouched: the "gate 7 stays CONDITIONAL" verdict of that run, §5, §6, §9, and **§10.1's "2 of 6 literal"** — that is a record of the 2026-09-02 run (steps 2–5 could not be literal, which is finding 6), not a claim about the gate. The insertion says so explicitly, so the number is not read as a reopening.

## Out of scope, deliberately

- **No gate row in the §1 table is touched.** Gate 7's is settled, gate 1 is closed by owner decision, and gates 2/3/6 are being re-earned by a live testnet run.
- `docs/vault/launch-readiness-gates.md` rows 2/3/6 still read STALE while the source has moved gate 2 to GO. That mirror already disclaims itself as non-authoritative and those rows belong to the run in flight; the banner now flags it.
- `README.md` and `apps/site` — other agents are working there.

## Verification

- `node --test scripts/test/claims-lede-truth.test.mjs` — **6/6**
- `node --test scripts/test/config-doc-truth.test.mjs` — **9/9** (run from an isolated worktree, so the skip-list defect that reads `.claude/worktrees/` could not fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
