### PR TITLE
feat(site): redirect every non-canonical hostname to the zone, closing the geofence bypass

### DIFF
--- a/apps/site/_redirects
+++ b/apps/site/_redirects
@@ -8,9 +8,15 @@
 # gives `workers.example.com/* workers.example.com/blog/:splat 301` as an example of a line that
 # does not work. Invalid lines are ignored rather than reported, so a hostname rule written here
 # would look correct in review, deploy without error, and silently do nothing -- which is worse
-# than not writing it. Redirecting `www.rwally.com` to `rwally.com` is a zone-level Bulk Redirect
-# in the Cloudflare dashboard; the steps are in the pull request that added this file and in
-# Cloudflare's "Redirecting www to domain apex" guide.
+# than not writing it. That much is still true of THIS file.
+#
+# THE HOSTNAME RULE NOW LIVES IN `functions/_middleware.js`, which can read `Host` because it is a
+# Function rather than a static rule table. It redirects every non-canonical hostname — including
+# `www.rwally.com` AND the `*.rwally.pages.dev` hostnames — to `rwally.com` with a 301. That is not
+# only a www->apex tidy-up: the sanctions geofence is a WAF rule on the `rwally.com` ZONE, and the
+# pages.dev hostnames are not in that zone, so before the middleware they were an unfiltered path
+# to the same content. Read that file before changing anything here. A zone-level Bulk Redirect in
+# the dashboard remains a valid alternative for the www leg, but it would not cover pages.dev.
 #
 # NO CANONICALIZATION RULE IS NEEDED EITHER. Pages already redirects HTML pages to their
 # extension-less counterparts: `/faq.html` to `/faq`, and `/index.html` to `/`. Those are the

--- a/apps/site/functions/_middleware.js
+++ b/apps/site/functions/_middleware.js
@@ -1,0 +1,45 @@
+/**
+ * Canonical-host redirect for the public site.
+ *
+ * WHY THIS EXISTS — it closes a hole in the sanctions geofence, not an SEO nicety.
+ *
+ * The country block is a WAF custom rule on the `rwally.com` ZONE. Cloudflare Pages also serves
+ * this exact site on hostnames that are NOT part of that zone:
+ *
+ *   rwally.pages.dev              the project's production Pages hostname
+ *   <hash>.rwally.pages.dev       one per deployment
+ *   <branch>.rwally.pages.dev     one per branch alias
+ *
+ * Zone WAF rules never see those requests, so every one of them was an unfiltered path to the
+ * same content — the restriction was one hostname away from being irrelevant. Note the fix is
+ * NOT to hide the pages.dev URLs: `rwally.pages.dev` is the PRODUCTION Pages hostname, and the
+ * "public access to preview deployments" setting governs previews only, so it cannot remove it.
+ * Redirecting is what actually works, because it puts every real visitor back on the zone where
+ * the WAF applies.
+ *
+ * WHY HERE AND NOT `_redirects` — that file explains at length that Pages matches the source
+ * column on PATH ONLY, so a hostname rule written there deploys clean and silently does nothing.
+ * A Function is the only in-repo mechanism that can read `Host`. It needs no plan upgrade and no
+ * Cloudflare Access configuration.
+ *
+ * CANONICAL HOST is `rwally.com`, matching sitemap.xml, robots.txt's Sitemap line, and every
+ * page's og:url. `www.rwally.com` redirects here too, which is the www->apex rule `_redirects`
+ * records as impossible to express there.
+ *
+ * A redirect is not an access control. Someone who ignores the 301 can still read the response
+ * from a pages.dev hostname directly. This closes the ordinary-visitor path, and is deliberately
+ * the weaker of the two claims — the geofence itself remains the WAF rule on the zone.
+ */
+
+const CANONICAL_HOST = 'rwally.com';
+
+export const onRequest = async (context) => {
+  const { request, next } = context;
+  const url = new URL(request.url);
+
+  if (url.hostname === CANONICAL_HOST) return next();
+
+  // Preserve path and query so a shared deep link survives the hop.
+  const target = new URL(`${url.pathname}${url.search}`, `https://${CANONICAL_HOST}`);
+  return Response.redirect(target.toString(), 301);
+};

--- a/apps/site/test/middleware.test.mjs
+++ b/apps/site/test/middleware.test.mjs
@@ -1,0 +1,69 @@
+// @ts-check
+/**
+ * The canonical-host middleware, which is what keeps the sanctions geofence from being one
+ * hostname away from irrelevant.
+ *
+ * The country block is a WAF rule on the `rwally.com` ZONE. Cloudflare Pages serves the same
+ * site on `rwally.pages.dev` and on per-deployment and per-branch hostnames, none of which are
+ * in that zone, so zone WAF rules never see them. The middleware 301s every non-canonical
+ * hostname back to `rwally.com`, which puts real visitors back where the rule applies.
+ *
+ * These tests exist because that is easy to break by accident — a refactor that returns
+ * `next()` unconditionally would still serve every page correctly on every hostname, pass every
+ * other test in this suite, and silently re-open the hole. Nothing else would notice.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest } from '../functions/_middleware.js';
+
+const SERVED = 'served-by-next';
+/** @param {string} url */
+const ctx = (url) => ({
+  request: new Request(url),
+  next: async () => new Response(SERVED, { status: 200 }),
+});
+
+test('the canonical host is served, not redirected', async () => {
+  const res = await onRequest(ctx('https://rwally.com/how-it-works'));
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), SERVED);
+});
+
+test('every pages.dev hostname is redirected to the zone — the geofence hole', async () => {
+  // Production Pages hostname. This one CANNOT be removed by the "public access to preview
+  // deployments" setting, because it is not a preview — redirecting is the only in-repo fix.
+  for (const host of [
+    'rwally.pages.dev',
+    'aa060edf.rwally.pages.dev', // a per-deployment hostname
+    'protocol-main.rwally.pages.dev', // a per-branch alias
+  ]) {
+    const res = await onRequest(ctx(`https://${host}/risks`));
+    assert.equal(res.status, 301, `${host} was served instead of redirected`);
+    assert.equal(
+      res.headers.get('location'),
+      'https://rwally.com/risks',
+      `${host} did not land on the canonical zone`
+    );
+  }
+});
+
+test('www redirects to the apex — the rule _redirects cannot express', async () => {
+  const res = await onRequest(ctx('https://www.rwally.com/faq'));
+  assert.equal(res.status, 301);
+  assert.equal(res.headers.get('location'), 'https://rwally.com/faq');
+});
+
+test('path and query survive the hop, so a shared deep link still works', async () => {
+  const res = await onRequest(ctx('https://rwally.pages.dev/operators?ref=x&y=1'));
+  assert.equal(res.headers.get('location'), 'https://rwally.com/operators?ref=x&y=1');
+});
+
+test('the root path redirects without producing a double slash', async () => {
+  const res = await onRequest(ctx('https://rwally.pages.dev/'));
+  assert.equal(res.headers.get('location'), 'https://rwally.com/');
+});
+
+test('an http request on a non-canonical host is upgraded to https', async () => {
+  const res = await onRequest(ctx('http://rwally.pages.dev/agents'));
+  assert.equal(res.headers.get('location'), 'https://rwally.com/agents');
+});


### PR DESCRIPTION
## The hole

The sanctions geofence is a WAF custom rule on the **`rwally.com` zone**. Cloudflare Pages serves the identical site on hostnames that are **not in that zone**:

```
rwally.pages.dev            the project's PRODUCTION Pages hostname
<hash>.rwally.pages.dev     one per deployment
<branch>.rwally.pages.dev   one per branch alias
```

Zone WAF rules never see those requests. Each was an unfiltered path to the same content — the country block was **one hostname away from irrelevant**.

## Why not just hide them

The *"public access to preview deployments"* setting governs **preview** hostnames only. `rwally.pages.dev` is the **production** Pages hostname, not a preview, so that setting cannot remove it. (I'd pointed the owner at that setting earlier — it was wrong advice.) Redirecting is what actually works: it puts every real visitor back on the zone where the rule applies, and it needs **no plan upgrade and no Cloudflare Access config** — the zone is on Free.

## Why a Function and not `_redirects`

`_redirects` already documents at length that Pages matches the source column on **path only**, so a hostname rule written there deploys clean and silently does nothing. A Function is the only in-repo mechanism that can read `Host`.

`_redirects` now **points at the middleware** instead of asserting the www→apex rule is only expressible as a dashboard Bulk Redirect — true of that file, no longer true of the repo.

## Behaviour

Canonical host `rwally.com`, matching `sitemap.xml`, `robots.txt`'s Sitemap line and every page's `og:url`. `www.rwally.com` redirects there too — the www→apex leg `_redirects` recorded as impossible. Path and query preserved so shared deep links survive.

**Scoped honestly:** a 301 is not an access control. Someone who ignores it can still read a response from a pages.dev hostname directly. This closes the ordinary-visitor path; the geofence itself remains the WAF rule on the zone. Both statements are in the file header.

## Tested, and the test is probed

Six cases: canonical host, all three pages.dev shapes, www, query preservation, root path, http→https. Injecting the obvious regression — `return next()` unconditionally, which would still serve every page correctly on every hostname and pass every other test in the suite — turns **5 of 6 red**.

`npm run gate` passes (382.6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
