### PR TITLE
fix(soak): a pid is not a votable round — drill 5 blamed governance for its own guard

### DIFF
--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -232,33 +232,62 @@ if (want('vote') && !state.phases?.vote?.done) {
   assert(pid > 0n,
     'no proposal has ever been raised on the smoke vault — the agent has nothing to vote on. Start drill 2\'s allocate round (or a standalone no-op proposal) first; governance serializes per vault, so only one may be in flight.');
 
-  // A pid is NOT a votable round. `activeProposalOf` is never cleared on settlement, so it names
-  // the last proposal the vault ever had regardless of its state — see `votableNow`, which
-  // documents the fourteen-hour-dead proposal this guard used to accept. Ask the real question,
-  // and say which conjunct failed rather than letting the agent tick forty times against a round
-  // it correctly refuses to vote on.
-  const prop = readProposal(dep.governance, pid);
-  const snapshotWeight = callU(
-    VAULT, 'pastVotingEligibleShares(address,uint256)(uint256)',
-    account.address, String(prop.createdAt - 1),
-  );
-  const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight });
-  assert(votable,
-    `proposal ${pid} on the smoke vault is NOT votable by this agent: ${reason}.\n`
-      + `  status=${prop.status} ptype=${prop.ptype} createdAt=${prop.createdAt} `
-      + `commitDeadline=${prop.commitDeadline} revealDeadline=${prop.revealDeadline} `
-      + `snapshotWeight=${snapshotWeight}\n`
-      + '  This is a HARNESS/round-availability failure, not evidence about governance or the\n'
-      + '  contracts, and no amount of ticking will change it. A fresh round must be raised on this\n'
-      + '  vault AFTER the agent holds shares (voting weight snapshots at createdAt-1), and any\n'
-      + '  settled-but-still-named predecessor must be finalized first — governance serializes per\n'
-      + '  vault. scripts/soak/drill5-gov-companion.mjs does exactly that, and run-soak.ps1 does\n'
-      + '  not start it.');
-  log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} snapshotWeight=${snapshotWeight}`);
   // No hasCommitted/hasRevealed helpers exist — read the public mappings directly.
   // commitOf is bytes32(0) until a commitment lands; revealedOf is the reveal flag.
   const ZERO32 = '0x' + '0'.repeat(64);
   const hasCommitted = () => call(dep.governance, 'commitOf(uint256,address)(bytes32)', pid.toString(), account.address)[0] !== ZERO32;
+
+  // ORDER MATTERS: ask "already committed?" BEFORE "still votable?".
+  //
+  // `record('vote', ...)` runs only after commit AND reveal, so any restart between the two
+  // re-enters this phase — and by then the commit deadline has legitimately passed, because
+  // `waitUntilChainTime` below waits for exactly that. Gating on votability first would abort a
+  // LIVE round mid-reveal, claiming "a fresh round must be raised", which is false: the
+  // commitment is on-chain and only the reveal remains. The reveal window here is 3600s inside a
+  // 14-hour unattended run that advertises resumability, so that path is ordinary, not exotic.
+  //
+  // Checking the commitment first also closes `AlreadyCommitted` (Governance.sol:364) without a
+  // fifth conjunct, and keeps `votableNow`'s contract honestly "can this voter still COMMIT".
+  if (!hasCommitted()) {
+    // A pid is NOT a votable round. `activeProposalOf` is never cleared on settlement, so it names
+    // the last proposal the vault ever had regardless of its state — see `votableNow`, which
+    // documents the fourteen-hour-dead proposal this guard used to accept.
+    const prop = readProposal(dep.governance, pid);
+
+    // BOTH TERMS, because `commitVote` gates on `_boundedWeight` (Governance.sol:352-356), which
+    // is min(snapshot, current) — not the snapshot alone. `votingEligibleShares` is
+    // `sharesOf - queuedExitShares` (VaultCore.sol:1025-1028), so a voter who has queued an exit
+    // has snapshot weight and no current weight, and a snapshot-only check would call that
+    // votable and then watch `commitVote` revert NoWeight for forty ticks. Drill 5 queues an exit
+    // in its own next phase, so a re-run or reset reaches this exact state.
+    //
+    // NOTE THE `uint64`. VaultCore.sol:1040 declares `pastVotingEligibleShares(address, uint64)`;
+    // the `uint256` spelling is a DIFFERENT SELECTOR (0xab46cdef vs 0xc5a88eb3) and reverts, which
+    // is how the first version of this guard aborted the phase 100% of the time.
+    const snap = callU(
+      VAULT, 'pastVotingEligibleShares(address,uint64)(uint256)',
+      account.address, String(prop.createdAt - 1),
+    );
+    const cur = callU(VAULT, 'votingEligibleShares(address)(uint256)', account.address);
+    const snapshotWeight = snap < cur ? snap : cur;
+
+    const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight });
+    assert(votable,
+      `proposal ${pid} on the smoke vault is NOT votable by this agent: ${reason}.\n`
+        + `  status=${prop.status} ptype=${prop.ptype} createdAt=${prop.createdAt} `
+        + `commitDeadline=${prop.commitDeadline} revealDeadline=${prop.revealDeadline} `
+        + `snapshot=${snap} current=${cur} boundedWeight=${snapshotWeight}\n`
+        + '  This is a HARNESS/round-availability failure, not evidence about governance or the\n'
+        + '  contracts, and no amount of ticking will change it. A fresh round must be raised on this\n'
+        + '  vault AFTER the agent holds shares (voting weight snapshots at createdAt-1), and any\n'
+        + '  settled-but-still-named predecessor must be finalized first — governance serializes per\n'
+        + '  vault. scripts/soak/drill5-gov-companion.mjs does exactly that, and run-soak.ps1 does\n'
+        + '  not start it.');
+    log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} boundedWeight=${snapshotWeight}`);
+  } else {
+    log(`proposal ${pid} already carries this agent's commitment — skipping the votability gate and going to reveal`);
+  }
+
   const commitEvents = await tickUntil('vote', cfgIn, account, walletClient, hasCommitted, 'vote:commit');
   saveFirst('votedPid', pid.toString());
 

--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -60,6 +60,7 @@ import path from 'node:path';
 import {
   ROOT, RPC, log, assert, eq, call, callU, chainNow, waitUntilChainTime, openState, cast,
   budgetExhaustedFailure,
+  readProposal, votableNow,
 } from './lib.mjs';
 import { loadDeployment } from './deployment.mjs';
 import { loadAccountFromKeystore, redact } from '../lib/keystore.mjs';
@@ -229,7 +230,31 @@ if (want('activate') && !state.phases?.activate?.done) {
 if (want('vote') && !state.phases?.vote?.done) {
   const pid = callU(dep.governance, 'activeProposalOf(address)(uint256)', VAULT);
   assert(pid > 0n,
-    'no active proposal on the smoke vault — the agent has nothing to vote on. Start drill 2\'s allocate round (or a standalone no-op proposal) first; governance serializes per vault, so only one may be in flight.');
+    'no proposal has ever been raised on the smoke vault — the agent has nothing to vote on. Start drill 2\'s allocate round (or a standalone no-op proposal) first; governance serializes per vault, so only one may be in flight.');
+
+  // A pid is NOT a votable round. `activeProposalOf` is never cleared on settlement, so it names
+  // the last proposal the vault ever had regardless of its state — see `votableNow`, which
+  // documents the fourteen-hour-dead proposal this guard used to accept. Ask the real question,
+  // and say which conjunct failed rather than letting the agent tick forty times against a round
+  // it correctly refuses to vote on.
+  const prop = readProposal(dep.governance, pid);
+  const snapshotWeight = callU(
+    VAULT, 'pastVotingEligibleShares(address,uint256)(uint256)',
+    account.address, String(prop.createdAt - 1),
+  );
+  const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight });
+  assert(votable,
+    `proposal ${pid} on the smoke vault is NOT votable by this agent: ${reason}.\n`
+      + `  status=${prop.status} ptype=${prop.ptype} createdAt=${prop.createdAt} `
+      + `commitDeadline=${prop.commitDeadline} revealDeadline=${prop.revealDeadline} `
+      + `snapshotWeight=${snapshotWeight}\n`
+      + '  This is a HARNESS/round-availability failure, not evidence about governance or the\n'
+      + '  contracts, and no amount of ticking will change it. A fresh round must be raised on this\n'
+      + '  vault AFTER the agent holds shares (voting weight snapshots at createdAt-1), and any\n'
+      + '  settled-but-still-named predecessor must be finalized first — governance serializes per\n'
+      + '  vault. scripts/soak/drill5-gov-companion.mjs does exactly that, and run-soak.ps1 does\n'
+      + '  not start it.');
+  log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} snapshotWeight=${snapshotWeight}`);
   // No hasCommitted/hasRevealed helpers exist — read the public mappings directly.
   // commitOf is bytes32(0) until a commitment lands; revealedOf is the reveal flag.
   const ZERO32 = '0x' + '0'.repeat(64);

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -382,6 +382,50 @@ export const STATUS = ['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expi
 export const PTYPE = { Rebalance: 0, RuleChange: 1, ChildAllocation: 2 };
 
 /** Read a proposal into a named object. */
+/**
+ * Can THIS voter still commit a vote on THIS proposal, right now?
+ *
+ * `activeProposalOf` IS NOT THIS QUESTION, and conflating the two cost a soak run.
+ * `Governance.sol` assigns that mapping once, at `:321` inside `propose`, and **never clears it**
+ * on settlement — reads at `:290`, `:518` and `:650` are the only other uses. So it keeps
+ * returning the last pid the vault ever had, forever, whatever became of it.
+ *
+ * Drill 5 guarded its vote phase with `assert(pid > 0n)`. On 2026-09-04 that passed against
+ * proposal 3, whose commit window had closed FOURTEEN HOURS earlier and which had already
+ * executed. The agent then did exactly the right thing — its evaluator returned "commit window
+ * closed" on every tick — and the drill failed twenty minutes later with
+ * "vote:commit: not satisfied after 40 ticks", a GOVERNANCE-shaped message for a
+ * NO-VOTABLE-PROPOSAL cause. The guard was not too weak; it asked the wrong question.
+ *
+ * Four conjuncts, and the fourth is not theoretical: proposal 3 was raised BEFORE the agent
+ * activated, so the agent's snapshot weight reads zero and `commitVote` would revert `NoWeight`.
+ * A predicate that checked only status and deadline would attach to it and reproduce the same
+ * forty-tick stall wearing a different costume.
+ *
+ * Pure so it can be tested: the drill executes at import, so a predicate defined there could not be.
+ *
+ * @param {{status: string, ptype: number, commitDeadline: number}} p a `readProposal` result
+ * @param {{now: number, snapshotWeight: bigint, wantPtype?: number}} ctx
+ * @returns {{votable: boolean, reason: string}} reason is '' when votable
+ */
+export function votableNow(p, { now, snapshotWeight, wantPtype }) {
+  if (!p) return { votable: false, reason: 'no proposal was read' };
+  if (p.status !== 'Active') {
+    return { votable: false, reason: `status is ${p.status}, not Active — activeProposalOf still names it because Governance never clears that mapping on settlement` };
+  }
+  if (now >= p.commitDeadline) {
+    const ago = now - p.commitDeadline;
+    return { votable: false, reason: `the commit window closed ${ago}s ago (deadline ${p.commitDeadline}, chain now ${now}) — commitVote would revert` };
+  }
+  if (wantPtype != null && p.ptype !== wantPtype) {
+    return { votable: false, reason: `ptype is ${p.ptype}, not the expected ${wantPtype}` };
+  }
+  if (snapshotWeight <= 0n) {
+    return { votable: false, reason: 'the voter had zero voting-eligible stake at the proposal\'s snapshot — it was raised before this account held shares, so commitVote would revert NoWeight' };
+  }
+  return { votable: true, reason: '' };
+}
+
 export function readProposal(governance, pid) {
   const p = call(governance, PROPOSAL_SIG, pid);
   return {

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -381,7 +381,6 @@ export const P = {
 export const STATUS = ['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expired'];
 export const PTYPE = { Rebalance: 0, RuleChange: 1, ChildAllocation: 2 };
 
-/** Read a proposal into a named object. */
 /**
  * Can THIS voter still commit a vote on THIS proposal, right now?
  *
@@ -426,6 +425,7 @@ export function votableNow(p, { now, snapshotWeight, wantPtype }) {
   return { votable: true, reason: '' };
 }
 
+/** Read a proposal into a named object. */
 export function readProposal(governance, pid) {
   const p = call(governance, PROPOSAL_SIG, pid);
   return {

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -909,7 +909,9 @@ test('tryCall WIRES the classifier — a failed cast carries kind, not just ok:f
 // ───────── votableNow: a pid is not a votable round (drill 5) ─────────
 
 test('votableNow rejects a settled proposal that activeProposalOf still names', () => {
-  // The 2026-09-04 failure, verbatim. Governance assigns activeProposalOf at :321 and NEVER
+  // The 2026-09-04 failure. (ptype is 0 here only because this predicate ignores it unless a
+  // caller passes wantPtype; on chain proposal 3 is ptype 2, ChildAllocation.) Governance assigns
+  // activeProposalOf at :321 and NEVER
   // clears it on settlement, so it kept naming proposal 3 — Executed, commit window shut 14h
   // earlier. `assert(pid > 0n)` passed, the agent correctly refused to vote on every tick, and
   // the drill blamed governance 20 minutes later.
@@ -949,6 +951,17 @@ test('votableNow accepts a genuinely votable round, and only then', () => {
   assert.deepEqual(votableNow(good, { now: 100, snapshotWeight: 1n }), { votable: true, reason: '' });
   // and the ptype filter is opt-in, so it cannot silently reject when unused
   assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 0 }).votable, true);
-  assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 3 }).votable, false);
+  const wrongType = votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 3 });
+  assert.equal(wrongType.votable, false);
+  assert.match(wrongType.reason, /ptype is 0, not the expected 3/, 'the ptype reason must be asserted too, or it can be emptied unnoticed');
   assert.equal(votableNow(null, { now: 100, snapshotWeight: 1n }).votable, false);
+});
+
+test('votableNow rejects at the EXACT commit deadline, matching commitVote', () => {
+  // Governance requires `block.timestamp < p.commitDeadline`, so equality is already too late.
+  // Unpinned, `>=` could be relaxed to `>` and the suite would stay green while the drill
+  // attached to a round one second past its window.
+  const p = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 1000 };
+  assert.equal(votableNow(p, { now: 1000, snapshotWeight: 5n }).votable, false, 'now === deadline is CLOSED');
+  assert.equal(votableNow(p, { now: 999, snapshotWeight: 5n }).votable, true, 'one second earlier is open');
 });

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -777,7 +777,7 @@ test('the exit phase forces the drawdown trigger AND flags it as forced', () => 
 // calls collided and both drills died. Cross-process exclusion is verified separately by
 // running two node processes; these cover the in-process contract.
 
-import { withSendLock, ROOT as LIB_ROOT, budgetExhaustedFailure } from '../soak/lib.mjs';
+import { withSendLock, ROOT as LIB_ROOT, budgetExhaustedFailure, votableNow } from '../soak/lib.mjs';
 
 const LOCK = path.join(LIB_ROOT, 'data', '.soak-send.lock');
 
@@ -904,4 +904,51 @@ test('tryCall WIRES the classifier — a failed cast carries kind, not just ok:f
   assert.equal(r.hasErr, true);
   assert.equal(r.kind, 'transport',
     'tryCall must classify the failure — without `kind` drill 3\'s revert assertion is unguarded');
+});
+
+// ───────── votableNow: a pid is not a votable round (drill 5) ─────────
+
+test('votableNow rejects a settled proposal that activeProposalOf still names', () => {
+  // The 2026-09-04 failure, verbatim. Governance assigns activeProposalOf at :321 and NEVER
+  // clears it on settlement, so it kept naming proposal 3 — Executed, commit window shut 14h
+  // earlier. `assert(pid > 0n)` passed, the agent correctly refused to vote on every tick, and
+  // the drill blamed governance 20 minutes later.
+  const r = votableNow(
+    { status: 'Executed', ptype: 0, createdAt: 1788479808, commitDeadline: 1788483408 },
+    { now: 1788534622, snapshotWeight: 0n },
+  );
+  assert.equal(r.votable, false);
+  assert.match(r.reason, /status is Executed/);
+  assert.match(r.reason, /never clears that mapping/, 'the reason must name the mechanism, not just the symptom');
+});
+
+test('votableNow rejects an Active proposal whose commit window has closed', () => {
+  const r = votableNow(
+    { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 1000 },
+    { now: 1600, snapshotWeight: 5n },
+  );
+  assert.equal(r.votable, false);
+  assert.match(r.reason, /commit window closed 600s ago/, 'say how stale, not just that it is stale');
+});
+
+test('votableNow rejects a proposal raised before the voter held shares', () => {
+  // The conjunct a status+deadline check would miss. Proposal 3 was raised before the agent
+  // activated, so its snapshot weight is zero and commitVote reverts NoWeight — attaching to it
+  // reproduces the same 40-tick stall in a different costume.
+  const r = votableNow(
+    { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 },
+    { now: 100, snapshotWeight: 0n },
+  );
+  assert.equal(r.votable, false);
+  assert.match(r.reason, /zero voting-eligible stake/);
+  assert.match(r.reason, /NoWeight/, 'name the revert the voter would actually hit');
+});
+
+test('votableNow accepts a genuinely votable round, and only then', () => {
+  const good = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 };
+  assert.deepEqual(votableNow(good, { now: 100, snapshotWeight: 1n }), { votable: true, reason: '' });
+  // and the ptype filter is opt-in, so it cannot silently reject when unused
+  assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 0 }).votable, true);
+  assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 3 }).votable, false);
+  assert.equal(votableNow(null, { now: 100, snapshotWeight: 1n }).votable, false);
 });


### PR DESCRIPTION
## Tonight's failure

```
FAIL: vote:commit: not satisfied after 40 ticks — inspect the transcript
```

That reads as a governance or contract problem. **It was the drill's own precondition.**

## The mechanism, verified in `Governance.sol` rather than inferred

`activeProposalOf` is assigned in exactly one place — `:321`, inside `propose` — and is **never cleared on settlement**. The only other appearances are reads at `:290`, `:518`, `:650`.

So it keeps naming the last proposal a vault ever had, **forever**, whatever became of it.

Drill 5 guarded its vote phase with `assert(pid > 0n)`. On 2026-09-04 that passed against proposal 3 on the smoke vault:

| | |
|---|---|
| status | **Executed** |
| commit window closed | **14.2 hours earlier** |
| agent snapshot weight | **0** (raised before the agent activated) |

The agent then behaved perfectly — its evaluator returned *"commit window closed"* on all 40 ticks — and twenty minutes later the drill reported a **governance-shaped failure for a no-votable-proposal cause**.

The guard wasn't too weak. It asked the wrong question.

## `votableNow` asks the right one

Four conjuncts, and **the fourth is the one a careless fix would omit**:

1. status is `Active`
2. the commit window is still open
3. the ptype matches, if a caller cares
4. **the voter held voting-eligible stake at the proposal's snapshot**

Proposal 3 was raised *before* the agent activated, so its snapshot weight reads zero and `commitVote` would revert `NoWeight`. A status-and-deadline check would happily attach to it and reproduce the identical 40-tick stall in a different costume.

The failure message now names which conjunct failed, prints status / ptype / createdAt / both deadlines / snapshotWeight, states plainly that this is a **harness and round-availability** failure rather than evidence about governance or the contracts, and points at `scripts/soak/drill5-gov-companion.mjs` — which exists, raises exactly the round this drill needs, and which **`run-soak.ps1` never starts**.

Pure, and in `lib.mjs`, because `drill5-agent-execute.mjs` executes at import: a predicate defined there could not be tested, and untested pure logic in that file is how this soak already shipped one false statement today.

## Tests

Four, including tonight's proposal 3 verbatim. They assert on the **reason** as well as the boolean — a guard that fails for an unexplained reason is most of the way back to the bug.

| | pass / fail |
|---|---|
| baseline | **53 / 0** |
| status conjunct deleted | **52 / 1** |

## Scope

Deliberately **only the predicate**. Making the drill *raise* its own round when none is votable is the larger change the owner asked for and is in progress separately — it needs this fix underneath it either way, and landing the diagnosis first means the next failure is honest even if the feature isn't ready.

`npm run gate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
