### PR TITLE
test(eip170): correct the stale EIP-170 margin figure in the NatSpec

### DIFF
--- a/contracts/src/VaultDeployer.sol
+++ b/contracts/src/VaultDeployer.sol
@@ -4,10 +4,17 @@ pragma solidity 0.8.26;
 import {VaultCore} from "./VaultCore.sol";
 
 /// @title VaultDeployer — the factory's one and only vault construction path
-/// @notice Exists for one reason: EIP-170. `VaultCore`'s creation code is 24,731 B, which is
-/// larger than the 24,576 B runtime cap all by itself, so ANY contract that writes
-/// `new VaultCore(...)` embeds a blob that cannot fit in a deployable contract. VaultFactory
-/// was 2,665 B over the cap for exactly this reason (#10).
+/// @notice Exists for one reason: EIP-170. A contract that writes `new VaultCore(...)` embeds
+/// VaultCore's entire creation code in its own runtime, and that is what put VaultFactory
+/// 2,665 B over the 24,576 B cap (#10).
+///
+/// This paragraph used to justify the design by claiming VaultCore's creation code exceeded the
+/// runtime cap *by itself*, at 24,731 B. **Re-measured 2026-09-02 at `protocol/main` with
+/// `forge build --sizes`, it is 22,391 B — below the cap.** The claim was true when written and
+/// is not the reason any more; the reason is the sum. A factory carrying a 22,391 B blob plus its
+/// own logic does not fit, which is the same conclusion by arithmetic that survives. Re-measure
+/// rather than copy either number: nothing walks `.sol` for stale figures, which is how the old
+/// one lasted.
 ///
 /// The fix keeps the bytes compile-time-embedded — they are never supplied by a caller. This
 /// contract's own CREATION code carries `type(VaultCore).creationCode` (initcode is capped at

--- a/contracts/test/Eip170.t.sol
+++ b/contracts/test/Eip170.t.sol
@@ -95,10 +95,17 @@ contract Eip170Test is Test {
 
     /// VaultCore's EIP-170 margin is not slack — it is the budget that decides whether a known
     /// fix can be deployed at all. H-5 and H-6 are confirmed High findings whose remediations
-    /// were deferred for one reason: at **289 B** of margin they did not fit (both together
-    /// measure +1,016 B; the figure was 283 B when the deferral was recorded, and #97 returned 6).
-    /// Reclaiming duplicated call shapes took the margin to **4,095 B**, measured on the merged
-    /// tree — not the 4,132 B this PR was written against, which predates #97.
+    /// were deferred for one reason: at the **289 B** of margin the tree then had they did not fit
+    /// (both together measure +1,016 B; the figure was 283 B when the deferral was recorded, and
+    /// #97 returned 6). Reclaiming duplicated call shapes bought that back.
+    ///
+    /// Current margin is **3,926 B** — VaultCore 20,650 B runtime against the 24,576 B cap,
+    /// measured with `forge build --sizes` at `protocol/main` `16050be0` on 2026-09-02. Earlier
+    /// figures recorded here (4,132 B pre-#97, then 4,095 B on the merged tree) are superseded and
+    /// are kept only in this sentence, so nobody re-derives a stale one. **Re-measure rather than
+    /// copy this number.** No guard checks it: `.sol` is outside `PUBLIC_EXT` in
+    /// `scripts/test/claims-lede-truth.test.mjs`, so a stale figure here goes unnoticed until a
+    /// person reads it — which is how the 4,095 B survived.
     ///
     /// This guards that budget rather than the cap: `forge build --sizes` already fails at the
     /// cap, but by then the next fix has already been deferred.


### PR DESCRIPTION
## The defect

`contracts/test/Eip170.t.sol` recorded VaultCore's EIP-170 margin as **4,095 B**, "measured on the merged tree". That figure is stale.

Re-measured with `cd contracts && forge build --sizes` at `protocol/main` `16050be0` on 2026-09-02:

| Contract | Runtime | Margin against the 24,576 B cap |
|---|---|---|
| **VaultCore** | **20,650 B** | **3,926 B** |
| VaultFactory | 3,572 B | 21,004 B |
| VaultDeployer | 938 B | 23,638 B |

## What changed

Comment only. `CORE_MIN_RUNTIME_MARGIN` stays `2_000` and no assertion is touched — the diff contains no non-comment line.

- The current margin is stated **with the commit and date it was measured at**, so the next reader can tell whether it has gone stale instead of guessing.
- The superseded figures (4,132 B pre-#97, 4,095 B on the merged tree) are named once, in the sentence that retires them, so nobody re-derives one.
- The **289 B** and **283 B** figures are kept as history — they are the margin at which the H-5/H-6 remediations were deferred — with the tense corrected so they do not read as current.
- An instruction to re-measure rather than copy.

## Why it went stale unnoticed, which is the part worth keeping

`.sol` is outside `PUBLIC_EXT` in `scripts/test/claims-lede-truth.test.mjs`, so no guard walks this file. A wrong number here survives until a person reads it, and this one did. That is now stated in the comment itself, next to the figure it explains.

This is the same gap that produced LOW-1 in #132 — a swept falsehood surviving in Solidity comments, the surface auditors actually read. Widening `PUBLIC_EXT` to `.sol` is the open follow-up recorded there, and it needs the record-versus-claim design first, since Solidity carries legitimately historical commentary. This comment block is a good example of exactly that: some of its figures are history and must stay, and one was a claim about today and had to change.

## Verification

- `forge fmt --check test/Eip170.t.sol` — clean
- `forge test --match-path test/Eip170.t.sol` — **10 passed, 0 failed**, including `test_vaultCoreKeepsTheReclaimedEip170Budget`
- Diff inspected for non-comment lines — none