### PR TITLE
fix(soak): the harness reported symptoms as causes — a 429 passed a security assertion, and a spent budget blamed governance

### DIFF
--- a/scripts/soak/drill3-modef.mjs
+++ b/scripts/soak/drill3-modef.mjs
@@ -233,8 +233,16 @@ function stepProveSettleBlocked() {
   const attempt = tryCall(state.vault, 'settleQueuedExit(address)', state.signer);
   assert(!attempt.ok,
     'settleQueuedExit succeeded while execution was still pending — EE-10/K-1 violated');
-  log(`settleQueuedExit correctly refused while pending: ${attempt.err}`);
-  state.steps.proveSettleBlocked = { done: true, revertedWith: attempt.err };
+  // `!ok` alone does NOT prove the contract refused it. A rate limit, a timeout or an unreachable
+  // RPC also produces `ok:false`, so the assertion above was satisfiable by a 429 — a security
+  // invariant PASSING because the network was busy, and then persisted to the state file as
+  // `revertedWith: "...429 Too Many Requests..."` where it reads like evidence. Only a recognised
+  // REVERT is evidence about the contract; anything else means this step did not run.
+  assert(attempt.kind === 'revert',
+    `settleQueuedExit did not revert — the call failed for a NON-CONTRACT reason (${attempt.kind}), `
+      + `so EE-10/K-1 is UNPROVEN, not proven: ${attempt.err}`);
+  log(`settleQueuedExit correctly reverted while pending: ${attempt.err}`);
+  state.steps.proveSettleBlocked = { done: true, revertedWith: attempt.err, kind: attempt.kind };
   save();
 }
 

--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -59,6 +59,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   ROOT, RPC, log, assert, eq, call, callU, chainNow, waitUntilChainTime, openState, cast,
+  budgetExhaustedFailure,
 } from './lib.mjs';
 import { loadDeployment } from './deployment.mjs';
 import { loadAccountFromKeystore, redact } from '../lib/keystore.mjs';
@@ -87,7 +88,18 @@ async function buildAgent(phase, cfgIn, account, walletClient, entryMarks = {}) 
 
   const config = loadConfig({
     mode: 'execute',
-    api: { baseUrl: cfgIn.apiBaseUrl, payments: { enabled: true, maxSessionSpendUsdc: '0.25', maxSingleReadUsdc: '0.05' } },
+    // The cap is a SAFETY CONTROL on an agent that signs, so the default is not widened here to
+    // make a drill pass — it is surfaced. `tickUntil` computes the spend actually needed for the
+    // poll window and names SOAK_AGENT_CAP_USDC when the two disagree, leaving the decision with
+    // the operator. Default unchanged at $0.25.
+    api: {
+      baseUrl: cfgIn.apiBaseUrl,
+      payments: {
+        enabled: true,
+        maxSessionSpendUsdc: process.env.SOAK_AGENT_CAP_USDC ?? '0.25',
+        maxSingleReadUsdc: '0.05',
+      },
+    },
     chain: {
       rpcUrl: cfgIn.rpcUrl, chainId: dep.chainId, chainName: 'base-sepolia',
       governance: dep.governance.toLowerCase(),
@@ -131,6 +143,21 @@ async function tickUntil(phase, cfgIn, account, walletClient, done, label, entry
     if (done()) { log(`${label}: goal already satisfied on-chain`); break; }
     await agent.loop({ maxTicks: 1 });
     if (done()) { log(`${label}: goal reached after ${i + 1} tick(s)`); break; }
+
+    // THE BUDGET IS TERMINAL, SO STOP POLLING AS IF IT WERE NOT.
+    //
+    // The agent perceives through PAID x402 reads. Once the session spend cap is exhausted it can
+    // no longer read the vault list or the leaderboard, so it reports "perception gaps" and
+    // "no action warranted" on every subsequent tick — forever. No later tick can satisfy `done()`.
+    //
+    // On 2026-09-04 this drill hit the cap at tick 5 of 40 and then polled a permanently blind
+    // agent for the remaining 35 ticks — 17.5 minutes — before failing with
+    // "vote:commit: not satisfied after 40 ticks", which names a GOVERNANCE symptom for what was
+    // a HARNESS BUDGET cause. Same substitution this soak keeps making: the observed effect
+    // standing in for the reason.
+    const exhausted = budgetExhaustedFailure(agent.budget?.summary?.(), i + 1, MAX_TICKS, label);
+    if (exhausted) assert(false, exhausted);
+
     log(`${label}: tick ${i + 1}/${MAX_TICKS}, not yet satisfied`);
     await new Promise((r) => setTimeout(r, TICK_MS));
   }

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -145,6 +145,41 @@ export function classifyCallError(err) {
   return REVERTED.test(err) ? 'revert' : 'transport';
 }
 
+/**
+ * Is a paid-perception agent permanently blind, and if so what should the operator be told?
+ *
+ * The reference agent perceives through PAID x402 reads. Once its session spend cap is exhausted
+ * it can no longer read the vault list or the leaderboard, so it reports "perception gaps" and
+ * "no action warranted" on every subsequent tick — forever. No later tick can satisfy the goal.
+ *
+ * On 2026-09-04 drill 5 hit the cap at tick 5 of 40 and then polled a blind agent for the
+ * remaining 35 ticks — 17.5 minutes — before failing with "vote:commit: not satisfied after 40
+ * ticks", which names a GOVERNANCE symptom for a HARNESS BUDGET cause. That misattribution is the
+ * defect; the wasted ticks are just how long it took to arrive at it.
+ *
+ * Pure, and in lib.mjs rather than in the drill, because the drill executes at import and so
+ * anything defined there cannot be tested.
+ *
+ * @param {{enabled:boolean,spentUsdc:string,capUsdc:string,remainingUsdc:string,paidReads:number}|undefined} spend
+ * @param {number} tick 1-based tick just completed
+ * @param {number} maxTicks
+ * @param {string} label
+ * @returns {string|null} the failure message, or null to keep polling
+ */
+export function budgetExhaustedFailure(spend, tick, maxTicks, label) {
+  if (!spend?.enabled) return null;
+  if (Number(spend.remainingUsdc) > 0) return null;
+  const perTick = Number(spend.spentUsdc) / Math.max(tick, 1);
+  return `${label}: the agent exhausted its x402 session spend cap at tick ${tick}/${maxTicks} `
+    + `($${spend.spentUsdc} of $${spend.capUsdc}, ${spend.paidReads} paid reads). It perceives through `
+    + `paid reads, so from here it is BLIND and no further tick can satisfy the goal — this is a `
+    + `HARNESS BUDGET failure, NOT evidence about governance or the contracts. The cap must cover the `
+    + `whole poll window: this phase burned ~$${perTick.toFixed(3)} per tick, so ${maxTicks} ticks needs `
+    + `about $${(perTick * maxTicks).toFixed(2)}. Raise it deliberately via SOAK_AGENT_CAP_USDC (it is a `
+    + `spend limit on an agent that signs, so it is the operator's call, not a default to quietly `
+    + `widen), or lower SOAK_MAX_TICKS.`;
+}
+
 /** Read-only call that may legitimately revert. Never throws. Carries `kind` on failure. */
 export function tryCall(to, sig, ...args) {
   try {
@@ -356,3 +391,4 @@ export const TOPIC = {
   DepositPending: () => keccakOf('DepositPending(address,uint256,uint64)'),
   DepositActivated: () => keccakOf('DepositActivated(address,uint256,uint256)'),
 };
+

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -125,12 +125,33 @@ export function call(to, sig, ...args) {
 }
 export const callU = (to, sig, ...args) => BigInt(call(to, sig, ...args)[0]);
 
-/** Read-only call that may legitimately revert. Never throws. */
+const TRANSPORT_ERR = /429|rate.?limit|max retries exceeded|timed out|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket|connection|dns|502|503|504|521/i;
+/** cast's wording for a contract-level revert, in both the JSON-RPC and the local-decode spellings. */
+const REVERTED = /execution reverted|revert(ed)?:/i;
+
+/**
+ * Classify a failed `cast` call. ONLY a recognised revert is evidence about the contract; anything
+ * else is missing evidence and must be recorded as such.
+ *
+ * This exists because a drill asserted `!result.ok` to prove a call was REFUSED, and `ok:false` is
+ * also what a rate limit produces — so a 429 satisfied a security assertion. "It failed" and "the
+ * contract refused it" are different claims, and only one of them is a finding.
+ *
+ * @param {string} err
+ * @returns {'revert'|'transport'}
+ */
+export function classifyCallError(err) {
+  if (TRANSPORT_ERR.test(err) && !REVERTED.test(err)) return 'transport';
+  return REVERTED.test(err) ? 'revert' : 'transport';
+}
+
+/** Read-only call that may legitimately revert. Never throws. Carries `kind` on failure. */
 export function tryCall(to, sig, ...args) {
   try {
     return { ok: true, lines: call(to, sig, ...args) };
   } catch (e) {
-    return { ok: false, err: String(e.message).split('\n').slice(0, 2).join(' ') };
+    const err = String(e.message).split('\n').slice(0, 2).join(' ');
+    return { ok: false, err, kind: classifyCallError(err) };
   }
 }
 
@@ -139,7 +160,8 @@ export function staticCallAs(from, to, sig, ...args) {
   try {
     return { ok: true, out: cast(['call', to, sig, ...args.map(String), '--from', from, '--rpc-url', RPC]) };
   } catch (e) {
-    return { ok: false, err: String(e.message).split('\n').slice(0, 2).join(' ') };
+    const err = String(e.message).split('\n').slice(0, 2).join(' ');
+    return { ok: false, err, kind: classifyCallError(err) };
   }
 }
 

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -125,6 +125,11 @@ export function call(to, sig, ...args) {
 }
 export const callU = (to, sig, ...args) => BigInt(call(to, sig, ...args)[0]);
 
+// REDUNDANT WITH THE TERNARY BELOW, and kept only as documentation of what "transport" means in
+// practice. Trace it: if REVERTED matches, this cannot fire; if it does not, both paths already
+// return 'transport'. Deleting it changes no behaviour and no test. It is labelled rather than
+// removed because in a file whose whole subject is that this classification is security-relevant,
+// a decorative regex reading as load-bearing logic is its own hazard.
 const TRANSPORT_ERR = /429|rate.?limit|max retries exceeded|timed out|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket|connection|dns|502|503|504|521/i;
 /** cast's wording for a contract-level revert, in both the JSON-RPC and the local-decode spellings. */
 const REVERTED = /execution reverted|revert(ed)?:/i;
@@ -168,10 +173,24 @@ export function classifyCallError(err) {
  */
 export function budgetExhaustedFailure(spend, tick, maxTicks, label) {
   if (!spend?.enabled) return null;
-  if (Number(spend.remainingUsdc) > 0) return null;
+
+  // BLIND IS NOT THE SAME AS ZERO. The budget refuses a read when `spent + price > cap`, so an
+  // agent holding $0.004 against a $0.01 read is ALREADY permanently blind while `remainingUsdc`
+  // still reads positive. Testing `=== 0` would have polled that agent for the full window with
+  // the misleading failure this function exists to replace; the 2026-09-04 run landed on exactly
+  // zero only because its reads happened to divide the cap evenly.
+  //
+  // The average price paid so far is the best floor available from `summary()` — it exposes no
+  // per-read price — and it is the right shape: if what remains cannot buy an average read, the
+  // next perception is already refused.
+  const remaining = Number(spend.remainingUsdc);
+  const avgRead = spend.paidReads > 0 ? Number(spend.spentUsdc) / spend.paidReads : 0;
+  if (remaining > 0 && !(avgRead > 0 && remaining < avgRead)) return null;
+
   const perTick = Number(spend.spentUsdc) / Math.max(tick, 1);
   return `${label}: the agent exhausted its x402 session spend cap at tick ${tick}/${maxTicks} `
-    + `($${spend.spentUsdc} of $${spend.capUsdc}, ${spend.paidReads} paid reads). It perceives through `
+    + `($${spend.spentUsdc} of $${spend.capUsdc} spent, $${spend.remainingUsdc} left, `
+    + `${spend.paidReads} paid reads averaging $${avgRead.toFixed(3)}). It perceives through `
     + `paid reads, so from here it is BLIND and no further tick can satisfy the goal — this is a `
     + `HARNESS BUDGET failure, NOT evidence about governance or the contracts. The cap must cover the `
     + `whole poll window: this phase burned ~$${perTick.toFixed(3)} per tick, so ${maxTicks} ticks needs `

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -110,21 +110,15 @@ const clean = (s) => s.replace(/\s+\[[^\]]*\]$/, '').trim();
  * A transport failure is NOT a contract verdict. Conflating the two is how a rate-limited public
  * RPC turns into "the oracle is frozen" in a report — the same defect `verify-chainlink-oracle.mjs`
  * found in itself when a dropped `aggregator()` call announced a swap that never happened.
+ *
+ * SINGLE SOURCE, in `lib.mjs`. This used to be defined here and `lib.mjs`'s own `tryCall` had no
+ * equivalent at all, which is how drill 3 came to assert `!attempt.ok` as proof that a call had
+ * been REFUSED — an assertion a 429 satisfies. Two copies of a security-relevant regex drift; one
+ * of them would eventually be the stale one. Re-exported so this module's public API is unchanged.
  */
-const TRANSPORT_ERR = /429|rate.?limit|max retries exceeded|timed out|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket|connection|dns|502|503|504|521/i;
-/** cast's wording for a contract-level revert, in both the JSON-RPC and the local-decode spellings. */
-const REVERTED = /execution reverted|revert(ed)?:/i;
+import { classifyCallError } from './lib.mjs';
 
-/**
- * Classify a failed `cast call`. Only a recognised REVERT is evidence about the contract; anything
- * else is missing evidence and must be recorded as such.
- * @param {string} err
- * @returns {'revert'|'transport'}
- */
-export function classifyCallError(err) {
-  if (TRANSPORT_ERR.test(err) && !REVERTED.test(err)) return 'transport';
-  return REVERTED.test(err) ? 'revert' : 'transport';
-}
+export { classifyCallError };
 
 /** @returns {{ok:true,out:string}|{ok:false,err:string,kind:'revert'|'transport'}} */
 function tryCast(args, { attempts = 2 } = {}) {

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -802,3 +802,43 @@ test('a stale lock from a crashed drill is broken rather than waited on forever'
   assert.equal(got, 'proceeded', 'a dead holder must not block the rest of the soak');
   assert.equal(fs.existsSync(LOCK), false);
 });
+
+// ─────────── transport is not a verdict (drill 3's false PASS) ───────────
+
+test('classifyCallError: only a recognised revert is evidence about the contract', () => {
+  // drill3-modef asserted `!attempt.ok` to prove settleQueuedExit was REFUSED while a rebalance
+  // was pending (EE-10/K-1). A rate limit also yields `ok:false`, so the assertion PASSED on a
+  // 429 and the drill persisted the 429 text as `revertedWith` — a security invariant recorded as
+  // proven because the network was busy. These are the two claims that must never be conflated.
+  for (const err of [
+    'server returned an error response: error code 3: execution reverted, data: "0x88cce429"',
+    'Error: execution reverted',
+    'reverted: ExecutionPending()',
+  ]) {
+    assert.equal(classifyCallError(err), 'revert', `should be a contract verdict: ${err}`);
+  }
+
+  for (const err of [
+    'error sending request: 429 Too Many Requests',
+    'Error: operation timed out',
+    'ECONNRESET',
+    'getaddrinfo ENOTFOUND base-sepolia-rpc.publicnode.com',
+    'max retries exceeded',
+    'error sending request: 503 Service Unavailable',
+  ]) {
+    assert.equal(classifyCallError(err), 'transport', `must NOT be read as a contract verdict: ${err}`);
+  }
+});
+
+test('classifyCallError: a revert whose text also mentions a transport-ish token is still a revert', () => {
+  // The order matters. A revert reason containing "timeout" or a 429-like number must not be
+  // demoted to missing evidence, or a real finding disappears.
+  assert.equal(classifyCallError('execution reverted, data: "0x429" timeout'), 'revert');
+  assert.equal(classifyCallError('reverted: DeadlineTimeout()'), 'revert');
+});
+
+test('classifyCallError is fail-safe for the drill: an unknown string is NOT a revert', () => {
+  // Unknown wording must not satisfy an assertion that a refusal was observed. Erring toward
+  // "transport" makes drill 3 fail loudly (UNPROVEN) rather than pass quietly.
+  assert.equal(classifyCallError('something nobody has seen before'), 'transport');
+});

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -11,6 +11,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer,
@@ -881,4 +882,26 @@ test('budgetExhaustedFailure keeps quiet while budget remains, or when payments 
     'payments disabled means the cap is irrelevant, not exhausted',
   );
   assert.equal(budgetExhaustedFailure(undefined, 3, 40, 'x'), null, 'no budget surface, no claim');
+});
+
+test('tryCall WIRES the classifier — a failed cast carries kind, not just ok:false', () => {
+  // THE WIRING, not the classifier. Mutation showed that stripping `kind` from `tryCall` changed
+  // no test: the classifier was well covered and drill 3's assert was well reasoned, but nothing
+  // pinned the connection between them. A `kind`-keyed guard wired to a producer that never sets
+  // `kind` is exactly how the freeze-safety probe shipped inert.
+  //
+  // CAST is read at module load, so a child process with it pointed at a binary that does not
+  // exist makes every call fail at the transport layer — no RPC, no network, no transaction.
+  const src = `
+    process.env.CAST = 'definitely-not-a-real-binary-${'x'.repeat(8)}';
+    const { tryCall } = await import(${JSON.stringify(new URL('../soak/lib.mjs', import.meta.url).href)});
+    const r = tryCall('0x0000000000000000000000000000000000000000', 'foo()');
+    console.log(JSON.stringify({ ok: r.ok, kind: r.kind, hasErr: typeof r.err === 'string' }));
+  `;
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', src], { encoding: 'utf8' });
+  const r = JSON.parse(out.trim().split('\n').pop());
+  assert.equal(r.ok, false, 'a missing binary must fail the call');
+  assert.equal(r.hasErr, true);
+  assert.equal(r.kind, 'transport',
+    'tryCall must classify the failure — without `kind` drill 3\'s revert assertion is unguarded');
 });

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -776,7 +776,7 @@ test('the exit phase forces the drawdown trigger AND flags it as forced', () => 
 // calls collided and both drills died. Cross-process exclusion is verified separately by
 // running two node processes; these cover the in-process contract.
 
-import { withSendLock, ROOT as LIB_ROOT } from '../soak/lib.mjs';
+import { withSendLock, ROOT as LIB_ROOT, budgetExhaustedFailure } from '../soak/lib.mjs';
 
 const LOCK = path.join(LIB_ROOT, 'data', '.soak-send.lock');
 
@@ -841,4 +841,44 @@ test('classifyCallError is fail-safe for the drill: an unknown string is NOT a r
   // Unknown wording must not satisfy an assertion that a refusal was observed. Erring toward
   // "transport" makes drill 3 fail loudly (UNPROVEN) rather than pass quietly.
   assert.equal(classifyCallError('something nobody has seen before'), 'transport');
+});
+
+// ───────── budget exhaustion is terminal, and must say so (drill 5) ─────────
+
+test('budgetExhaustedFailure fires the moment the cap is gone, and names the real cause', () => {
+  // The 2026-09-04 run verbatim: cap hit at tick 5 of 40, then 35 more ticks against a blind
+  // agent before failing with "vote:commit: not satisfied after 40 ticks" — a governance symptom
+  // standing in for a harness budget cause.
+  const msg = budgetExhaustedFailure(
+    { enabled: true, spentUsdc: '0.25', capUsdc: '0.25', remainingUsdc: '0', paidReads: 25 },
+    5, 40, 'vote:commit',
+  );
+  assert.ok(msg, 'an exhausted cap must stop the poll, not be waited out');
+  assert.match(msg, /tick 5\/40/);
+  assert.match(msg, /HARNESS BUDGET failure, NOT evidence about governance/);
+  assert.match(msg, /SOAK_AGENT_CAP_USDC/, 'the operator needs the lever named');
+  // The arithmetic must be derived, not asserted: $0.25 over 5 ticks is $0.05/tick, so 40 ticks
+  // needs $2.00. Stating the shortfall is what turns a failure into a decision.
+  assert.match(msg, /\$0\.050 per tick/);
+  assert.match(msg, /40 ticks needs about \$2\.00/);
+});
+
+test('budgetExhaustedFailure keeps quiet while budget remains, or when payments are off', () => {
+  assert.equal(
+    budgetExhaustedFailure(
+      { enabled: true, spentUsdc: '0.10', capUsdc: '0.25', remainingUsdc: '0.15', paidReads: 10 },
+      3, 40, 'vote:commit',
+    ),
+    null,
+    'must not abort a run that can still perceive',
+  );
+  assert.equal(
+    budgetExhaustedFailure(
+      { enabled: false, spentUsdc: '0', capUsdc: '0', remainingUsdc: '0', paidReads: 0 },
+      3, 40, 'vote:commit',
+    ),
+    null,
+    'payments disabled means the cap is irrelevant, not exhausted',
+  );
+  assert.equal(budgetExhaustedFailure(undefined, 3, 40, 'x'), null, 'no budget surface, no claim');
 });


### PR DESCRIPTION
Two defects in the soak harness, same shape: **the observed effect reported as the cause.** One was found by review, one by tonight's live run.

---

## 1. A 429 could satisfy drill 3's security assertion

`drill3-modef.mjs` proves **EE-10/K-1** — settlement must be impossible while a rebalance is pending:

```js
const attempt = tryCall(state.vault, 'settleQueuedExit(address)', state.signer);
assert(!attempt.ok, 'settleQueuedExit succeeded while execution was still pending — violated');
```

**`!ok` is also what a rate limit produces.** `tryCall` returned `{ok:false, err}` identically for a 429, a timeout, or a revert — so a **security invariant could pass because the network was busy**, then persist the 429 text to the state file as `revertedWith`, where it reads like evidence.

### It did not bite tonight, and that matters because this feeds gate 3

Track A completed `04:09:53Z` with **DRILL 3 PASSED**, recording:

```
execution reverted, data: "0x885cf1d7"
```

`0x885cf1d7` resolves against `VaultCore`'s own error set to **`ExecutionStillPending()`** — the correct refusal, from the contract. The evidence is genuine; this change is **preventative, not a retraction**.

**Fix:** `lib.mjs` gains `classifyCallError`; `tryCall`/`staticCallAs` carry `kind`. Drill 3 additionally asserts `kind === 'revert'`, so a non-contract failure fails **loudly as UNPROVEN**. Single source — the classifier already existed in `oracle-sampler.mjs`, and duplicating a security-relevant regex guarantees one copy goes stale, so it moved to the base module and is re-exported.

---

## 2. Drill 5 polled a blind agent for 35 ticks, then blamed governance

**Tonight's Track B failure**, `06:20:35Z`:

```
FAIL: vote:commit: not satisfied after 40 ticks — inspect the transcript
```

That reads as a governance or contract problem. It was neither.

The agent perceives through **paid** x402 reads. It exhausted its session cap — $0.25, 25 reads — at **tick 5 of 40**. Every tick after that:

```
! skipped paid read "listVaults" — session spend cap reached: spent $0.25 of $0.25
! perception gaps: vault list unavailable; leaderboard unavailable
· no action warranted this tick
```

**35 more ticks. 17.5 minutes. Against an agent that could not see and therefore could never act.** The outcome was fixed at tick 5; the rest only delayed the report — which then named the symptom rather than the cause.

**Fix 1 (load-bearing):** exhaustion is **terminal**, so stop polling as if it isn't. `budgetExhaustedFailure` aborts immediately, states that this is a **harness budget** failure and *not* evidence about governance or the contracts, and derives the arithmetic rather than asserting it:

> this phase burned ~**$0.050 per tick**, so 40 ticks needs about **$2.00** — against **$0.25** configured. An 8× shortfall.

**Fix 2:** the cap is now readable from `SOAK_AGENT_CAP_USDC`, **default unchanged at $0.25**. I did not raise it. It is a spend limit on an agent that **signs and moves funds**, so widening it to make a drill pass is the operator's call — `docs/SWARM.md` §10's escalate-don't-act list is about exactly this. The message hands over the number and the lever.

Both helpers live in `lib.mjs` and are pure, because `drill5-agent-execute.mjs` **executes at import** — anything defined there cannot be unit-tested, which is how an untested branch in this same soak shipped a false statement earlier today.

---

## Swept

`assert(!x.ok)` appears exactly **once** in `scripts/soak/**` — it was drill 3's.

**Correction.** An earlier version of this line went on to say *"Every other `!ok` site in `oracle-sampler.mjs` already gates on `kind`."* **That was false on this branch.** `classifyCancelPending` receives a result carrying `kind` and ignores it, so a 429 there returns `BLOCKED` — which `summarizeFreezeSafety` counts into `oracleBlocked` and reports as the freeze-safety property **not demonstrated**. It is a false *alarm* rather than a false *pass*, so it does not block this PR, but the claim was wrong, in the same file this PR edits, inside the sweep this PR claims to have done. **PR #170 fixes exactly that site** with the `unreadable` verdict; it is a separate unmerged branch, which is why this one still has it.

Also outside this PR's sweep and named rather than silently skipped: `scripts/verify-mainnet-config.mjs:88` holds a third uncoordinated `tryCall` with no `kind`, whose failure is reported as *"observe reverted — the pool cannot serve a Ns window"*. Same shape, different scope, filed separately.

## Deliberately out of scope

`packages/canary/src/reader.mjs` computes **no `kind` at all**, and thirteen `if (!x.ok)` sites turn a failed read into a **page**:

| file | what a 429 produces |
|---|---|
| `exit-liveness.mjs` | *"EXIT LIVENESS BROKEN … members cannot exit"* (MO-1) |
| `oracle-health.mjs:367` | *"ORACLE FROZEN … EXITS are all frozen"* |

A rate limit wakes an operator with a claim about member funds. Larger blast radius, its own PR.

## Tests

Six new. Both directions on the classifier (a revert mentioning `DeadlineTimeout` or a 429-like number is still a **revert**; an **unrecognised** string is **not**, so drill 3 fails loudly rather than passes quietly), and the verbatim 2026-09-04 budget shape with its derived arithmetic.

**soak-drills 55 / 0, soak-deployment 15 / 0.** (An earlier commit message on this branch said "soak-drills 67" — that was the combined figure mislabelled as one suite; corrected.)

`npm run gate` passes (397 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



