### PR TITLE
test(soak): pin the budget guard to its real producer and to the near-exhaustion case

### DIFF
--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -913,7 +913,7 @@ test('budgetExhaustedFailure fires on a remainder that is still positive but bel
 test('budgetExhaustedFailure reads the field names createBudget().summary() actually emits', () => {
   // THE WIRING, not the predicate. Every case above hand-builds the summary object, so nothing
   // connected the guard's five field reads to their only real producer. A rename in budget.mjs
-  // would break the guard in one of two silent ways and change no test: `enabled` renamed makes
+  // would break the guard in one of two silent ways and change no test in this file: `enabled` renamed makes
   // `!spend?.enabled` short-circuit and the guard goes inert; `remainingUsdc` renamed makes
   // `Number(undefined)` NaN, `NaN > 0` false, and the guard fire on tick 1 of every run. Both
   // mutations turn this test red.

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -845,6 +845,12 @@ test('classifyCallError is fail-safe for the drill: an unknown string is NOT a r
 });
 
 // ───────── budget exhaustion is terminal, and must say so (drill 5) ─────────
+//
+// The guard is fed `agent.budget.summary()` in the drill, so the real producer is imported here
+// rather than described: a test that hand-builds the summary cannot notice a rename in budget.mjs.
+
+import { createBudget } from '../../packages/reference-agent/src/budget.mjs';
+import { toBaseUnits } from '../../packages/reference-agent/src/config.mjs';
 
 test('budgetExhaustedFailure fires the moment the cap is gone, and names the real cause', () => {
   // The 2026-09-04 run verbatim: cap hit at tick 5 of 40, then 35 more ticks against a blind
@@ -882,6 +888,61 @@ test('budgetExhaustedFailure keeps quiet while budget remains, or when payments 
     'payments disabled means the cap is irrelevant, not exhausted',
   );
   assert.equal(budgetExhaustedFailure(undefined, 3, 40, 'x'), null, 'no budget surface, no claim');
+});
+
+test('budgetExhaustedFailure fires on a remainder that is still positive but below one average read', () => {
+  // THE NEAR-EXHAUSTION HALF OF THE PREDICATE. Replacing the whole condition with plain
+  // `remaining > 0` — so nothing above zero ever fires — left every other test in this file green:
+  // none of them distinguishes "the remainder cannot buy one more average read" from "the
+  // remainder is zero". A remainder of exactly zero is the lucky case; it needs the reads to
+  // divide the cap evenly. A $0.004 remainder against $0.01025 average reads is the ordinary one,
+  // and it is just as blind.
+  const msg = budgetExhaustedFailure(
+    { enabled: true, spentUsdc: '0.246', capUsdc: '0.25', remainingUsdc: '0.004', paidReads: 24 },
+    20, 40, 'vote:commit',
+  );
+  assert.ok(msg, 'a remainder too small to buy a read is already blind — waiting it out proves nothing');
+  assert.match(msg, /tick 20\/40/);
+  // Derived, not asserted: $0.246 over 24 reads averages $0.01025, which $0.004 cannot buy; and
+  // $0.246 over 20 ticks is $0.0123 per tick, so 40 ticks would need about $0.49.
+  assert.match(msg, /24 paid reads averaging \$0\.010/);
+  assert.match(msg, /\$0\.012 per tick/);
+  assert.match(msg, /40 ticks needs about \$0\.49/);
+});
+
+test('budgetExhaustedFailure reads the field names createBudget().summary() actually emits', () => {
+  // THE WIRING, not the predicate. Every case above hand-builds the summary object, so nothing
+  // connected the guard's five field reads to their only real producer. A rename in budget.mjs
+  // would break the guard in one of two silent ways and change no test: `enabled` renamed makes
+  // `!spend?.enabled` short-circuit and the guard goes inert; `remainingUsdc` renamed makes
+  // `Number(undefined)` NaN, `NaN > 0` false, and the guard fire on tick 1 of every run. Both
+  // mutations turn this test red.
+  const budget = createBudget({ maxSessionSpendUsdc: '0.25', maxSingleReadUsdc: '0.05' });
+  assert.equal(
+    budgetExhaustedFailure(budget.summary(), 1, 40, 'vote:commit'),
+    null,
+    'a budget with nothing spent must not abort the run before its first read',
+  );
+
+  // Spend it to the cap through the same call the agent's guarded signer makes: `charge()`, at
+  // signature time, in base units (perceive.mjs wraps the signer with `guardSigner`, which charges).
+  // Ten reads at $0.025 keeps the average read distinct from the per-tick burn, so the two
+  // derivations below are pinned separately rather than coinciding.
+  for (let i = 0; i < 10; i += 1) budget.charge(toBaseUnits('0.025'), 'metered read');
+  assert.throws(
+    () => budget.charge(toBaseUnits('0.025'), 'metered read'),
+    /spend refused/,
+    'the premise of the guard: this budget will not fund another average read',
+  );
+
+  const msg = budgetExhaustedFailure(budget.summary(), 4, 40, 'vote:commit');
+  assert.ok(msg, 'a real spent-out budget must stop the poll');
+  // One regex over the four fields the message prints, plus the average derived from two of them.
+  // The fifth, `enabled`, is pinned by the guard returning a message at all rather than null.
+  assert.match(msg, /\$0\.25 of \$0\.25 spent, \$0 left, 10 paid reads averaging \$0\.025/);
+  assert.match(msg, /tick 4\/40/);
+  assert.match(msg, /\$0\.063 per tick/);
+  assert.match(msg, /40 ticks needs about \$2\.50/);
 });
 
 test('tryCall WIRES the classifier — a failed cast carries kind, not just ok:false', () => {


### PR DESCRIPTION
Closes the two coverage nits PR #173 was accepted with. Test-only: one file, 61 added lines, no production code changed.

## N-1 — the budget guard's wiring was unpinned

`scripts/soak/drill5-agent-execute.mjs:159` feeds the guard `agent.budget?.summary?.()`, but every existing test hand-builds that object. Nothing connected the guard's five field reads (`enabled`, `spentUsdc`, `capUsdc`, `remainingUsdc`, `paidReads`) to `createBudget().summary()` in `packages/reference-agent/src/budget.mjs:116-124` — the only place in the tree that emits them (`grep remainingUsdc` finds one production producer).

The new test imports the real `createBudget`, spends it to its $0.25 cap through the same `charge()` call `guardSigner` makes in `perceive.mjs:53`, and passes the real `summary()` in. Ten reads at $0.025 keep the average read ($0.025) distinct from the per-tick burn ($0.0625), so the two derivations in the message are pinned separately rather than coinciding. A companion assertion pins the other direction: a fresh budget with nothing spent yields `null`.

## N-2 — the near-exhaustion predicate was untested

Nothing distinguished "the remainder cannot buy one more average read" from "the remainder is exactly zero". The new case is `{ enabled: true, spentUsdc: '0.246', capUsdc: '0.25', remainingUsdc: '0.004', paidReads: 24 }` at tick 20/40, asserting both the message and its derived arithmetic ($0.01025 average read, $0.0123 per tick, ~$0.49 for 40 ticks).

## Mutation proof

Each mutation applied alone and reverted, with `git diff` confirmed empty on both production files afterwards.

| # | Mutation | Result |
|---|---|---|
| 1 | `scripts/soak/lib.mjs` — the reviewer's: whole condition replaced with plain `remaining > 0`, so nothing above zero fires | exactly one test red: "fires on a remainder that is still positive but below one average read". 91/0 → 90/1 |
| 2 | `budget.mjs summary()` — `enabled` → `paymentsEnabled` (guard goes inert) | exactly one test red: the new wiring test. 90/1 |
| 3 | `budget.mjs summary()` — `remainingUsdc` → `leftUsdc` (`Number(undefined)` is NaN, guard fires on tick 1 of every run) | exactly one test red: the same wiring test, via its fresh-budget assertion. 90/1 |

Mutation 1 was re-run after the rebase onto the squashed #174 and still produces exactly that one red.

## Counts

`node --test --test-reporter=tap scripts/test/soak-drills.test.mjs scripts/test/soak-deployment.test.mjs`

| | before | after |
|---|---|---|
| soak-drills | 73 pass / 0 fail | 75 pass / 0 fail |
| soak-deployment | 16 pass / 0 fail | 16 pass / 0 fail |
| both | 89 pass / 0 fail | 91 pass / 0 fail |

## The same shape, elsewhere — reported, not fixed

`votableNow` (`scripts/soak/lib.mjs:410`) has the identical unpinned-wiring shape. Its JSDoc says its argument is "a `readProposal` result", and at the real call site it is one (`drill5-agent-execute.mjs:255` reads, `:274` passes it in; `drill2-subvault.mjs`, `drill3-modef.mjs` and `drill5-gov-companion.mjs` also consume `readProposal`). But all five tests at `scripts/test/soak-drills.test.mjs:972-1027` hand-build the proposal literal — none goes through `readProposal`.

The concrete exposure: `readProposal` derives `status` from a lookup, `STATUS[Number(p[P.STATUS])]` (`lib.mjs:437`), and `votableNow` compares `p.status !== 'Active'` against that string. Respell an entry in `STATUS` and `votableNow` rejects every proposal with "status is …, not Active" while the whole suite stays green — the same silent failure this PR just closed for the budget guard. `commitDeadline` and `ptype` are exposed the same way.

Not fixed here, for two reasons. It is outside this nit — #174, which introduced `votableNow`, has already merged, so this is unowned queue work rather than something to hand back. And unlike `createBudget`, `readProposal` cannot be driven in-process: it goes through `call()`, i.e. a live `cast` against a chain, so pinning it needs a decoding fixture rather than a five-line spend loop. Filing it as a follow-up rather than widening this PR.

## Reported, deliberately not changed

- **`scripts/soak/lib.mjs:182-184` calls the average read "the best floor available".** A mean is not a floor: it sits between the cheapest and dearest read, so `remaining < avgRead` neither proves nor disproves that the cheapest remaining read is unaffordable. The wording is inaccurate in both directions. Left alone — it is prose outside this nit, and the test names here do not repeat the claim.
- **The same message says the agent "exhausted its x402 session spend cap"** while the near-exhaustion branch fires with $0.004 still held. Also inaccurate; the new test asserts the arithmetic and the HARNESS BUDGET attribution, not the word "exhausted".
- **`drill5-agent-execute.mjs`'s `Env (optional):` docstring omits `SOAK_AGENT_CAP_USDC`,** which the file reads at line 100. Untouched on purpose: the companion PR on `fix/soak-wire-gov-companion` owns that docstring, and editing it here would only manufacture a conflict.

