### PR TITLE
fix(claims): the operator's site-stated powers omit the one power that differs — the fee

### DIFF
--- a/apps/site/faq.html
+++ b/apps/site/faq.html
@@ -79,7 +79,7 @@
 
       <article class="qa">
         <h2>Can you rug me?</h2>
-        <p>Not through the contracts. As written they are non-custodial, with no seize function, no privileged withdrawal and no admin key. An operator cannot withdraw another member's funds, and neither can anyone else. The operator's powers are the powers of any member holding the same stake: propose, and vote.</p>
+        <p>Not through the contracts. As written they are non-custodial, with no seize function, no privileged withdrawal and no admin key. An operator cannot withdraw another member's funds, and neither can anyone else. Operatorship confers no authority to execute an unpassed rebalance, pause, reprice, upgrade, skip the timelock, or move, freeze or seize member funds. Its one power beyond proposing and voting like any member of equal stake is economic: the operator identity receives the 10% performance fee, which no other member does.</p>
         <p>This describes source code. Nothing is deployed to mainnet, and the current testnet deployment carries no value.</p>
         <p>You can still lose everything — to a bug, to the market, or to a governance majority you disagree with. Those are different failure modes and they are all on the <a href="risks.html">risks page</a>.</p>
         <!-- COUNSEL: the non-custodial claim, stated as a direct answer about SOURCE and paired with the standing qualifier that nothing has been deployed. Must be re-verified against bytecode if anything is ever deployed. -->

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -106,7 +106,7 @@
         </div>
         <div>
           <dt>What we hold</dt>
-          <dd>Nothing. As written, the contracts are non-custodial: an operator cannot withdraw another member's funds, and no address in the system can seize, freeze or reassign your shares.</dd>
+          <dd>No custody of your funds and no control over them. As written, the contracts are non-custodial: an operator cannot withdraw another member's funds, and no address in the system can seize, freeze or reassign your shares. (The operator identity does earn the 10% performance fee — compensation, not custody or control; the operators page sets it out.)</dd>
           <!-- COUNSEL: the non-custodial claim, recast as a statement about source — no party, including the operator or the deploying team, can move another member's funds. Nothing is deployed to mainnet, so re-verify against the launch tree before publication and against bytecode if anything is ever deployed there. -->
         </div>
       </dl>
@@ -125,7 +125,7 @@
         </div>
         <div>
           <h3>Cannot take your funds</h3>
-          <p>There is no seize function and no privileged withdrawal. The operator's powers are the powers of any member holding the same stake: propose and vote.</p>
+          <p>There is no seize function and no privileged withdrawal. Operatorship confers no authority to execute a rebalance the members did not pass, to pause, reprice, upgrade, skip the timelock, or move, freeze or seize another member's funds. Its one power beyond proposing and voting like any member of equal stake is economic: the operator identity receives the 10% performance fee, which no other member does.</p>
         </div>
         <div>
           <h3>Cannot route the exit fee to the operator</h3>


### PR DESCRIPTION
## Why

`CLAUDE.md` mandates **enumerating the operator's lack of authority** rather than a blanket equivalence, precisely because the operator **is** the sole recipient of the 10% performance fee — which makes *"the operator's powers are the powers of any member of equal stake"* falsifiable in one transaction.

Verified against source: `FeeEngine.sol:104/120/151` credit `claimableFees[registry.operatorAddressOf(opId)] += fee`, so a same-stake **non-operator** member receives none of it.

## Fixed

Two site claims stated the false equivalence, corrected to the enumerated form already used on `operators.html:123` — operatorship confers no authority to execute an unpassed rebalance, pause, reprice, upgrade, skip the timelock, or move/freeze/seize member funds; its one power beyond propose+vote is economic (the 10% fee, which no other member receives):

- `apps/site/index.html:128` ("Cannot take your funds")
- `apps/site/faq.html:82` ("Can you rug me?")

Also `apps/site/index.html:108` — *"What we hold: Nothing"*, the bare universal negative the CLAUDE.md guard warns is falsifiable. Recast to "No custody of your funds and no control over them", keeping the true non-custodial core and noting the operator earns the fee as compensation, not custody.

## Left alone — verified already correct

`operators.html:123` (the enumerated CANNOT-do list) and `:147/:152` (fee mechanics) — the model this copied. `risks.html:182`'s *"the operator has no such power"* is scoped to moving funds and is true.

## Verification

Site HTML only. Full `npm run gate` passes (412.7s); site test and `claims-lede-truth` guard 6 (operator universal-power shape) pass. Nothing deployed — publishing remains the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
