### PR TITLE
test(indexer): kill the shutdown-test flake by awaiting the drain, not a stopwatch

### DIFF
--- a/packages/indexer/test/shutdown.test.mjs
+++ b/packages/indexer/test/shutdown.test.mjs
@@ -44,14 +44,17 @@ function fakeClient(head = 30) {
  * boundary, and the assertions red against a cursor short of head — CI run 33696190801 failed
  * this file with lastBlock 29 on a README-only PR.
  *
- * The deadline is an upper bound that FAILS, and it is deliberately far above any plausible load:
- * `node --test` has no timeout by default, so a condition that never comes true has to red the
- * job rather than hang it forever.
+ * The deadline is an upper bound that FAILS, and it is deliberately far above any plausible load.
+ * A deadline is not enough on its own: throwing here skips the rest of the test body, so whatever
+ * shuts the indexer down has to run in a `finally`. Otherwise the poll loop's re-arming sleep
+ * keeps the event loop alive and the timeout hangs the runner instead of redding it — `node --test`
+ * has no default timeout and ci.yml sets no `timeout-minutes`, so that costs six hours, not 12
+ * seconds. Every caller below shuts down unconditionally for exactly this reason.
  */
 async function waitFor(condition, describe, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    if (condition()) return;
+    if (await condition()) return;
     if (Date.now() >= deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${describe()}`);
     await new Promise((r) => setTimeout(r, 2));
   }
@@ -105,11 +108,14 @@ test('catchUp with no signal still drains to the head (existing behaviour unchan
 
 test('stop() ends the poll loop and leaves a readable snapshot at the right cursor', async () => {
   const dir = await tmp();
+  /** @type {null | (() => Promise<number>)} */
+  let stop = null;
   try {
     const cfg = resolveIndexerConfig(ENV(dir));
-    const { start, stop, daemon } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
-    const running = start();
-    await caughtUpTo(daemon, 30);                   // it caught up and is idling — not "60ms elapsed"
+    const built = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    stop = built.stop;
+    const running = built.start();
+    await caughtUpTo(built.daemon, 30);             // it caught up and is idling — not "60ms elapsed"
 
     const lastBlock = await stop();
     assert.equal(lastBlock, 30);
@@ -121,6 +127,10 @@ test('stop() ends the poll loop and leaves a readable snapshot at the right curs
     assert.equal(report.counts.vaults, 1, 'the vault it indexed survived the shutdown');
     assert.equal(report.resumeFrom, 31);
   } finally {
+    // Unconditional: an assertion or a timeout above must not leave the poll loop running (see
+    // waitFor). Calling it twice on the happy path is harmless — the abort is idempotent and the
+    // final save just rewrites the state we already read.
+    await stop?.();
     await rm(dir, { recursive: true, force: true });
   }
 });
@@ -139,14 +149,18 @@ test('stop() is safe before start() — a process killed during boot still write
 
 test('the indexer heartbeats while polling, stamped with its own staleness budget', async () => {
   const dir = await tmp();
+  /** @type {null | (() => Promise<number>)} */
+  let stop = null;
   try {
     const cfg = resolveIndexerConfig(ENV(dir));
     // POLL_INTERVAL_MS=20 → floored at 30s so a fast poll cannot become a hair-trigger.
     assert.equal(cfg.heartbeatStaleMs, 30_000);
 
-    const { start, stop, heartbeat, daemon } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
-    start();
-    await caughtUpTo(daemon, 30);
+    const built = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    stop = built.stop;
+    const heartbeat = built.heartbeat;
+    built.start();
+    await caughtUpTo(built.daemon, 30);
 
     // Beaten at boot, before the first batch: an indexer grinding through a cold-start backlog is
     // alive and must not be reported dead while it works.
@@ -154,15 +168,22 @@ test('the indexer heartbeats while polling, stamped with its own staleness budge
     assert.equal(boot.service, 'indexer');
     assert.equal(boot.staleAfterMs, 30_000);
 
-    // And it keeps advancing as it polls. The 1s floor on writes is why this waits: a fast
-    // catch-up ticks far quicker than that and must not turn into a write per batch.
-    await new Promise((r) => setTimeout(r, 1100));
-    const later = await readHeartbeatFile(heartbeat.path);
+    // And it keeps advancing as it polls. This takes about a second because of the 1s floor on
+    // writes — a fast catch-up ticks far quicker than that and must not turn into a write per
+    // batch — but it waits for the beat ITSELF to advance rather than for a duration chosen to be
+    // longer than the floor. A fixed sleep here has the same defect as the one above: its margin
+    // is whatever is left over after everything else on a loaded runner.
+    let later = boot;
+    await waitFor(
+      async () => { later = await readHeartbeatFile(heartbeat.path); return later.ts > boot.ts; },
+      () => `the heartbeat to advance past its boot beat at ${boot.ts} (still ${later.ts})`,
+    );
     await stop();
     assert.ok(later.ts > boot.ts, 'the beat keeps advancing while polling');
     assert.equal(later.detail.lastBlock, 30);
     assert.equal(later.detail.vaults, 1);
   } finally {
+    await stop?.();                                 // unconditional — see waitFor
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/packages/indexer/test/shutdown.test.mjs
+++ b/packages/indexer/test/shutdown.test.mjs
@@ -37,6 +37,32 @@ function fakeClient(head = 30) {
   };
 }
 
+/**
+ * Wait for something the daemon actually reaches, instead of for a duration we hope is long
+ * enough. A fixed sleep here was a race: on a loaded runner the poll loop is still working
+ * through the backlog when the sleep expires, stop() then honours the abort at the next batch
+ * boundary, and the assertions red against a cursor short of head — CI run 33696190801 failed
+ * this file with lastBlock 29 on a README-only PR.
+ *
+ * The deadline is an upper bound that FAILS, and it is deliberately far above any plausible load:
+ * `node --test` has no timeout by default, so a condition that never comes true has to red the
+ * job rather than hang it forever.
+ */
+async function waitFor(condition, describe, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (condition()) return;
+    if (Date.now() >= deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${describe()}`);
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+/** The completion signal these tests actually mean by "let it catch up": the cursor reached head. */
+const caughtUpTo = (daemon, block) => waitFor(
+  () => daemon.getState().lastBlock === block,
+  () => `the poll loop to drain to block ${block} (cursor is at ${daemon.getState().lastBlock})`,
+);
+
 test('catchUp checks the abort signal BETWEEN batches, so SIGTERM is honoured mid-backlog', async () => {
   const dir = await tmp();
   try {
@@ -81,9 +107,9 @@ test('stop() ends the poll loop and leaves a readable snapshot at the right curs
   const dir = await tmp();
   try {
     const cfg = resolveIndexerConfig(ENV(dir));
-    const { start, stop } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    const { start, stop, daemon } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
     const running = start();
-    await new Promise((r) => setTimeout(r, 60));   // let it catch up and idle
+    await caughtUpTo(daemon, 30);                   // it caught up and is idling — not "60ms elapsed"
 
     const lastBlock = await stop();
     assert.equal(lastBlock, 30);
@@ -118,9 +144,9 @@ test('the indexer heartbeats while polling, stamped with its own staleness budge
     // POLL_INTERVAL_MS=20 → floored at 30s so a fast poll cannot become a hair-trigger.
     assert.equal(cfg.heartbeatStaleMs, 30_000);
 
-    const { start, stop, heartbeat } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
+    const { start, stop, heartbeat, daemon } = await buildIndexer(cfg, { log: () => {}, logger: {}, client: fakeClient(30) });
     start();
-    await new Promise((r) => setTimeout(r, 60));
+    await caughtUpTo(daemon, 30);
 
     // Beaten at boot, before the first batch: an indexer grinding through a cold-start backlog is
     // alive and must not be reported dead while it works.


### PR DESCRIPTION
## What red, and why it was not the code under test

`stop() ends the poll loop and leaves a readable snapshot at the right cursor`
(`packages/indexer/test/shutdown.test.mjs`) failed the `backend` job on
[#150](https://github.com/SlumperSan/agent-governed-vaults/pull/150), a
README-only change that cannot be causal. From run `33696190801` attempt 1:

```
test at packages/indexer/test/shutdown.test.mjs:80:1
  at TestContext.<anonymous> (.../shutdown.test.mjs:89:12)
    actual: 29,
    expected: 30,
```

The test slept a fixed **60ms** to "let it catch up and idle", then called `stop()`
and asserted the cursor sat at head. With `POLL_INTERVAL_MS=20`, `BATCH_BLOCKS=10`
and head=30, catch-up is four batches, each doing an atomic write. Unloaded that
takes ~11ms, so the sleep carries 50ms of slack. Loaded, it does not: `stop()`
aborts, `catchUp()` honours the abort at the next batch boundary **exactly as
designed**, and the assertion reds against a cursor one batch short of head. `29`
is the third batch — `[20..29]` persisted, `[30..30]` never ran.

Nothing about the shutdown path is wrong. The test's expectation of wall-clock was.

## The fix

Wait for the completion signal the test actually means — the daemon reaching the
head cursor — instead of for a duration we hope is long enough. `daemon` and
`getState()` are already public and already used elsewhere in this file.

Widening the sleep was rejected: it makes the flake rarer and the suite slower
without removing the race.

The wait carries a 5s deadline that fails, **and every call site shuts the indexer
down in a `finally`.** The second half is not decoration — see below.

## The deadline alone was a defect, caught in review

The first commit had the deadline but not the `finally`, and `waitFor` throws
*before* `stop()`. So on the timeout path `ac.abort()` never ran, the poll loop's
20ms re-arming sleep kept the event loop alive, and the runner **red and then
hung** — the opposite of the docblock's stated intent. `node --test` has no
default timeout and `ci.yml` sets no `timeout-minutes`, so the `backend` job would
have burned GitHub's 360-minute default instead of failing in 12 seconds. That is
strictly worse than the flake being fixed.

Caught by FlakeReview155, reproduced independently before changing anything
(shipped body, 2000ms-per-round-trip client: threw at 5s, still alive when a 25s
`timeout` killed it — exit 124). After the `finally`, same harness:

```
node --test hang.test.mjs other.test.mjs
ℹ pass 1  ℹ fail 1  ℹ duration_ms 10147
node --test exit=1 after 10s          ← reds and EXITS
```

Single-file and multi-file both. The `waitFor` docblock now records why the
`finally` is load-bearing, so the next call site added here inherits the reason.

The trigger that makes this matter is not the slow-runner tail — it is fixture
coupling. `caughtUpTo(daemon, 30)` is reachable only because `ENV()` sets
`CONFIRMATIONS: '0'`: `tick()` caps `to` at `head - confirmations`, so 30 *is* the
cursor's terminal value. Bump `CONFIRMATIONS` or the fake head and the condition
becomes permanently unreachable, and the penalty for that ordinary edit has to be
an assertion diff, not a six-hour wedge.

## Evidence

"Passes locally" proves nothing here — it already did that, 7/7 across five runs,
while red in CI. The discriminating test is the shipped test body run against a
client whose every RPC round-trip costs `lag` ms, which is what a loaded runner
does to it. (`setTimeout(0)` is ~15ms on Windows, so `lag=0` is already mild load,
not a baseline; the `none` row is a client with no delay at all.)

| lag | old body | new body |
|---|---|---|
| none | PASS (70ms) | PASS (28ms) |
| 0ms | **FAIL** `actual=9` | PASS |
| 15ms | **FAIL** `actual=9` | PASS |
| 50ms | **FAIL** `actual=9` | PASS |

Lag-**independent**, not merely lag-tolerant. The `lag=15` old-body failure
reproduces at 137–157ms against CI's observed 147ms. Independently confirmed by
the reviewer, who reproduced the same class of red at `actual: 9` with no
production code changed.

## Scope

- Fixed the heartbeat test's identical "let it catch up" sleep — same race, same
  file; its `later.detail.lastBlock === 30` assertion depends on the same drain.
- The **1100ms heartbeat-floor sleep** below it also changed, because the faster
  wait above silently cut its slack from ~184ms to ~125ms (measured by the
  reviewer) — a regression this PR would have introduced, surfacing later as a
  confusing new flake with `later.detail.lastBlock` at `0`. Widening it to 1300ms
  is the move this PR exists to argue against, so it now waits for the beat
  *itself* to advance past the boot beat, under the same deadline. No margin left
  to erode, and the test went 1136ms → ~1030ms.
- **Left alone:** the 200ms wait in the listener-leak test. It asserts the
  *absence* of a warning, and a slow runner only produces fewer sleeps, which
  cannot false-red.
- **No production change.** `createRotatingWriter.write()`'s elapsed-time gate was
  the other suspect and is not implicated: with `SNAPSHOT_BACKUP_INTERVAL_MS`
  defaulting to 300 000ms it rotates once here, and rotation only ever *reads*
  `path` (copy, never rename) while `atomicWriteFile` is write-tmp-then-rename, so
  `path` never blinks for `verifySnapshot`. Confirmed independently in review.

One known adjacent wart, deliberately not fixed here: `start()` assigns `running`
only after awaiting the boot heartbeat, so a `stop()` landing in that window does
not wait for the loop. It is not the cause of this flake, it interacts with the
`stop() is safe before start()` test, and folding it in would turn a test-only fix
into a design argument.

Suite after the change: 7/7 on this file across repeated runs; `npm run test:backend`
967/971, with the two failures in `scripts/test/config-doc-truth.test.mjs` caused by
other agents' `.claude/worktrees/` copies of `docs/LAUNCH-READINESS.md` being scanned
in this shared working tree — absent from a clean CI checkout, and green in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
