### PR TITLE
fix(soak): the freeze-safety probe was inert for the whole run — half its wiring was never set

### DIFF
--- a/scripts/soak/drill4-oraclefreeze.mjs
+++ b/scripts/soak/drill4-oraclefreeze.mjs
@@ -129,7 +129,7 @@ for (const r of canaryRows) {
 
 if (result.verdict === 'INSUFFICIENT_EVIDENCE') {
   log('VERDICT: INSUFFICIENT EVIDENCE — the series contains no readable asset observation');
-  log(`  ${result.unreadableSamples} unreadable sample(s). "Nothing broke" and "nothing was measured" are opposite claims;`);
+  log(`  ${result.unreadableObservations} unreadable asset observation(s). "Nothing broke" and "nothing was measured" are opposite claims;`);
   log('  this drill will not report the second as the first. Fix the sampler/RPC and re-run across a fresh window.');
   assert(false,
     'drill 4 collected no readable oracle observation across the window — it certifies nothing, so it must not pass');

--- a/scripts/soak/drill4-oraclefreeze.mjs
+++ b/scripts/soak/drill4-oraclefreeze.mjs
@@ -52,6 +52,7 @@ import { ROOT, log, assert, openState } from './lib.mjs';
 import { loadDeployment } from './deployment.mjs';
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer, oracleCanaryRows, verdictOf,
+  freezeSafetyReport,
 } from './series-analysis.mjs';
 
 const dep = loadDeployment(
@@ -116,38 +117,10 @@ if (!sequencer.exercised) {
   log(`  *** the sequencer was not fully up in ${sequencer.notUpSamples} sample(s); earliest computed resume ${sequencer.earliestResumesAtSec ?? 'n/a'} ***`);
 }
 
-log(`freeze-safety verdicts: ${JSON.stringify(freeze.verdicts)}`);
-if (freeze.oracleBlocked > 0) {
-  log(`  *** cancelPending was NOT callable in ${freeze.oracleBlocked} sample(s) — freeze-safety VIOLATED ***`);
-  for (const b of freeze.blockedDetail) log(`     ${b.at} ${b.vault}: ${b.verdict} — ${b.detail}`);
-} else if (freeze.probedWithPending === 0 && (freeze.unmeasured ?? 0) > 0) {
-  // NOT the same as "no pending deposit existed". The probe never ran — no vault list resolved, or
-  // no member to probe as. Saying "every sample was n/a-no-pending" here would misattribute a
-  // CONFIGURATION failure to an on-chain fact, which is the exact substitution that let this leg
-  // sit inert for a whole soak run: a statement about pending deposits standing in for a statement
-  // about the probe. The advice differs too — no observation window fixes an unconfigured probe.
-  log(`  cancelPending was NEVER PROBED: ${freeze.unmeasured} sample(s) carry not-configured/not-probed.`);
-  log('  This is MISSING EVIDENCE, not a passing check and not an on-chain finding — the probe did');
-  log('  not run, so nothing was measured either way.');
-  log('  TO FIX: the sampler resolves its vault set from SOAK_VAULTS, else from the indexer');
-  log('  projection. An empty result means the indexer had projected no vaults yet (start the');
-  log('  sampler after the indexer catches up), or SOAK_PROBE_MEMBER was unset. The per-sample');
-  log('  `reason` field names which.');
-} else if (freeze.probedWithPending === 0) {
-  log('  cancelPending was never probed against a REAL pending deposit (every sample was n/a-no-pending),');
-  log('  so freeze safety is NOT demonstrated by this run — it is merely un-contradicted.');
-  log('  TO FIX: the sampler must run DURING a 4h observation window, with SOAK_PROBE_MEMBER set');
-  log('  to the depositor. Drills 1, 2 and 5 each open one — that is the window in which a pending');
-  log('  deposit actually exists to cancel. Restart oracle-sampler.mjs right after a deposit lands.');
-} else {
-  log(`  cancelPending stayed callable in all ${freeze.probedWithPending} probed sample(s) — freeze safety held`);
-  // Partial coverage must be said out loud. "Held" over a window that was only partly probed is a
-  // narrower claim than "held", and the difference is invisible unless it is printed.
-  if ((freeze.unmeasured ?? 0) > 0) {
-    log(`  NOTE: ${freeze.unmeasured} further sample(s) were not probed at all (not-configured/not-probed),`);
-    log('  so that holds over the probed samples only, not over the whole window.');
-  }
-}
+// The wording lives in series-analysis so it can be unit-tested: nothing here executes this file,
+// so prose written inline has no regression coverage, and the first version of these branches
+// shipped a falsehood for exactly that reason.
+for (const line of freezeSafetyReport(freeze)) log(line);
 
 log(`canary oracle-freshness rows: ${canaryRows.length} (${result.canaryAssetRows ?? 0} keyed by a basket asset)${canaryExists ? '' : ' (canary state file absent)'}`);
 for (const r of canaryRows) {

--- a/scripts/soak/drill4-oraclefreeze.mjs
+++ b/scripts/soak/drill4-oraclefreeze.mjs
@@ -120,6 +120,19 @@ log(`freeze-safety verdicts: ${JSON.stringify(freeze.verdicts)}`);
 if (freeze.oracleBlocked > 0) {
   log(`  *** cancelPending was NOT callable in ${freeze.oracleBlocked} sample(s) — freeze-safety VIOLATED ***`);
   for (const b of freeze.blockedDetail) log(`     ${b.at} ${b.vault}: ${b.verdict} — ${b.detail}`);
+} else if (freeze.probedWithPending === 0 && (freeze.unmeasured ?? 0) > 0) {
+  // NOT the same as "no pending deposit existed". The probe never ran — no vault list resolved, or
+  // no member to probe as. Saying "every sample was n/a-no-pending" here would misattribute a
+  // CONFIGURATION failure to an on-chain fact, which is the exact substitution that let this leg
+  // sit inert for a whole soak run: a statement about pending deposits standing in for a statement
+  // about the probe. The advice differs too — no observation window fixes an unconfigured probe.
+  log(`  cancelPending was NEVER PROBED: ${freeze.unmeasured} sample(s) carry not-configured/not-probed.`);
+  log('  This is MISSING EVIDENCE, not a passing check and not an on-chain finding — the probe did');
+  log('  not run, so nothing was measured either way.');
+  log('  TO FIX: the sampler resolves its vault set from SOAK_VAULTS, else from the indexer');
+  log('  projection. An empty result means the indexer had projected no vaults yet (start the');
+  log('  sampler after the indexer catches up), or SOAK_PROBE_MEMBER was unset. The per-sample');
+  log('  `reason` field names which.');
 } else if (freeze.probedWithPending === 0) {
   log('  cancelPending was never probed against a REAL pending deposit (every sample was n/a-no-pending),');
   log('  so freeze safety is NOT demonstrated by this run — it is merely un-contradicted.');
@@ -128,6 +141,12 @@ if (freeze.oracleBlocked > 0) {
   log('  deposit actually exists to cancel. Restart oracle-sampler.mjs right after a deposit lands.');
 } else {
   log(`  cancelPending stayed callable in all ${freeze.probedWithPending} probed sample(s) — freeze safety held`);
+  // Partial coverage must be said out loud. "Held" over a window that was only partly probed is a
+  // narrower claim than "held", and the difference is invisible unless it is printed.
+  if ((freeze.unmeasured ?? 0) > 0) {
+    log(`  NOTE: ${freeze.unmeasured} further sample(s) were not probed at all (not-configured/not-probed),`);
+    log('  so that holds over the probed samples only, not over the whole window.');
+  }
 }
 
 log(`canary oracle-freshness rows: ${canaryRows.length} (${result.canaryAssetRows ?? 0} keyed by a basket asset)${canaryExists ? '' : ' (canary state file absent)'}`);

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -173,6 +173,16 @@ export const SEL_NO_PENDING = '0xda7557bc';
 export function classifyCancelPending(r, pendingAmount) {
   if (r.ok) return 'callable';
   if (r.err.includes(SEL_NO_PENDING)) return 'n/a-no-pending';
+  // A TRANSPORT failure is not a contract verdict — this file's own header says so, and the
+  // priceWad path already honours it via `kind === 'transport'`. This branch did not, and the
+  // consequence is worse here than there: two consecutive rate-limits against a public RPC would
+  // have fallen through to BLOCKED, which drill 4 prints as "freeze-safety VIOLATED" — a
+  // fabricated claim that member funds were trapped, caused by a 429. Recorded as unreadable
+  // instead, which counts as missing evidence and pages nobody.
+  //
+  // Latent until now: `VAULTS` was always empty, so this classifier never ran on a live probe.
+  // The discovery fallback is what makes it reachable, at 3 vaults every 120 s.
+  if (r.kind === 'transport') return 'unreadable';
   // Defence in depth: if the revert data was truncated by the RPC, a zero pending balance is
   // itself sufficient to explain a NoPending revert.
   if (pendingAmount === '0') return 'n/a-no-pending';

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -68,6 +68,35 @@ const SERIES = process.env.SOAK_SERIES ?? path.join(ROOT, 'data', 'oracle-series
 const SAMPLE_MS = Number(process.env.SOAK_SAMPLE_MS ?? 120_000);
 const PROBE_MEMBER = process.env.SOAK_PROBE_MEMBER ?? '';
 const VAULTS = (process.env.SOAK_VAULTS ?? '').split(',').map((v) => v.trim()).filter(Boolean);
+const STATE_PATH = process.env.SOAK_INDEXER_STATE ?? path.join(ROOT, 'data', 'indexer-state.json');
+
+/**
+ * The vaults to probe `cancelPending` against — explicit `SOAK_VAULTS`, else every vault the
+ * indexer has projected. Mirrors `canary-runner.resolveVaults`, and for the same reason.
+ *
+ * WHY THE FALLBACK EXISTS. `run-soak.ps1` sets `SOAK_PROBE_MEMBER` — with a comment explaining
+ * exactly why drill 4's freeze-safety probe needs it — and never set `SOAK_VAULTS`, which is the
+ * other half of the same wiring. So `VAULTS` was `[]`, the probe `.map` produced NO ROWS AT ALL,
+ * and every sample recorded `freezeSafety: []`. Drill 4 then correctly refused to claim freeze
+ * safety, but the reason looked like "no pending deposit existed" rather than "the probe was never
+ * configured" — two very different facts.
+ *
+ * It also cannot be fixed by setting `SOAK_VAULTS` at launch: drills 1 and 2 CREATE their vaults
+ * at runtime, so the addresses do not exist when the sampler starts. Discovery is the only
+ * configuration that is correct on the first sample and still correct on the hundredth.
+ */
+function resolveProbeVaults() {
+  if (VAULTS.length > 0) return { vaults: VAULTS, source: 'SOAK_VAULTS' };
+  try {
+    const state = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+    // `vaults` is a serialized Map: [[address, projection], ...].
+    const found = (state.vaults ?? []).map((e) => (Array.isArray(e) ? e[0] : e?.vault)).filter(Boolean);
+    if (found.length > 0) return { vaults: found, source: 'indexer' };
+    return { vaults: [], source: 'indexer-empty' };
+  } catch {
+    return { vaults: [], source: 'no-indexer-state' };
+  }
+}
 
 const dep = loadDeployment(
   path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
@@ -429,7 +458,12 @@ function sample(env) {
   });
 
   // FREEZE-SAFETY: cancelPending must stay callable while the oracle is frozen.
-  const freezeSafety = VAULTS.map((vault) => {
+  //
+  // An EMPTY probe set must record itself. Mapping over `[]` yields `[]`, which reads downstream as
+  // "probed, nothing to report" when the truth is "never probed" — the silent-inertness failure
+  // this repository has shipped twice. One sentinel row per sample keeps the absence in the series.
+  const { vaults: probeVaults, source: probeSource } = resolveProbeVaults();
+  const probeOne = (vault) => {
     if (!PROBE_MEMBER) return { vault, probed: false, verdict: 'not-probed', reason: 'no SOAK_PROBE_MEMBER set' };
     const pend = callRaw(vault, 'pendingDeposit(address)(uint256,uint64)', PROBE_MEMBER);
     const pendingAmount = pend.ok ? clean(pend.out.split('\n')[0]) : null;
@@ -439,7 +473,10 @@ function sample(env) {
       verdict: classifyCancelPending(r, pendingAmount),
       detail: r.ok ? 'static call returned successfully' : r.err,
     };
-  });
+  };
+  const freezeSafety = probeVaults.length === 0
+    ? [{ vault: null, probed: false, verdict: 'not-configured', reason: `no vaults to probe (${probeSource})` }]
+    : probeVaults.map(probeOne);
 
   return { t: new Date().toISOString(), chainNow, oracle: dep.aggregator, sequencer: seq, assets, freezeSafety };
 }

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -152,10 +152,10 @@ export const SEL_STALE_ORACLE = '0xa2671f4b';
 export const SEL_NO_PENDING = '0xda7557bc';
 
 /**
- * Classify a `cancelPending()` static call into a TRI-STATE verdict.
+ * Classify a `cancelPending()` static call into a FOUR-STATE verdict.
  *
- * This is the evidence drill 4 turns on, so "it reverted" is not good enough — the call reverts
- * for two entirely different reasons and only one of them is a finding:
+ * This is the evidence drill 4 turns on, so "it failed" is not good enough — the call can fail for
+ * three entirely different reasons and only one of them is a finding:
  *
  *   'callable'        the escrow-return path is open. THIS is the freeze-safety property.
  *   'n/a-no-pending'  reverted NoPending(): there is no pending deposit for this member to

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -166,9 +166,20 @@ export const SEL_NO_PENDING = '0xda7557bc';
  *   'BLOCKED'         reverted for any other reason. While the oracle is frozen this is the
  *                     real finding: a path that must never consult a price just did.
  *
- * @param {{ok:true,out:string}|{ok:false,err:string}} r
+ *   'unreadable'      the call was ATTEMPTED and the transport failed (rate limit, timeout,
+ *                     unreachable RPC). Missing evidence, never a finding — see below.
+ *
+ * NOTE the classifier is FAIL-OPEN by default: `classifyCallError` is effectively
+ * `REVERTED.test(err) ? 'revert' : 'transport'`, so an error string this file does not recognise
+ * lands on 'transport' and therefore 'unreadable' rather than 'BLOCKED'. Against a real RPC `cast`
+ * prints "execution reverted", which is matched, so the production path classifies correctly; but
+ * an exotic client wording would be recorded as missing evidence rather than as a finding. That is
+ * the quieter failure and it is deliberate — a fabricated "member funds are trapped" page is worse
+ * than a sample scored unmeasured — but it is stated here rather than left to be discovered.
+ *
+ * @param {{ok:true,out:string}|{ok:false,err:string,kind?:'revert'|'transport'}} r
  * @param {string|null} pendingAmount
- * @returns {'callable'|'n/a-no-pending'|'BLOCKED'}
+ * @returns {'callable'|'n/a-no-pending'|'unreadable'|'BLOCKED'}
  */
 export function classifyCancelPending(r, pendingAmount) {
   if (r.ok) return 'callable';
@@ -471,7 +482,7 @@ function sample(env) {
   //
   // An EMPTY probe set must record itself. Mapping over `[]` yields `[]`, which reads downstream as
   // "probed, nothing to report" when the truth is "never probed" — the silent-inertness failure
-  // this repository has shipped twice. One sentinel row per sample keeps the absence in the series.
+  // this repository has shipped three times. One sentinel row per sample keeps it in the series.
   const { vaults: probeVaults, source: probeSource } = resolveProbeVaults();
   const probeOne = (vault) => {
     if (!PROBE_MEMBER) return { vault, probed: false, verdict: 'not-probed', reason: 'no SOAK_PROBE_MEMBER set' };

--- a/scripts/soak/run-soak.ps1
+++ b/scripts/soak/run-soak.ps1
@@ -104,6 +104,15 @@ $env:SOAK_API         = if ($env:SOAK_API) { $env:SOAK_API } else { 'http://127.
 # Drill 4's freeze-safety probe needs a member who actually HAS a pending deposit. The deployer
 # gets one during drill 1's and drill 2's 4h observation windows - that is the only window in
 # which cancelPending has anything to cancel.
+#
+# The probe needs a VAULT LIST as well as a member, and this script deliberately does not set one.
+# Only half the wiring was here for the whole of the 2026-09-03 run: SOAK_PROBE_MEMBER was set and
+# SOAK_VAULTS was not, so oracle-sampler.mjs mapped over an empty list, emitted no freeze-safety
+# rows at all, and the leg was silently absent for six hours. Setting SOAK_VAULTS here would not
+# have fixed it either - drills 1 and 2 CREATE their vaults at runtime, so the addresses do not
+# exist when the sampler starts. The sampler now DISCOVERS them from the indexer projection (the
+# same source the canary uses) and records an explicit `not-configured` sentinel when it finds
+# none, so the absence can never be silent again. Set SOAK_VAULTS only to override that.
 $env:SOAK_PROBE_MEMBER = $Deployer
 
 # ── launch ───────────────────────────────────────────────────────────────────

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -182,19 +182,35 @@ export function findGaps(samples, maxGapMult) {
  * `n/a-no-pending` is counted SEPARATELY and never as a pass: with no pending deposit there is
  * nothing to cancel, so the probe proves nothing. A run in which every sample was `n/a` leaves
  * the property un-contradicted, not demonstrated — `demonstrated` says so.
+ *
+ * `not-configured` / `not-probed` are a THIRD category, added after a live run in which the
+ * sampler emitted `freezeSafety: []` for six hours because `SOAK_VAULTS` was never set: the probe
+ * had nothing to iterate, so it produced no rows and its own absence was invisible. Those verdicts
+ * now record the absence explicitly, and they must NOT be counted as `oracleBlocked` — a
+ * misconfigured harness reporting a freeze-safety BREACH is the same class of lie in the opposite
+ * direction.
  * @param {any[]} samples
  */
+export const UNMEASURED_VERDICTS = ['not-configured', 'not-probed'];
+
 export function summarizeFreezeSafety(samples) {
   /** @type {Record<string, number>} */
   const verdicts = {};
   let probedWithPending = 0;
   let oracleBlocked = 0;
+  let unmeasured = 0;
   const blockedDetail = [];
   for (const s of samples) {
     for (const f of s.freezeSafety ?? []) {
       verdicts[f.verdict] = (verdicts[f.verdict] ?? 0) + 1;
       if (f.verdict === 'callable' || f.verdict === 'ok') probedWithPending++;
-      if (!['callable', 'ok', 'n/a-no-pending'].includes(f.verdict)) {
+      // MISSING EVIDENCE IS NOT A BREACH. `not-configured` (no vaults resolved) and `not-probed`
+      // (no SOAK_PROBE_MEMBER) mean the probe never ran; treating them as `oracleBlocked` would
+      // report a freeze-safety FAILURE caused entirely by the harness being misconfigured, which
+      // is the mirror image of the bug that made this leg silent in the first place. They suppress
+      // `demonstrated` — which is correct, nothing was shown — without manufacturing an incident.
+      else if (UNMEASURED_VERDICTS.includes(f.verdict)) unmeasured++;
+      else if (f.verdict !== 'n/a-no-pending') {
         oracleBlocked++;
         if (blockedDetail.length < 5) {
           blockedDetail.push({ at: s.t, vault: f.vault, verdict: f.verdict, detail: f.detail });
@@ -206,6 +222,7 @@ export function summarizeFreezeSafety(samples) {
     verdicts,
     probedWithPending,
     oracleBlocked,
+    unmeasured,
     blockedDetail,
     demonstrated: probedWithPending > 0 && oracleBlocked === 0,
   };

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -191,7 +191,15 @@ export function findGaps(samples, maxGapMult) {
  * direction.
  * @param {any[]} samples
  */
-export const UNMEASURED_VERDICTS = ['not-configured', 'not-probed'];
+/**
+ * Verdicts that mean NOTHING WAS MEASURED, as opposed to something was measured and was fine
+ * (`callable`/`ok`), or measured and was not (`BLOCKED`).
+ *
+ * `unreadable` belongs here for the same reason the others do: a rate-limited RPC is a fact about
+ * the transport, never about the contract. Folding it into the failure bucket would let a 429
+ * print as "freeze-safety VIOLATED" — a fabricated claim that member funds were trapped.
+ */
+export const UNMEASURED_VERDICTS = ['not-configured', 'not-probed', 'unreadable'];
 
 export function summarizeFreezeSafety(samples) {
   /** @type {Record<string, number>} */
@@ -207,8 +215,13 @@ export function summarizeFreezeSafety(samples) {
       // MISSING EVIDENCE IS NOT A BREACH. `not-configured` (no vaults resolved) and `not-probed`
       // (no SOAK_PROBE_MEMBER) mean the probe never ran; treating them as `oracleBlocked` would
       // report a freeze-safety FAILURE caused entirely by the harness being misconfigured, which
-      // is the mirror image of the bug that made this leg silent in the first place. They suppress
-      // `demonstrated` — which is correct, nothing was shown — without manufacturing an incident.
+      // is the mirror image of the bug that made this leg silent in the first place.
+      //
+      // They do NOT suppress `demonstrated` on their own — an earlier version of this comment said
+      // they did, which overstated it. `demonstrated` turns on `probedWithPending > 0 &&
+      // oracleBlocked === 0`, so unmeasured samples alongside a real `callable` leave it true. That
+      // is the right behaviour (positive evidence exists, no breach) and drill 4 prints the
+      // unmeasured count beside the verdict so partial coverage is visible rather than implied.
       else if (UNMEASURED_VERDICTS.includes(f.verdict)) unmeasured++;
       else if (f.verdict !== 'n/a-no-pending') {
         oracleBlocked++;

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -233,29 +233,48 @@ export function freezeSafetyReport(freeze) {
     return out;
   }
 
-  if (freeze.probedWithPending === 0 && unmeasured > 0) {
-    out.push(`  cancelPending produced NO USABLE MEASUREMENT: ${unmeasured} sample(s) carry ${named}.`);
-    out.push('  This is MISSING EVIDENCE, not a passing check and not an on-chain finding.');
-    if (ranButUnreadable) {
-      out.push('  `unreadable` means the static call WAS attempted and the transport failed (rate limit,');
-      out.push('  timeout, unreachable RPC) — not a contract verdict, and not something the sampler');
-      out.push('  configuration can fix. TO FIX: use a less rate-limited RPC and re-run.');
-    }
-    if (kinds.some((k) => k !== 'unreadable')) {
-      out.push('  `not-configured`/`not-probed` mean the probe never ran. TO FIX: the sampler resolves its');
-      out.push('  vault set from SOAK_VAULTS, else from the indexer projection. An empty result means the');
-      out.push('  indexer had projected no vaults yet (start the sampler after it catches up), or');
-      out.push('  SOAK_PROBE_MEMBER was unset. The per-sample `reason` field names which.');
-    }
-    return out;
-  }
-
   if (freeze.probedWithPending === 0) {
-    out.push('  cancelPending was never probed against a REAL pending deposit (every sample was n/a-no-pending),');
-    out.push('  so freeze safety is NOT demonstrated by this run — it is merely un-contradicted.');
-    out.push('  TO FIX: the sampler must run DURING a 4h observation window, with SOAK_PROBE_MEMBER set');
-    out.push('  to the depositor. Drills 1, 2 and 5 each open one — that is the window in which a pending');
-    out.push('  deposit actually exists to cancel. Restart oracle-sampler.mjs right after a deposit lands.');
+    // EVERY cause present gets named, and every remedy that applies gets printed. These were
+    // mutually exclusive branches, which meant one `unreadable` sample in an otherwise all-`n/a`
+    // window suppressed the `n/a` remedy entirely — and the `n/a` remedy is the one that would
+    // actually help, since a better RPC does not conjure a pending deposit. That is the dominant
+    // real shape (the run this was written for was all-`n/a`, and one transport blip over six
+    // hours at N vaults every 120 s is near-certain), so exclusivity was the wrong structure.
+    const nA = freeze.verdicts?.['n/a-no-pending'] ?? 0;
+    out.push('  cancelPending was never observed against a REAL pending deposit, so freeze safety is');
+    out.push('  NOT demonstrated by this run. Nothing here is a passing check or an on-chain finding.');
+
+    if (unmeasured > 0) {
+      out.push(`  ${unmeasured} sample(s) yielded NO MEASUREMENT (${named}):`);
+      if (ranButUnreadable) {
+        out.push('    `unreadable` — the static call WAS attempted and the transport failed (rate limit,');
+        out.push('    timeout, unreachable RPC). Not a contract verdict, and not something the sampler');
+        out.push('    configuration can fix. TO FIX: use a less rate-limited RPC and re-run.');
+      }
+      if (kinds.some((k) => k !== 'unreadable')) {
+        out.push('    `not-configured`/`not-probed` — the probe never ran. TO FIX: the sampler resolves its');
+        out.push('    vault set from SOAK_VAULTS, else from the indexer projection. An empty result means');
+        out.push('    the indexer had projected no vaults yet (start the sampler after it catches up), or');
+        out.push('    SOAK_PROBE_MEMBER was unset. The per-sample `reason` field names which.');
+      }
+    }
+
+    if (nA > 0) {
+      out.push(`  ${nA} sample(s) were probed and found NO PENDING DEPOSIT to cancel, so they prove`);
+      out.push('  nothing either way. TO FIX: the sampler must run DURING a 4h observation window, with');
+      out.push('  SOAK_PROBE_MEMBER set to the depositor. Drills 1, 2 and 5 each open one — that is the');
+      out.push('  window in which a pending deposit actually exists to cancel.');
+    }
+
+    if (unmeasured === 0 && nA === 0) {
+      // The pre-fix sampler's signature: `freezeSafety: []` on every sample, so the reducer sees
+      // no rows at all. Saying "every sample was n/a-no-pending" about THIS is the exact lie that
+      // let the leg sit inert for a whole run — and it was still being printed for this input.
+      out.push('  The series carries NO freeze-safety rows at all — not a single probe was recorded.');
+      out.push('  That is the signature of a sampler running without a resolved vault set (the pre-fix');
+      out.push('  behaviour: mapping over an empty list yields no rows and no error). Re-run the soak');
+      out.push('  with a sampler that discovers its vaults, and this section will have data to reduce.');
+    }
     return out;
   }
 

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -221,14 +221,14 @@ export const UNMEASURED_VERDICTS = ['not-configured', 'not-probed', 'unreadable'
 export function freezeSafetyReport(freeze) {
   const out = [`freeze-safety verdicts: ${JSON.stringify(freeze.verdicts)}`];
   const kinds = Object.keys(freeze.verdicts ?? {}).filter((v) => UNMEASURED_VERDICTS.includes(v));
-  const named = kinds.join('/') || 'not-configured/not-probed';
+  const named = kinds.join('/') || 'unknown';
   // `unreadable` means the call WAS attempted and the transport failed. The others mean it was
   // never attempted. Only the latter is fixed by configuring the sampler.
   const ranButUnreadable = kinds.includes('unreadable');
   const unmeasured = freeze.unmeasured ?? 0;
 
   if (freeze.oracleBlocked > 0) {
-    out.push(`  *** cancelPending was NOT callable in ${freeze.oracleBlocked} sample(s) — freeze-safety VIOLATED ***`);
+    out.push(`  *** cancelPending was NOT callable in ${freeze.oracleBlocked} probe(s) — freeze-safety VIOLATED ***`);
     for (const b of freeze.blockedDetail ?? []) out.push(`     ${b.at} ${b.vault}: ${b.verdict} — ${b.detail}`);
     return out;
   }
@@ -245,7 +245,7 @@ export function freezeSafetyReport(freeze) {
     out.push('  NOT demonstrated by this run. Nothing here is a passing check or an on-chain finding.');
 
     if (unmeasured > 0) {
-      out.push(`  ${unmeasured} sample(s) yielded NO MEASUREMENT (${named}):`);
+      out.push(`  ${unmeasured} probe(s) yielded NO MEASUREMENT (${named}):`);
       if (ranButUnreadable) {
         out.push('    `unreadable` — the static call WAS attempted and the transport failed (rate limit,');
         out.push('    timeout, unreachable RPC). Not a contract verdict, and not something the sampler');
@@ -260,7 +260,7 @@ export function freezeSafetyReport(freeze) {
     }
 
     if (nA > 0) {
-      out.push(`  ${nA} sample(s) were probed and found NO PENDING DEPOSIT to cancel, so they prove`);
+      out.push(`  ${nA} probe(s) found NO PENDING DEPOSIT to cancel, so they prove`);
       out.push('  nothing either way. TO FIX: the sampler must run DURING a 4h observation window, with');
       out.push('  SOAK_PROBE_MEMBER set to the depositor. Drills 1, 2 and 5 each open one — that is the');
       out.push('  window in which a pending deposit actually exists to cancel.');
@@ -278,11 +278,11 @@ export function freezeSafetyReport(freeze) {
     return out;
   }
 
-  out.push(`  cancelPending stayed callable in all ${freeze.probedWithPending} probed sample(s) — freeze safety held`);
+  out.push(`  cancelPending stayed callable in all ${freeze.probedWithPending} probe(s) that found a pending deposit — freeze safety held`);
   // Partial coverage must be said out loud. "Held" over a window that was only partly measured is a
   // narrower claim than "held", and the difference is invisible unless it is printed.
   if (unmeasured > 0) {
-    out.push(`  NOTE: ${unmeasured} further sample(s) yielded no measurement (${named}),`);
+    out.push(`  NOTE: ${unmeasured} further probe(s) yielded no measurement (${named}),`);
     out.push('  so that holds over the measured samples only, not over the whole window.');
   }
   return out;
@@ -384,7 +384,11 @@ export function verdictOf(byAsset, canaryRows) {
     return {
       verdict: 'INSUFFICIENT_EVIDENCE',
       breached: [], worst: null, canaryTracked: null, canaryAssetRows: 0,
-      unreadableSamples: assets.reduce((n, a) => n + (a.unreadableSamples ?? 0), 0),
+      // SUMMED ACROSS ASSETS, so this is a count of asset OBSERVATIONS, not of samples: a
+      // 2-asset basket contributes 2 per sample. Named for what it counts, because the sibling
+      // freeze-safety counters were printed as "sample(s)" while holding per-vault rows and
+      // overstated the evidence threefold.
+      unreadableObservations: assets.reduce((n, a) => n + (a.unreadableSamples ?? 0), 0),
     };
   }
 

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -201,6 +201,74 @@ export function findGaps(samples, maxGapMult) {
  */
 export const UNMEASURED_VERDICTS = ['not-configured', 'not-probed', 'unreadable'];
 
+/**
+ * The operator-facing lines for the freeze-safety leg. A PURE function of the summary, living here
+ * rather than inline in drill 4, for one reason: nothing in the repository executes
+ * `drill4-oraclefreeze.mjs`, so prose written inline has no regression coverage at all — and the
+ * first version of these branches shipped a falsehood because of exactly that.
+ *
+ * It hardcoded "not-configured/not-probed" as the cause while `unreadable` sat in the same bucket,
+ * so an all-`unreadable` window printed "the probe did not run" about samples that ran, and a TO
+ * FIX block naming vault discovery for what was a rate limit. That is a statement about
+ * CONFIGURATION standing in for a statement about TRANSPORT — the same substitution the branch
+ * above it exists to remove, re-created eleven lines below. The cause is now read from the verdict
+ * tally instead of assumed, and this function is unit-tested.
+ *
+ * @param {{verdicts: Record<string, number>, probedWithPending: number, oracleBlocked: number,
+ *          unmeasured?: number, blockedDetail?: any[]}} freeze
+ * @returns {string[]} lines to log, in order
+ */
+export function freezeSafetyReport(freeze) {
+  const out = [`freeze-safety verdicts: ${JSON.stringify(freeze.verdicts)}`];
+  const kinds = Object.keys(freeze.verdicts ?? {}).filter((v) => UNMEASURED_VERDICTS.includes(v));
+  const named = kinds.join('/') || 'not-configured/not-probed';
+  // `unreadable` means the call WAS attempted and the transport failed. The others mean it was
+  // never attempted. Only the latter is fixed by configuring the sampler.
+  const ranButUnreadable = kinds.includes('unreadable');
+  const unmeasured = freeze.unmeasured ?? 0;
+
+  if (freeze.oracleBlocked > 0) {
+    out.push(`  *** cancelPending was NOT callable in ${freeze.oracleBlocked} sample(s) — freeze-safety VIOLATED ***`);
+    for (const b of freeze.blockedDetail ?? []) out.push(`     ${b.at} ${b.vault}: ${b.verdict} — ${b.detail}`);
+    return out;
+  }
+
+  if (freeze.probedWithPending === 0 && unmeasured > 0) {
+    out.push(`  cancelPending produced NO USABLE MEASUREMENT: ${unmeasured} sample(s) carry ${named}.`);
+    out.push('  This is MISSING EVIDENCE, not a passing check and not an on-chain finding.');
+    if (ranButUnreadable) {
+      out.push('  `unreadable` means the static call WAS attempted and the transport failed (rate limit,');
+      out.push('  timeout, unreachable RPC) — not a contract verdict, and not something the sampler');
+      out.push('  configuration can fix. TO FIX: use a less rate-limited RPC and re-run.');
+    }
+    if (kinds.some((k) => k !== 'unreadable')) {
+      out.push('  `not-configured`/`not-probed` mean the probe never ran. TO FIX: the sampler resolves its');
+      out.push('  vault set from SOAK_VAULTS, else from the indexer projection. An empty result means the');
+      out.push('  indexer had projected no vaults yet (start the sampler after it catches up), or');
+      out.push('  SOAK_PROBE_MEMBER was unset. The per-sample `reason` field names which.');
+    }
+    return out;
+  }
+
+  if (freeze.probedWithPending === 0) {
+    out.push('  cancelPending was never probed against a REAL pending deposit (every sample was n/a-no-pending),');
+    out.push('  so freeze safety is NOT demonstrated by this run — it is merely un-contradicted.');
+    out.push('  TO FIX: the sampler must run DURING a 4h observation window, with SOAK_PROBE_MEMBER set');
+    out.push('  to the depositor. Drills 1, 2 and 5 each open one — that is the window in which a pending');
+    out.push('  deposit actually exists to cancel. Restart oracle-sampler.mjs right after a deposit lands.');
+    return out;
+  }
+
+  out.push(`  cancelPending stayed callable in all ${freeze.probedWithPending} probed sample(s) — freeze safety held`);
+  // Partial coverage must be said out loud. "Held" over a window that was only partly measured is a
+  // narrower claim than "held", and the difference is invisible unless it is printed.
+  if (unmeasured > 0) {
+    out.push(`  NOTE: ${unmeasured} further sample(s) yielded no measurement (${named}),`);
+    out.push('  so that holds over the measured samples only, not over the whole window.');
+  }
+  return out;
+}
+
 export function summarizeFreezeSafety(samples) {
   /** @type {Record<string, number>} */
   const verdicts = {};

--- a/scripts/test/soak-deployment.test.mjs
+++ b/scripts/test/soak-deployment.test.mjs
@@ -170,6 +170,21 @@ test('any other revert WITH a real pending deposit is the reportable finding', (
   assert.equal(classifyCancelPending(r, '5000000'), 'BLOCKED');
 });
 
+test('a TRANSPORT failure is unreadable, not BLOCKED — a 429 is not a contract verdict', () => {
+  // The file's own header: "An unreadable observation is recorded as missing evidence, never
+  // folded into a value that reads as a finding." This classifier did not honour it, and the
+  // consequence is worse here than on the price path: BLOCKED prints as "freeze-safety VIOLATED",
+  // i.e. a fabricated claim that member funds are trapped — from a rate limit.
+  const r = { ok: false, err: 'error sending request: 429 Too Many Requests', kind: 'transport' };
+  assert.equal(classifyCancelPending(r, '5000000'), 'unreadable');
+  assert.notEqual(classifyCancelPending(r, '5000000'), 'BLOCKED');
+
+  // …and the carve-out must be keyed on `kind`, not on the error text. A REVERT whose message
+  // happens to mention a number must still be the reportable finding.
+  const revert = { ok: false, err: 'execution reverted, data: "0x88cce429"', kind: 'revert' };
+  assert.equal(classifyCancelPending(revert, '5000000'), 'BLOCKED');
+});
+
 test('SEL_NO_PENDING matches the NoPending() selector cast computes', () => {
   // Pinned rather than derived, so renaming the error in VaultCore fails here instead of
   // silently reclassifying every BLOCKED result as n/a.

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -176,18 +176,43 @@ test('freezeSafetyReport names the ACTUAL unmeasured kind, never a hardcoded one
   const lines = freezeSafetyReport({
     verdicts: { unreadable: 3 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 3,
   }).join('\n');
-  assert.match(lines, /3 sample\(s\) carry unreadable/);
+  assert.match(lines, /3 sample\(s\) yielded NO MEASUREMENT \(unreadable\)/);
   assert.doesNotMatch(lines, /not-configured|not-probed/, 'names a cause that is not present');
   assert.doesNotMatch(lines, /probe did not run|never probed at all/i, 'the call WAS attempted');
   assert.match(lines, /transport failed/, 'must say what unreadable actually means');
   assert.doesNotMatch(lines, /SOAK_VAULTS/, 'no sampler config fixes a rate limit');
 });
 
+test('freezeSafetyReport reports the n/a remedy even when one unmeasured sample is present', () => {
+  // The branches used to be exclusive, so a SINGLE transport blip in an otherwise all-`n/a`
+  // window suppressed the only remedy that would have helped. One blip over six hours at N vaults
+  // every 120 s is near-certain, so this is the dominant shape, not a corner.
+  const lines = freezeSafetyReport({
+    verdicts: { 'n/a-no-pending': 19, unreadable: 1 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 1,
+  }).join('\n');
+  assert.match(lines, /1 sample\(s\) yielded NO MEASUREMENT \(unreadable\)/);
+  assert.match(lines, /19 sample\(s\) were probed and found NO PENDING DEPOSIT/);
+  assert.match(lines, /4h observation window/, 'the remedy that would actually help must survive');
+  assert.match(lines, /less rate-limited RPC/, 'and so must the one for the blip');
+});
+
+test('freezeSafetyReport does not claim "n/a" about a series with NO probe rows at all', () => {
+  // The pre-fix sampler emitted `freezeSafety: []` every sample, so the reducer sees nothing.
+  // Reporting that as "every sample was n/a-no-pending" is the exact misattribution this whole
+  // change exists to remove — and it was still being printed for precisely this input.
+  const lines = freezeSafetyReport({
+    verdicts: {}, probedWithPending: 0, oracleBlocked: 0, unmeasured: 0,
+  }).join('\n');
+  assert.match(lines, /NO freeze-safety rows at all/);
+  assert.doesNotMatch(lines, /n\/a-no-pending/, 'must not describe absent rows as n/a rows');
+  assert.match(lines, /mapping over an empty list/, 'name the actual mechanism');
+});
+
 test('freezeSafetyReport still names configuration when THAT is the cause', () => {
   const lines = freezeSafetyReport({
     verdicts: { 'not-configured': 2 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 2,
   }).join('\n');
-  assert.match(lines, /2 sample\(s\) carry not-configured/);
+  assert.match(lines, /2 sample\(s\) yielded NO MEASUREMENT \(not-configured\)/);
   assert.match(lines, /SOAK_VAULTS/, 'the config remedy belongs on the config cause');
   assert.doesNotMatch(lines, /transport failed/);
 });

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -169,6 +169,36 @@ test('an UNCONFIGURED probe is missing evidence, not a freeze-safety breach', ()
 
 // ── the operator-facing prose (previously untested, and it shipped a falsehood) ──
 
+test('freezeSafetyReport counts PROBES and says so — the tally is per-vault, not per-sample', () => {
+  // THE UNITS ARE THE CLAIM. `summarizeFreezeSafety` iterates `for (const f of s.freezeSafety)`,
+  // so every counter is a per-VAULT-per-sample ROW. While the probe set was always empty that
+  // count was 0 and the units could not diverge; discovery makes 3 rows per sample the norm, so
+  // calling them "sample(s)" overstated the evidence THREEFOLD — 4 samples across 3 vaults
+  // printed as "12 sample(s)". This is gate-3 evidence, where the count is the claim about how
+  // much of it exists.
+  //
+  // Pinned as a UNIT test rather than a wording test: the numbers below are row counts by
+  // construction, and the assertion is that the noun matches them.
+  const threeVaults = summarizeFreezeSafety([
+    sample('t1', 1, { freezeSafety: [
+      { vault: '0xa', verdict: 'n/a-no-pending' },
+      { vault: '0xb', verdict: 'n/a-no-pending' },
+      { vault: '0xc', verdict: 'n/a-no-pending' },
+    ] }),
+    sample('t2', 2, { freezeSafety: [
+      { vault: '0xa', verdict: 'n/a-no-pending' },
+      { vault: '0xb', verdict: 'n/a-no-pending' },
+      { vault: '0xc', verdict: 'n/a-no-pending' },
+    ] }),
+  ]);
+  assert.equal(threeVaults.verdicts['n/a-no-pending'], 6, 'two samples over three vaults is six ROWS');
+
+  const lines = freezeSafetyReport(threeVaults).join('\n');
+  assert.match(lines, /6 probe\(s\)/, 'six rows must be reported as six probes');
+  assert.doesNotMatch(lines, /\bsample\(s\)/,
+    'the report must never call a per-vault row a "sample" — 2 samples are not 6');
+});
+
 test('freezeSafetyReport names the ACTUAL unmeasured kind, never a hardcoded one', () => {
   // The first version hardcoded "not-configured/not-probed" while `unreadable` sat in the same
   // bucket, so an all-`unreadable` window printed "the probe did not run" about samples that DID
@@ -176,7 +206,7 @@ test('freezeSafetyReport names the ACTUAL unmeasured kind, never a hardcoded one
   const lines = freezeSafetyReport({
     verdicts: { unreadable: 3 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 3,
   }).join('\n');
-  assert.match(lines, /3 sample\(s\) yielded NO MEASUREMENT \(unreadable\)/);
+  assert.match(lines, /3 probe\(s\) yielded NO MEASUREMENT \(unreadable\)/);
   assert.doesNotMatch(lines, /not-configured|not-probed/, 'names a cause that is not present');
   assert.doesNotMatch(lines, /probe did not run|never probed at all/i, 'the call WAS attempted');
   assert.match(lines, /transport failed/, 'must say what unreadable actually means');
@@ -190,8 +220,8 @@ test('freezeSafetyReport reports the n/a remedy even when one unmeasured sample 
   const lines = freezeSafetyReport({
     verdicts: { 'n/a-no-pending': 19, unreadable: 1 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 1,
   }).join('\n');
-  assert.match(lines, /1 sample\(s\) yielded NO MEASUREMENT \(unreadable\)/);
-  assert.match(lines, /19 sample\(s\) were probed and found NO PENDING DEPOSIT/);
+  assert.match(lines, /1 probe\(s\) yielded NO MEASUREMENT \(unreadable\)/);
+  assert.match(lines, /19 probe\(s\) found NO PENDING DEPOSIT/);
   assert.match(lines, /4h observation window/, 'the remedy that would actually help must survive');
   assert.match(lines, /less rate-limited RPC/, 'and so must the one for the blip');
 });
@@ -212,7 +242,7 @@ test('freezeSafetyReport still names configuration when THAT is the cause', () =
   const lines = freezeSafetyReport({
     verdicts: { 'not-configured': 2 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 2,
   }).join('\n');
-  assert.match(lines, /2 sample\(s\) yielded NO MEASUREMENT \(not-configured\)/);
+  assert.match(lines, /2 probe\(s\) yielded NO MEASUREMENT \(not-configured\)/);
   assert.match(lines, /SOAK_VAULTS/, 'the config remedy belongs on the config cause');
   assert.doesNotMatch(lines, /transport failed/);
 });
@@ -231,7 +261,7 @@ test('freezeSafetyReport qualifies "held" when part of the window yielded no mea
     verdicts: { callable: 1, unreadable: 2 }, probedWithPending: 1, oracleBlocked: 0, unmeasured: 2,
   }).join('\n');
   assert.match(lines, /freeze safety held/);
-  assert.match(lines, /2 further sample\(s\) yielded no measurement \(unreadable\)/);
+  assert.match(lines, /2 further probe\(s\) yielded no measurement \(unreadable\)/);
   assert.match(lines, /measured samples only, not over the whole window/);
 });
 
@@ -639,8 +669,24 @@ test('a series with no readable asset observation is INSUFFICIENT_EVIDENCE, neve
   const s = summarize([liveSample('t1', 1, { asset: { unreadable: true, ageSec: null, priceReverts: null } })]);
   const r = verdictOf(s, []);
   assert.equal(r.verdict, 'INSUFFICIENT_EVIDENCE');
-  assert.equal(r.unreadableSamples, 1);
+  // `unreadableObservations`, not `...Samples`: it SUMS across assets, so a 2-asset basket
+  // contributes 2 per sample. Named for what it counts after the freeze-safety counters were
+  // caught printing per-vault rows as "sample(s)" and overstating the evidence threefold.
+  assert.equal(r.unreadableObservations, 1);
   assert.equal(verdictOf({}, []).verdict, 'INSUFFICIENT_EVIDENCE', 'an empty reduction certifies nothing either');
+});
+
+test('unreadableObservations sums ACROSS assets — two assets contribute two per sample', () => {
+  // The units defect, in the place the reviewer did not cite. With a 2-asset basket this counter
+  // is a row count, so reporting it as "sample(s)" would double the apparent missing evidence.
+  const s = summarize([liveSample('t1', 1, {
+    asset: { unreadable: true, ageSec: null, priceReverts: null },
+  })]);
+  // Fabricate a second asset with one unreadable observation in the same single sample.
+  s.LINK = { ...s.WETH, symbol: 'LINK' };
+  const r = verdictOf(s, []);
+  assert.equal(r.verdict, 'INSUFFICIENT_EVIDENCE');
+  assert.equal(r.unreadableObservations, 2, 'ONE sample over TWO assets is TWO observations');
 });
 
 // ───────────────────────── the sequencer leg over a window ─────────────────────────

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -14,7 +14,7 @@ import path from 'node:path';
 
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer,
-  oracleCanaryRows, verdictOf, isAssetSubject, isBreachSample,
+  oracleCanaryRows, verdictOf, isAssetSubject, isBreachSample, freezeSafetyReport,
 } from '../soak/series-analysis.mjs';
 import {
   sequencerState, attributeAsset, classifyCallError, SEL_STALE_ORACLE, SEL_NO_PENDING,
@@ -165,6 +165,62 @@ test('an UNCONFIGURED probe is missing evidence, not a freeze-safety breach', ()
   assert.equal(r.probedWithPending, 0);
   assert.equal(r.demonstrated, false, 'nothing was measured, so nothing is demonstrated');
   assert.deepEqual(r.blockedDetail, [], 'nothing to page on');
+});
+
+// ── the operator-facing prose (previously untested, and it shipped a falsehood) ──
+
+test('freezeSafetyReport names the ACTUAL unmeasured kind, never a hardcoded one', () => {
+  // The first version hardcoded "not-configured/not-probed" while `unreadable` sat in the same
+  // bucket, so an all-`unreadable` window printed "the probe did not run" about samples that DID
+  // run, and offered a fix (vault discovery) for what was a rate limit.
+  const lines = freezeSafetyReport({
+    verdicts: { unreadable: 3 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 3,
+  }).join('\n');
+  assert.match(lines, /3 sample\(s\) carry unreadable/);
+  assert.doesNotMatch(lines, /not-configured|not-probed/, 'names a cause that is not present');
+  assert.doesNotMatch(lines, /probe did not run|never probed at all/i, 'the call WAS attempted');
+  assert.match(lines, /transport failed/, 'must say what unreadable actually means');
+  assert.doesNotMatch(lines, /SOAK_VAULTS/, 'no sampler config fixes a rate limit');
+});
+
+test('freezeSafetyReport still names configuration when THAT is the cause', () => {
+  const lines = freezeSafetyReport({
+    verdicts: { 'not-configured': 2 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 2,
+  }).join('\n');
+  assert.match(lines, /2 sample\(s\) carry not-configured/);
+  assert.match(lines, /SOAK_VAULTS/, 'the config remedy belongs on the config cause');
+  assert.doesNotMatch(lines, /transport failed/);
+});
+
+test('freezeSafetyReport reports BOTH causes when both are present', () => {
+  const lines = freezeSafetyReport({
+    verdicts: { unreadable: 1, 'not-probed': 1 }, probedWithPending: 0, oracleBlocked: 0, unmeasured: 2,
+  }).join('\n');
+  assert.match(lines, /unreadable\/not-probed|not-probed\/unreadable/);
+  assert.match(lines, /transport failed/);
+  assert.match(lines, /SOAK_VAULTS/);
+});
+
+test('freezeSafetyReport qualifies "held" when part of the window yielded no measurement', () => {
+  const lines = freezeSafetyReport({
+    verdicts: { callable: 1, unreadable: 2 }, probedWithPending: 1, oracleBlocked: 0, unmeasured: 2,
+  }).join('\n');
+  assert.match(lines, /freeze safety held/);
+  assert.match(lines, /2 further sample\(s\) yielded no measurement \(unreadable\)/);
+  assert.match(lines, /measured samples only, not over the whole window/);
+});
+
+test('freezeSafetyReport puts a real breach first and never softens it', () => {
+  const lines = freezeSafetyReport({
+    verdicts: { callable: 1, BLOCKED: 1, unreadable: 5 },
+    probedWithPending: 1,
+    oracleBlocked: 1,
+    unmeasured: 5,
+    blockedDetail: [{ at: 't2', vault: '0xv', verdict: 'BLOCKED', detail: 'StaleOracle' }],
+  }).join('\n');
+  assert.match(lines, /freeze-safety VIOLATED/);
+  assert.match(lines, /StaleOracle/);
+  assert.doesNotMatch(lines, /freeze safety held/, 'a breach must not be reported as held');
 });
 
 test('a transport failure is unmeasured, not a freeze-safety breach', () => {

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -147,6 +147,38 @@ test('any verdict other than callable/ok/n-a counts as a freeze-safety violation
   assert.equal(r.blockedDetail[0].detail, 'StaleOracle');
 });
 
+test('an UNCONFIGURED probe is missing evidence, not a freeze-safety breach', () => {
+  // Regression for a live run in which the sampler emitted `freezeSafety: []` for six hours,
+  // because run-soak.ps1 set SOAK_PROBE_MEMBER but never SOAK_VAULTS: mapping over an empty vault
+  // list produced NO ROWS, so the leg's own absence was invisible and drill 4's refusal to claim
+  // freeze safety looked like "no pending deposit existed".
+  //
+  // The sampler now emits a `not-configured` sentinel instead. It must suppress `demonstrated` —
+  // nothing was shown — WITHOUT being counted as a violation: a misconfigured harness reporting a
+  // freeze-safety BREACH is the same lie in the opposite direction, and would page someone.
+  const r = summarizeFreezeSafety([
+    sample('t1', 1, { freezeSafety: [{ vault: null, probed: false, verdict: 'not-configured', reason: 'no vaults to probe (indexer-empty)' }] }),
+    sample('t2', 2, { freezeSafety: [{ vault: null, probed: false, verdict: 'not-configured', reason: 'no vaults to probe (indexer-empty)' }] }),
+  ]);
+  assert.equal(r.oracleBlocked, 0, 'an unconfigured probe must never be reported as a violation');
+  assert.equal(r.unmeasured, 2, 'the absence must be counted, not dropped');
+  assert.equal(r.probedWithPending, 0);
+  assert.equal(r.demonstrated, false, 'nothing was measured, so nothing is demonstrated');
+  assert.deepEqual(r.blockedDetail, [], 'nothing to page on');
+});
+
+test('not-probed (no SOAK_PROBE_MEMBER) is unmeasured too, and does not mask a real breach', () => {
+  const r = summarizeFreezeSafety([
+    sample('t1', 1, { freezeSafety: [{ vault: '0xv', probed: false, verdict: 'not-probed' }] }),
+    sample('t2', 2, { freezeSafety: [{ vault: '0xv', verdict: 'callable' }] }),
+    sample('t3', 3, { freezeSafety: [{ vault: '0xv', verdict: 'BLOCKED', detail: 'StaleOracle' }] }),
+  ]);
+  assert.equal(r.unmeasured, 1);
+  assert.equal(r.probedWithPending, 1);
+  assert.equal(r.oracleBlocked, 1, 'a real breach must still surface alongside unmeasured samples');
+  assert.equal(r.demonstrated, false);
+});
+
 // ───────────────────────────── canary + verdict ─────────────────────────────
 
 test('oracleCanaryRows selects only the oracle-freshness signal and splits its composite key', () => {

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -167,6 +167,34 @@ test('an UNCONFIGURED probe is missing evidence, not a freeze-safety breach', ()
   assert.deepEqual(r.blockedDetail, [], 'nothing to page on');
 });
 
+test('a transport failure is unmeasured, not a freeze-safety breach', () => {
+  // A rate-limited or timed-out RPC is a fact about the transport, never about the contract.
+  // Before this, two consecutive transport failures on the cancelPending static call fell through
+  // to BLOCKED, and drill 4 prints BLOCKED as "freeze-safety VIOLATED" — a fabricated claim that
+  // member funds were trapped, caused by a 429. Latent while the probe set was always empty; the
+  // discovery fallback is what makes it reachable, at 3 vaults every 120 s.
+  const r = summarizeFreezeSafety([
+    sample('t1', 1, { freezeSafety: [{ vault: '0xv', probed: true, verdict: 'unreadable', detail: '429 Too Many Requests' }] }),
+    sample('t2', 2, { freezeSafety: [{ vault: '0xv', verdict: 'callable' }] }),
+  ]);
+  assert.equal(r.oracleBlocked, 0, 'a 429 must never be reported as member funds being trapped');
+  assert.equal(r.unmeasured, 1);
+  assert.equal(r.probedWithPending, 1);
+  assert.deepEqual(r.blockedDetail, []);
+});
+
+test('a REAL revert still counts as a breach — the transport carve-out must not swallow it', () => {
+  // The other direction: making transport failures unmeasured must not make contract reverts
+  // unmeasured too, or the guard stops guarding.
+  const r = summarizeFreezeSafety([
+    sample('t1', 1, { freezeSafety: [{ vault: '0xv', verdict: 'callable' }] }),
+    sample('t2', 2, { freezeSafety: [{ vault: '0xv', verdict: 'BLOCKED', detail: 'StaleOracle' }] }),
+  ]);
+  assert.equal(r.oracleBlocked, 1);
+  assert.equal(r.demonstrated, false);
+  assert.equal(r.blockedDetail[0].detail, 'StaleOracle');
+});
+
 test('not-probed (no SOAK_PROBE_MEMBER) is unmeasured too, and does not mask a real breach', () => {
   const r = summarizeFreezeSafety([
     sample('t1', 1, { freezeSafety: [{ vault: '0xv', probed: false, verdict: 'not-probed' }] }),


### PR DESCRIPTION
## What was missing

Gate 3 needs evidence that **`cancelPending` stays callable while the oracle is frozen** — a pending deposit hasn't been priced, so returning escrowed USDC needs no oracle, and if that path froze a depositor's capital would be trapped for the length of an outage with no recourse (SF-2/K-4).

**It produced none.** Every sample of the 2026-09-03 soak recorded `freezeSafety: []` — confirmed by review: **132 of 132**.

## Cause — half the wiring

`run-soak.ps1` set `SOAK_PROBE_MEMBER`, with a comment explaining exactly why the probe needs it. Nothing anywhere set **`SOAK_VAULTS`**, and the sampler derived its probe set from that alone:

```js
const VAULTS = (process.env.SOAK_VAULTS ?? '').split(',')...filter(Boolean);
const freezeSafety = VAULTS.map(...)   // [] → []
```

**No rows, no error, no trace.** Drill 4's doctrine held — it refused to claim the property — but the reason it gave was *"every sample was `n/a-no-pending`"*, a statement **about pending deposits**. The truth was that the probe was never configured.

Setting `SOAK_VAULTS` at launch wouldn't have fixed it: drills 1 and 2 *create* their vaults at runtime.

## The fix

1. **Discovery** — resolve from `SOAK_VAULTS`, else from the indexer's projected vaults, mirroring `canary-runner.resolveVaults`.
2. **The absence records itself** — a `not-configured` sentinel row carrying *why*. An empty array is indistinguishable from "probed, nothing to report"; a row is not.
3. **Missing evidence is not a breach** — a third `unmeasured` bucket, so a misconfigured harness can't report a freeze-safety *violation*.

## Two rounds of review, both of which found something real

**Round 1 (ACCEPT WITH NITS)** — a **transport failure classified as `BLOCKED`**. Two consecutive 429s against a public RPC → drill 4 prints *"freeze-safety VIOLATED"*: a fabricated claim that member funds are trapped, caused by a rate limit. Latent before this PR (the probe set was always empty); **this PR is what makes it reachable**, at 3 vaults every 120s. Now a distinct `unreadable` verdict, keyed on `kind` — never on error text, with a test pinning the other direction so a real revert is still the finding.

**Round 2 (REJECT)** — the fix for that nit *introduced the very substitution it removes*. Both new drill-4 branches hardcoded `not-configured/not-probed` as the cause while `unreadable` sat in the same bucket, so an all-`unreadable` window printed *"the probe did not run"* about samples that ran, and offered vault discovery as the remedy for a rate limit.

**Root cause, and why the fix is structural:** **nothing in the repository executes `drill4-oraclefreeze.mjs`.** Prose written inline there has zero regression coverage — mutating those branches away changed no test. A string patch would leave the next one just as reachable.

So the wording moved into `series-analysis.freezeSafetyReport`, a pure function where the file's other reducers already live and are tested. It **reads the cause from the verdict tally** instead of assuming it, and separates the two kinds because their remedies differ.

## Verification

| | |
|---|---|
| soak-drills | **58 pass / 0 fail** |
| soak-deployment | **16 / 0** |
| re-hardcoding the cause | **55 / 3** |
| removing the `unmeasured` branch | **56 / 2** |
| removing the `transport` branch | soak-deployment **15 / 1** |

Five regression tests for prose that had none. `npm run gate` passes (399 s).

## Filed separately, not fixed here

The same transport-as-verdict shape is uncorrected in `packages/canary`, **where it pages a human**: `exit-liveness.mjs` turns an empty-returndata read into *"EXIT LIVENESS BROKEN … members cannot exit"*; `oracle-health.mjs` turns `!ok` into *"ORACLE FROZEN … EXITS are all frozen"*. Neither has a `kind`, because `canary/reader.mjs` doesn't compute one.

Worse in the other direction: `drill3-modef.mjs:233` asserts `!attempt.ok` for *"settleQueuedExit refused while pending"* — so a **429 makes that security assertion pass falsely**. All pre-existing and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
