### PR TITLE
fix(site): open redirect in the canonical-host middleware (CWE-601) — was live

### DIFF
--- a/apps/site/functions/_middleware.js
+++ b/apps/site/functions/_middleware.js
@@ -39,7 +39,26 @@ export const onRequest = async (context) => {
 
   if (url.hostname === CANONICAL_HOST) return next();
 
-  // Preserve path and query so a shared deep link survives the hop.
-  const target = new URL(`${url.pathname}${url.search}`, `https://${CANONICAL_HOST}`);
+  // Rewrite the AUTHORITY of the already-parsed URL. Never re-parse a path as a relative
+  // reference against a base — that was an open redirect (CWE-601), shipped and live:
+  //
+  //   new URL(`${url.pathname}${url.search}`, `https://${CANONICAL_HOST}`)
+  //
+  // A pathname beginning with `//` is a PROTOCOL-RELATIVE url, so the WHATWG parser keeps the
+  // base's scheme and REPLACES its authority. `https://rwally.pages.dev//evil.example/x` then
+  // redirected to `https://evil.example/x` — an attacker-controlled destination reached through
+  // a link on this project's own domain. A `\` variant worked too; the parser normalises it to
+  // `/` before parsing.
+  //
+  // Zone-level URL normalization does NOT save this: it is a zone feature, and `*.pages.dev` is
+  // in no zone — which is this file's own founding premise. The bug was exploitable precisely
+  // where the file exists to help.
+  //
+  // Mutating the parsed URL cannot escape the host: `hostname` is a setter on an already-parsed
+  // origin, so `//evil.example/x` stays a PATH.
+  const target = new URL(url);
+  target.protocol = 'https:';
+  target.hostname = CANONICAL_HOST;
+  target.port = '';
   return Response.redirect(target.toString(), 301);
 };

--- a/apps/site/test/middleware.test.mjs
+++ b/apps/site/test/middleware.test.mjs
@@ -75,7 +75,7 @@ test('a protocol-relative path cannot redirect off the canonical host (CWE-601)'
   //   https://rwally.pages.dev//evil.example/x  ->  https://evil.example/x
   for (const path of [
     '//evil.example/x',
-    '/\/evil.example/x', // the parser normalises `\` to `/` before parsing
+    '/' + String.fromCharCode(92) + '/evil.example/x', // a REAL backslash; a '\\/' literal collapses to '//' and silently duplicates the line above
     '//attacker.test/connect-wallet?a=1',
     '///triple.example/x',
   ]) {

--- a/apps/site/test/middleware.test.mjs
+++ b/apps/site/test/middleware.test.mjs
@@ -67,3 +67,24 @@ test('an http request on a non-canonical host is upgraded to https', async () =>
   const res = await onRequest(ctx('http://rwally.pages.dev/agents'));
   assert.equal(res.headers.get('location'), 'https://rwally.com/agents');
 });
+
+test('a protocol-relative path cannot redirect off the canonical host (CWE-601)', async () => {
+  // This shipped and was LIVE: building the target as `new URL(pathname+search, base)` treats a
+  // pathname starting with `//` as protocol-relative, so the parser replaces the AUTHORITY and
+  // the redirect leaves the site. Verified in production before the fix:
+  //   https://rwally.pages.dev//evil.example/x  ->  https://evil.example/x
+  for (const path of [
+    '//evil.example/x',
+    '/\/evil.example/x', // the parser normalises `\` to `/` before parsing
+    '//attacker.test/connect-wallet?a=1',
+    '///triple.example/x',
+  ]) {
+    const res = await onRequest(ctx(`https://rwally.pages.dev${path}`));
+    const loc = new URL(res.headers.get('location'));
+    assert.equal(
+      loc.hostname,
+      'rwally.com',
+      `open redirect: ${path} escaped to ${loc.hostname}`
+    );
+  }
+});


### PR DESCRIPTION
## This was live in production

An independent review of #166 found an **open redirect** in the redirect construction. #166 was merged and deployed **before that verdict landed**, so the vulnerability shipped. Confirmed against the live site before fixing:

```
https://rwally.pages.dev//evil.example/x              →  https://evil.example/x
https://rwally.pages.dev/\/evil.example/x             →  https://evil.example/x
https://rwally.pages.dev//attacker.test/connect-...   →  https://attacker.test/connect-...
```

## Cause

The target was built as a **relative reference against a base**:

```js
new URL(`${url.pathname}${url.search}`, `https://${CANONICAL_HOST}`)
```

A pathname beginning with `//` is **protocol-relative** — the WHATWG parser keeps the base's scheme and **replaces its authority**.

## Why nothing upstream caught it

Cloudflare can merge successive slashes, but only under zone URL normalization, whose **default type is RFC-3986, which does not merge slashes**. More decisively, normalization is a **zone** feature and `*.pages.dev` is in **no zone** — this middleware's own founding premise. Verified empirically by the reviewer: `curl -I 'https://rwally.pages.dev//evil.example/x'` showed the `//` reaching the Function unmerged.

So the bug was exploitable **exactly where the file exists to help**: a phishing link on the project's own Cloudflare-hosted domain, on a site about custody of member funds.

## Fix

```js
const target = new URL(url);
target.protocol = 'https:';
target.hostname = CANONICAL_HOST;
target.port = '';
```

`hostname` is a setter on an already-parsed origin, so `//evil.example/x` stays a **path**. There is no re-parse to hijack.

## Verification

- **Independent review: 216 hostile probes, 0 escapes.** Covered `//`, `///`, `\`, `/\/`, `%2f%2f`, `%5c%5c`, userinfo, `/https://evil`, traversal, NUL, tab, fraction-slash, ideographic full stop, Cyrillic homograph, punycode, 60k-char paths. Every `Location` was `https://rwally.com/…`.
- **CRLF header injection impossible** at two layers: the WHATWG parser strips CR/LF/TAB during parse, and `Response.redirect()` re-parses its argument.
- **Verified live after deploying**: all hostile shapes land on `rwally.com`, site serves 200, deep links keep path+query.
- **`_headers` survives `next()`** — CSP, `referrer-policy`, `nosniff` all measured present on the live deployment. (The review flagged Cloudflare's docs as ambiguous here; measurement settles it.)

## Second commit — a false coverage claim, corrected

The review also found that the test's backslash entry, `'/\/evil.example/x'`, is an **unrecognized JS escape** evaluating to `'//evil.example/x'` — byte-identical to the line above. There were **three** distinct shapes, not four, and the backslash shape was not among them. Rebuilt from a char code; now four distinct shapes, one with a real backslash — built from `String.fromCharCode(92)` in-test, so the backslash is true **by construction** rather than claimed in prose. (An independent review noted that an earlier wording here, "asserted in-test", overstated it: the block contains one assertion, on the resulting hostname, and none on the literal's contents. Construction is the stronger guarantee, but it is not an assertion, and this file's own history is why the distinction gets written down.) The behaviour was never wrong — this is a coverage claim being made true.

> **Sequencing note:** the fix is already deployed to production because the vulnerability was live. This PR reconciles `main` with what is serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
