### PR TITLE
fix(soak): vault B ships the pre-M-6 gov config and cannot register

### DIFF
--- a/scripts/soak/soak-vaults.json
+++ b/scripts/soak/soak-vaults.json
@@ -32,9 +32,9 @@
       "timelockDuration": 0,
       "executionWindow": 86400,
       "quorumBps": 5000,
-      "proposalThresholdBps": 0,
-      "concentrationCapBps": 10000,
-      "proposalCooldown": 0
+      "proposalThresholdBps": 100,
+      "concentrationCapBps": 4000,
+      "proposalCooldown": 3600
     }
   },
 


### PR DESCRIPTION
## Found by actually running the soak

Drill 1 fails on the live remediated contracts. Reproduced against Base Sepolia, 2026-09-03:

```
Error: cast send 0xD963f553…1805 registerVault(address,(uint32,…)) failed:
execution reverted, data: "0x41d05fdb": BadGovConfig
```

## Cause

`scripts/soak/soak-vaults.json` `vaultB.gov` still carries the **exact pre-M-6 values** the audit flagged as *"every named CM-6/VO-5 defence DISABLED"*:

| field | shipped | `_validateConfig` requires |
|---|---|---|
| `concentrationCapBps` | **10000** | nonzero and **≤ 5000** |
| `proposalCooldown` | **0** | **[1 hour, 30 days]** |
| `proposalThresholdBps` | 0 | contract-legal, but M-6 records that 0 re-opens the M-7/C-1 precondition |

M-6's remediation added those bounds to `Governance._validateConfig` and fixed both chain configs (`base-mainnet.json`, `base-sepolia.json`). **It never reached the soak's own drill config.** So the soak battery has been undeployable against the very contracts it validates — **gate 3 could not have passed for anyone.** The correction didn't travel.

## Fix

Values that satisfy the validator *and* don't ship a config that disables its own defences:

- `concentrationCapBps` → **4000** (matches `base-mainnet.json`)
- `proposalCooldown` → **3600** (the floor; matches base-sepolia's testnet choice)
- `proposalThresholdBps` → **100** (matches base-sepolia smoke)
- `quorumBps` stays **5000** — the deliberate 50%-vs-25% contrast with the smoke vault that drill 1 asserts on, and the only gov value the drill checks on-chain.

## Verification

All eight `_validateConfig` bounds checked against `Governance.sol` before restarting. Drill 1 then proceeded past the failure: vault B registered at quorum 5000bps, USDC approved, 5 USDC deposited and escrowed with `navWad` still 0 (EE-1 holds), now in its 4-hour observation window. **The soak is currently running against this fix.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
