### PR TITLE
fix(soak): start the governance companion from run-soak.ps1, and size the x402 cap to a window

### DIFF
--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -45,14 +45,21 @@
  * ## Governance serializes per VAULT
  *
  * The vote phase needs a live proposal on the smoke vault, and drill 2 also runs governance
- * rounds there. They cannot overlap. Run drill 2's allocate round first and let this drill's
- * agent vote on it, or raise a standalone no-op proposal for it — either way, only one
- * proposal is in flight on the smoke vault at a time.
+ * rounds there. They cannot overlap — only one proposal is in flight on the smoke vault at a time.
+ *
+ * `run-soak.ps1` supplies that round rather than leaving it to the operator: track B runs drill 2
+ * to completion, then this script's `join` and `activate` phases, then starts
+ * `drill5-gov-companion.mjs` in the background, then re-enters this script for `vote` and `exit`.
+ * The split is forced, because the two are each other's precondition: the companion refuses to
+ * propose until the agent holds shares (drill5-gov-companion.mjs:54-56), and the vote phase
+ * refuses to tick until a votable round exists.
  *
  * Env (required): SOAK_AGENT_KEYSTORE, SOAK_AGENT_KEYSTORE_PASSWORD,
  *                 AGENT_I_UNDERSTAND_THIS_SPENDS_FUNDS=yes
  * Env (optional): BASE_SEPOLIA_RPC, SOAK_API, SOAK_STATE_DIR, SOAK_TICK_MS, SOAK_MAX_TICKS,
- *                 SOAK_PHASE (run a single phase), SOAK_RESET=1
+ *                 SOAK_AGENT_CAP_USDC (x402 session spend cap per phase poll window, default
+ *                 5.00 — see the cap note in buildAgent), SOAK_PHASE (run a single phase),
+ *                 SOAK_RESET=1
  * Run:  node scripts/soak/drill5-agent-execute.mjs
  */
 import fs from 'node:fs';
@@ -89,15 +96,18 @@ async function buildAgent(phase, cfgIn, account, walletClient, entryMarks = {}) 
 
   const config = loadConfig({
     mode: 'execute',
-    // The cap is a SAFETY CONTROL on an agent that signs, so the default is not widened here to
-    // make a drill pass — it is surfaced. `tickUntil` computes the spend actually needed for the
-    // poll window and names SOAK_AGENT_CAP_USDC when the two disagree, leaving the decision with
-    // the operator. Default unchanged at $0.25.
+    // THE CAP MUST COVER A WHOLE POLL WINDOW, and $0.25 did not. One tick pays for `2 + vaultCount`
+    // metered reads (perceive.mjs:127, 133, 144) at $0.01 each (apps/api/src/serve.mjs:70,
+    // PRICE_AMOUNT default '10000'), so the 2026-09-04 run burned $0.05/tick against three indexed
+    // vaults and went blind at tick 5 of 40. 40 ticks at that rate needs $2.00; $5.00 buys 40 ticks
+    // at $0.125, i.e. ten indexed vaults. The owner authorised the raise for this testnet soak.
+    // Still PER SESSION, not per drill: `createBudget` runs inside `createAgent` (agent.mjs:52),
+    // and `tickUntil` builds a fresh agent per phase window.
     api: {
       baseUrl: cfgIn.apiBaseUrl,
       payments: {
         enabled: true,
-        maxSessionSpendUsdc: process.env.SOAK_AGENT_CAP_USDC ?? '0.25',
+        maxSessionSpendUsdc: process.env.SOAK_AGENT_CAP_USDC ?? '5.00',
         maxSingleReadUsdc: '0.05',
       },
     },
@@ -186,11 +196,24 @@ const account = await loadAccountFromKeystore(cfgIn.keystore, cfgIn.password);
 saveFirst('agent', account.address);
 log(`agent identity ${account.address} (throwaway, keystore-held by the operator)`);
 
+// SPENDABLE USDC IS A `join` PRECONDITION, NOT A DRILL-WIDE ONE. This check sits above every
+// `want(...)` guard, so it also gates activate, vote and exit — none of which spend USDC, and all
+// of which run AFTER the deposit has left the wallet. run-soak.ps1 now invokes this script three
+// times (join, activate, then vote+exit) so the governance companion can raise its round in
+// between, which makes those later invocations the normal case rather than a resume-only one.
+// On 2026-09-04 the agent read 995,100 units while holding 1e18 shares — under the threshold, so
+// the unqualified form aborts before the phase guard that would have skipped join.
+// The minimum is met once the money is escrowed or minted, so accept either as evidence of it.
 const usdc = callU(dep.usdc, 'balanceOf(address)(uint256)', account.address);
 const eth = BigInt(cast(['balance', account.address, '--rpc-url', cfgIn.rpcUrl]));
-assert(usdc >= 1_000_000n, `agent needs >= 1.00 USDC to meet the vault minimum (has ${usdc})`);
+const [pendingUsdc] = call(VAULT, 'pendingDeposit(address)(uint256,uint64)', account.address);
+const joinedShares = callU(VAULT, 'sharesOf(address)(uint256)', account.address);
+const joined = BigInt(pendingUsdc) > 0n || joinedShares > 0n;
+assert(usdc >= 1_000_000n || joined,
+  `agent needs >= 1.00 USDC to meet the vault minimum, or a deposit already in `
+  + `(has ${usdc} units, pending ${pendingUsdc}, shares ${joinedShares})`);
 assert(eth >= 10n ** 15n, `agent needs test ETH for gas (has ${eth} wei)`);
-log(`agent funded: ${usdc} USDC units, ${eth} wei`);
+log(`agent funded: ${usdc} USDC units, ${eth} wei (pending ${pendingUsdc}, shares ${joinedShares})`);
 
 const { createWalletClient, http } = await import('viem');
 const { baseSepolia } = await import('viem/chains');
@@ -281,8 +304,10 @@ if (want('vote') && !state.phases?.vote?.done) {
         + '  contracts, and no amount of ticking will change it. A fresh round must be raised on this\n'
         + '  vault AFTER the agent holds shares (voting weight snapshots at createdAt-1), and any\n'
         + '  settled-but-still-named predecessor must be finalized first — governance serializes per\n'
-        + '  vault. scripts/soak/drill5-gov-companion.mjs does exactly that, and run-soak.ps1 does\n'
-        + '  not start it.');
+        + '  vault. scripts/soak/drill5-gov-companion.mjs does exactly that, and run-soak.ps1 starts\n'
+        + '  it in the background before this phase — so read logs/gov-companion.log and\n'
+        + '  logs/gov-companion.err.log for why no round is there. Running this drill standalone,\n'
+        + '  start the companion yourself first.');
     log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} boundedWeight=${snapshotWeight}`);
   } else {
     log(`proposal ${pid} already carries this agent's commitment — skipping the votability gate and going to reveal`);

--- a/scripts/soak/drill5-gov-companion.mjs
+++ b/scripts/soak/drill5-gov-companion.mjs
@@ -14,8 +14,17 @@
  * `createdAt - 1`, so a proposal raised before activation would give the agent zero weight and
  * its reveal would be a no-op. Preflight enforces this.
  *
- * Env: SOAK_SIGNER_ARGS (deployer), BASE_SEPOLIA_RPC, SOAK_STATE_DIR, SOAK_RESET=1.
- * Run:  node scripts/soak/drill5-gov-companion.mjs
+ * `run-soak.ps1` starts this script in the background inside track B, between drill 5's `activate`
+ * and `vote` phases — the only window that satisfies the preflight above. Track B then waits for
+ * it to exit, because the settlement below happens AFTER drill 5's exit phase. Its pid is appended
+ * to logs/soak-pids.txt, so `run-soak.ps1 -Stop` reaches it; that matters because SOAK_SIGNER_ARGS
+ * names a `--password-file` the operator deletes once the run is over.
+ *
+ * Env: SOAK_SIGNER_ARGS (deployer), BASE_SEPOLIA_RPC, SOAK_STATE_DIR, SOAK_RESET=1. run-soak.ps1
+ *      sets the first two for the whole run; it never sets SOAK_STATE_DIR, and only reads it to
+ *      find the state file this script writes.
+ * Run:  node scripts/soak/drill5-gov-companion.mjs   (standalone: the agent must already hold
+ *       shares — drill5-fasttrack.mjs is one way to get there)
  */
 import fs from 'node:fs';
 import path from 'node:path';

--- a/scripts/soak/run-soak.ps1
+++ b/scripts/soak/run-soak.ps1
@@ -5,7 +5,9 @@
 # vault) genuinely overlap - running them serially wastes about six hours.
 #
 #   Track A: drill1-multivault  ->  drill3-modef
-#   Track B: drill2-subvault    ->  drill5-agent-execute
+#   Track B: drill2-subvault    ->  drill5(join) -> drill5(activate)
+#                               ->  drill5-gov-companion (background)
+#                               ->  drill5(vote + exit) -> wait for the companion
 #
 # Everything logs to .\logs\*.log. Every drill is resumable, so a crash or a reboot costs only
 # the step in flight. Nothing needs a human once the password files are in place.
@@ -14,6 +16,17 @@
 #         powershell -ExecutionPolicy Bypass -File scripts\soak\run-soak.ps1 -SkipAgent
 #         powershell -ExecutionPolicy Bypass -File scripts\soak\run-soak.ps1 -Status
 #         powershell -ExecutionPolicy Bypass -File scripts\soak\run-soak.ps1 -Stop
+#
+# Env READ if you set it:  BASE_SEPOLIA_RPC (default https://sepolia.base.org)
+#                          SOAK_API         (default http://127.0.0.1:8402)
+#                          SOAK_STATE_DIR   (default <repo>\scripts\soak - where the drills keep
+#                                            their resumable state; this script only reads it to
+#                                            find the companion's file)
+#                          SOAK_AGENT_CAP_USDC (default 5.00 - drill 5's x402 session spend cap,
+#                                            per phase poll window, see drill5-agent-execute.mjs)
+# Env SET by this script (your value is overwritten): SOAK_SIGNER_ARGS, SOAK_PROBE_MEMBER,
+#                          SOAK_PHASE, AGENT_I_UNDERSTAND_THIS_SPENDS_FUNDS, SOAK_AGENT_KEYSTORE,
+#                          SOAK_AGENT_KEYSTORE_PASSWORD
 
 param(
   [string]$SignerPasswordFile = "$env:USERPROFILE\.soak.pw",
@@ -132,13 +145,22 @@ function Start-Bg([string]$Name, [string]$File, [string[]]$ArgList) {
   return $p
 }
 
-# Track scripts: run the drills of one track in sequence inside a single child powershell, so
-# drill 3 starts the moment drill 1 finishes without anyone watching for it.
-function Start-Track([string]$Name, [string[]]$Scripts) {
-  $inner = ($Scripts | ForEach-Object {
-    "Write-Host '>>> $_'; node '$_'; if (`$LASTEXITCODE -ne 0) { Write-Host 'FAILED: $_'; exit `$LASTEXITCODE }"
-  }) -join '; '
-  return Start-Bg $Name 'powershell.exe' @('-NoProfile','-ExecutionPolicy','Bypass','-Command', $inner)
+# One track step: run a node script, and abandon the track if it fails.
+#
+# $Phase sets SOAK_PHASE for that step only. drill5-agent-execute.mjs runs a single phase when
+# SOAK_PHASE is set and every phase when it is empty or absent, so '' is the correct "all phases"
+# encoding under either PowerShell semantics for clearing an environment variable.
+function New-NodeStep([string]$Script, [string]$Phase = '') {
+  $label = if ($Phase) { "$Script [$Phase]" } else { $Script }
+  return "`$env:SOAK_PHASE = '$Phase'; Write-Host '>>> $label'; node '$Script'; " +
+         "if (`$LASTEXITCODE -ne 0) { Write-Host 'FAILED: $label'; exit `$LASTEXITCODE }"
+}
+
+# Track steps: run one track's steps in sequence inside a single child powershell, so drill 3
+# starts the moment drill 1 finishes without anyone watching for it. Each element must be a
+# single-line statement - they are joined with '; '.
+function Start-Track([string]$Name, [string[]]$Steps) {
+  return Start-Bg $Name 'powershell.exe' @('-NoProfile','-ExecutionPolicy','Bypass','-Command', ($Steps -join '; '))
 }
 
 # Services read their configuration from .env (RPC_URL, the contract addresses, START_BLOCK,
@@ -199,14 +221,74 @@ while ($true) {
 }
 
 Write-Host "`nstarting drill tracks (these run in PARALLEL - governance serializes per vault)..." -ForegroundColor Cyan
-Start-Track 'trackA' @('scripts/soak/drill1-multivault.mjs','scripts/soak/drill3-modef.mjs') | Out-Null
+Start-Track 'trackA' @(
+  (New-NodeStep 'scripts/soak/drill1-multivault.mjs'),
+  (New-NodeStep 'scripts/soak/drill3-modef.mjs')
+) | Out-Null
 
-$trackB = @('scripts/soak/drill2-subvault.mjs')
+$trackB = @(New-NodeStep 'scripts/soak/drill2-subvault.mjs')
 if ($runAgent) {
   $env:AGENT_I_UNDERSTAND_THIS_SPENDS_FUNDS = 'yes'
   $env:SOAK_AGENT_KEYSTORE = "$env:USERPROFILE\.foundry\keystores\soak-throwaway"
   $env:SOAK_AGENT_KEYSTORE_PASSWORD = (Get-Content $AgentPasswordFile -Raw)
-  $trackB += 'scripts/soak/drill5-agent-execute.mjs'
+  # The x402 session spend cap the agent runs under, stated rather than left to a default a
+  # reader would have to go find. drill5-agent-execute.mjs carries the same 5.00 as its own
+  # default; scripts/test/soak-drills.test.mjs pins the two together.
+  if (-not $env:SOAK_AGENT_CAP_USDC) { $env:SOAK_AGENT_CAP_USDC = '5.00' }
+  Write-Host "  SOAK_AGENT_CAP_USDC = `$$($env:SOAK_AGENT_CAP_USDC) per phase poll window" -ForegroundColor Green
+
+  # DRILL 5 AND THE GOVERNANCE COMPANION ARE EACH OTHER'S PRECONDITION, so drill 5 is split.
+  #
+  # drill5-gov-companion.mjs refuses to propose until the agent holds shares (it snapshots voting
+  # weight at createdAt-1, so a round raised earlier would give the agent zero weight), and drill
+  # 5's vote phase refuses to tick until a votable round exists. The only ordering that satisfies
+  # both is: join, activate, THEN the companion, THEN vote. Each `node` invocation re-reads the
+  # state file and skips what is already recorded done, so the split costs two extra preflights
+  # and nothing else.
+  $compOut   = Join-Path $LogDir 'gov-companion.log'
+  $compErr   = Join-Path $LogDir 'gov-companion.err.log'
+  # Mirrors drill5-gov-companion.mjs: SOAK_STATE_DIR ?? <repo>/scripts/soak, then the state file.
+  $compStateDir = if ($env:SOAK_STATE_DIR) { $env:SOAK_STATE_DIR } else { Join-Path $Root 'scripts\soak' }
+  $compState = Join-Path $compStateDir '.state-drill5gov.json'
+
+  $trackB += New-NodeStep 'scripts/soak/drill5-agent-execute.mjs' 'join'
+  $trackB += New-NodeStep 'scripts/soak/drill5-agent-execute.mjs' 'activate'
+
+  # Background, because the companion outlives drill 5: it settles the agent's queued exit after
+  # drill 5's exit phase. Start-Process detaches it, so stopping track B's powershell does NOT
+  # reach it - its pid line in $PidFile is the only thing that does, and -Stop is what reads that
+  # file. That is what keeps it from outliving the run, and why the operator must -Stop before
+  # deleting the password files the companion signs with.
+  $trackB += "Write-Host '>>> starting drill5-gov-companion (background) - drill 5 needs a votable round'"
+  $trackB += "`$comp = Start-Process -FilePath 'node' -ArgumentList 'scripts/soak/drill5-gov-companion.mjs' " +
+             "-WorkingDirectory '$Root' -NoNewWindow -PassThru -RedirectStandardOutput '$compOut' -RedirectStandardError '$compErr'"
+  $trackB += "Add-Content -Path '$PidFile' -Value ('gov-companion=' + `$comp.Id)"
+  $trackB += "Write-Host ('  started gov-companion pid ' + `$comp.Id)"
+
+  # Then WAIT for the round to exist before drill 5 looks for it, or the vote gate loses a race it
+  # would report as a governance problem. The signal is the companion's own state file: it writes
+  # steps.propose.done after the proposal id is confirmed on chain. A half-written file throws in
+  # ConvertFrom-Json and is simply retried on the next pass.
+  #
+  # Every exit from this loop is logged and NONE of them abort the track: if the companion could
+  # not raise a round, drill 5's own round-availability diagnostic is the one that belongs on the
+  # record, and masking it here with a launcher error would be the substitution this soak keeps
+  # making.
+  $trackB += "`$compDeadline = (Get-Date).AddMinutes(10)"
+  $trackB += "while (`$true) { " +
+             "`$raised = `$false; " +
+             "if (Test-Path '$compState') { try { `$raised = [bool](Get-Content '$compState' -Raw | ConvertFrom-Json).steps.propose.done } catch { `$raised = `$false } }; " +
+             "if (`$raised) { Write-Host '  companion raised the round'; break }; " +
+             "if (`$comp.HasExited) { Write-Host ('  companion EXITED ' + `$comp.ExitCode + ' without raising a round - see $compErr; running drill 5 anyway so its own diagnostic is what lands'); break }; " +
+             "if ((Get-Date) -gt `$compDeadline) { Write-Host '  companion has not raised a round after 10 minutes - see $compOut; running drill 5 anyway'; break }; " +
+             "Start-Sleep -Seconds 10 }"
+
+  # No SOAK_PHASE: join and activate are recorded as done, so this runs vote then exit and writes
+  # the full transcript.
+  $trackB += New-NodeStep 'scripts/soak/drill5-agent-execute.mjs'
+
+  $trackB += "Write-Host '>>> waiting for drill5-gov-companion (it finalizes, executes and settles the agent exit AFTER drill 5)'"
+  $trackB += "if (`$comp) { `$comp.WaitForExit(); Write-Host ('gov-companion exited ' + `$comp.ExitCode + ' - see $compOut') }"
 }
 Start-Track 'trackB' $trackB | Out-Null
 
@@ -224,7 +306,9 @@ sampler has covered a 4h observation window:
 
   node scripts/soak/drill4-oraclefreeze.mjs
 
-Delete the password files when the run is done:
+Delete the password files when the run is done - AFTER -Stop, never before. The governance
+companion signs with SOAK_SIGNER_ARGS, which names $SignerPasswordFile, and it keeps running
+past drill 5 to finalize, execute and settle:
   Remove-Item "$SignerPasswordFile","$AgentPasswordFile" -ErrorAction SilentlyContinue
 ===============================================================
 "@ -ForegroundColor Cyan

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -1026,3 +1026,156 @@ test('votableNow rejects at the EXACT commit deadline, matching commitVote', () 
   assert.equal(votableNow(p, { now: 1000, snapshotWeight: 5n }).votable, false, 'now === deadline is CLOSED');
   assert.equal(votableNow(p, { now: 999, snapshotWeight: 5n }).votable, true, 'one second earlier is open');
 });
+
+// ───────── the launcher wiring: run-soak.ps1 must actually start the companion ─────────
+//
+// The votability gate taught drill 5 to say "no votable round" instead of stalling for 40 ticks,
+// and the message it prints names drill5-gov-companion.mjs. Nothing started that script, so the
+// diagnostic was correct and the run still could not proceed.
+//
+// These are text-and-order pins over the PowerShell, not execution: CI runs on ubuntu-latest and
+// run-soak.ps1 is PowerShell, so no node test can run it. What they CAN catch is the defect that
+// actually happens here — a launcher edit that drops a step, reorders one, or leaves a claim about
+// the launcher standing in a file nobody thought to update.
+
+const SOAK_DIR = path.join(LIB_ROOT, 'scripts', 'soak');
+const RUN_SOAK = fs.readFileSync(path.join(SOAK_DIR, 'run-soak.ps1'), 'utf8');
+const DRILL5 = fs.readFileSync(path.join(SOAK_DIR, 'drill5-agent-execute.mjs'), 'utf8');
+
+/** Index of the first match, asserting the anchor still exists rather than silently yielding -1. */
+const anchorAt = (re, what) => {
+  const m = re.exec(RUN_SOAK);
+  assert.ok(m, `run-soak.ps1 no longer contains ${what} — this test lost its anchor`);
+  return m.index;
+};
+
+const PS_JOIN = /New-NodeStep 'scripts\/soak\/drill5-agent-execute\.mjs' 'join'/;
+const PS_ACTIVATE = /New-NodeStep 'scripts\/soak\/drill5-agent-execute\.mjs' 'activate'/;
+const PS_COMPANION = /Start-Process[^\n]*drill5-gov-companion\.mjs/;
+const PS_VOTE = /New-NodeStep 'scripts\/soak\/drill5-agent-execute\.mjs'\s*$/m;
+const PS_WAIT = /\$comp\.WaitForExit\(\)/;
+
+test('run-soak.ps1 starts the governance companion, between drill 5 activating and voting', () => {
+  // The ordering is FORCED, not a preference: drill5-gov-companion.mjs refuses to propose until
+  // the agent holds shares (voting weight snapshots at createdAt-1), and drill 5's vote phase
+  // refuses to tick until a votable round exists. Each is the other's precondition, so the only
+  // sequence satisfying both puts the companion between activate and vote.
+  const iJoin = anchorAt(PS_JOIN, "drill 5's join step");
+  const iActivate = anchorAt(PS_ACTIVATE, "drill 5's activate step");
+  const iComp = anchorAt(PS_COMPANION, 'the companion launch');
+  const iVote = anchorAt(PS_VOTE, "drill 5's phase-less vote+exit step");
+  const iWait = anchorAt(PS_WAIT, 'the wait for the companion');
+  assert.ok(iJoin < iActivate, 'join must precede activate');
+  assert.ok(iActivate < iComp, 'the companion cannot propose before the agent holds shares');
+  assert.ok(iComp < iVote, 'drill 5 has nothing to vote on until the companion has raised a round');
+  assert.ok(iVote < iWait, 'the companion settles the agent exit, so track B waits for it LAST');
+});
+
+test('run-soak.ps1 waits for the round to exist before drill 5 goes looking for it', () => {
+  // Backgrounding the companion and immediately running drill 5 loses a race that the vote gate
+  // would report as a governance problem. The launcher waits on the companion's own state file,
+  // which records steps.propose.done only after the proposal id is confirmed on chain.
+  const region = RUN_SOAK.slice(
+    anchorAt(PS_COMPANION, 'the companion launch'),
+    anchorAt(PS_VOTE, "drill 5's phase-less vote+exit step"),
+  );
+  assert.match(region, /Test-Path '\$compState'/, 'the wait must key on the companion state file');
+  assert.match(region, /steps\.propose\.done/, 'propose is the step drill 5 depends on');
+  assert.match(region, /AddMinutes\(\d+\)/, 'an unbounded wait would hang track B on a dead companion');
+
+  // And $compState must resolve the way drill5-gov-companion.mjs does — SOAK_STATE_DIR, else
+  // <repo>/scripts/soak — or the launcher watches a file nobody writes and always times out.
+  assert.match(RUN_SOAK, /\$compStateDir = if \(\$env:SOAK_STATE_DIR\) \{ \$env:SOAK_STATE_DIR \} else \{ Join-Path \$Root 'scripts\\soak' \}/);
+  assert.match(RUN_SOAK, /\$compState = Join-Path \$compStateDir '\.state-drill5gov\.json'/);
+});
+
+test('a companion that cannot raise a round is logged, and never masks drill 5', () => {
+  const region = RUN_SOAK.slice(
+    anchorAt(PS_COMPANION, 'the companion launch'),
+    anchorAt(PS_VOTE, "drill 5's phase-less vote+exit step"),
+  );
+  // `exit $LASTEXITCODE` is how New-NodeStep abandons a track. This region must not use it:
+  // drill 5's own round-availability diagnostic is the evidence that belongs on the record.
+  assert.doesNotMatch(region, /exit \$LASTEXITCODE/, 'the launcher must not abort track B here');
+  assert.match(region, /HasExited/, 'a dead companion must be detected, not waited out');
+  assert.match(region, /running drill 5 anyway/, 'say plainly that drill 5 still runs');
+});
+
+test('the companion logs beside the other drills, and its pid is in the file -Stop reads', () => {
+  // "must not outlive the run" reduces to exactly this. run-soak.ps1 has no automatic
+  // password-file wipe — it PRINTS a Remove-Item for the operator — and Start-Process detaches the
+  // companion, so killing track B's powershell would not reach it. The pid-file entry is the
+  // whole guarantee.
+  assert.match(RUN_SOAK, /Join-Path \$LogDir 'gov-companion\.log'/);
+  assert.match(RUN_SOAK, /Join-Path \$LogDir 'gov-companion\.err\.log'/);
+  assert.match(RUN_SOAK, /Add-Content -Path '\$PidFile' -Value \('gov-companion='/);
+  assert.match(RUN_SOAK, /if \(\$Stop\) \{[\s\S]*?Get-Content \$PidFile[\s\S]*?Stop-Process/,
+    '-Stop must still be the thing that reads the pid file');
+});
+
+test('the x402 session cap covers a whole poll window, and launcher and drill agree on it', () => {
+  // Derived, not asserted. The 2026-09-04 run spent $0.25 by tick 5 of 40, so a tick costs $0.05
+  // and the 40-tick window needs $2.00 — the same arithmetic budgetExhaustedFailure prints.
+  const OBSERVED_SPEND = 0.25;
+  const OBSERVED_TICK = 5;
+  const WINDOW_TICKS = 40;
+  const needed = (OBSERVED_SPEND / OBSERVED_TICK) * WINDOW_TICKS;
+  assert.equal(needed, 2, 'the observed rate must still work out to $2.00 for 40 ticks');
+
+  const inDrill = /SOAK_AGENT_CAP_USDC \?\? '([0-9.]+)'/.exec(DRILL5);
+  assert.ok(inDrill, 'drill 5 must still carry a default cap');
+  const inPs1 = /\$env:SOAK_AGENT_CAP_USDC = '([0-9.]+)'/.exec(RUN_SOAK);
+  assert.ok(inPs1, 'run-soak.ps1 must state the cap rather than inherit it silently');
+
+  assert.equal(Number(inPs1[1]), Number(inDrill[1]),
+    'a launcher that sets a different cap than the drill defaults to is two answers to one question');
+  assert.ok(Number(inDrill[1]) >= needed,
+    `cap $${inDrill[1]} does not cover ${WINDOW_TICKS} ticks at the observed rate ($${needed.toFixed(2)})`);
+  assert.match(RUN_SOAK, /if \(-not \$env:SOAK_AGENT_CAP_USDC\)/, 'an operator override must survive');
+  assert.match(RUN_SOAK, /Write-Host "  SOAK_AGENT_CAP_USDC = /, 'the operator has to SEE the cap');
+});
+
+test('drill 5 documents SOAK_AGENT_CAP_USDC among its optional env', () => {
+  const doc = DRILL5.slice(0, DRILL5.indexOf('*/'));
+  assert.match(doc, /Env \(optional\)[\s\S]*?SOAK_AGENT_CAP_USDC/,
+    'a knob a failure message tells the operator to set must be listed where they look for knobs');
+});
+
+// The NEGATIVE guard, and the one that matters most. A positive list can only ever require too
+// little; a negative guard must enumerate from the filesystem, because the stale claim arrives in
+// the file nobody added to a list. Same reasoning as config-doc-truth.test.mjs's header.
+//
+// Text is normalized first: the claim this replaces lived across two string concatenations
+// ("...run-soak.ps1 does\n' + '  not start it."), so matching raw source would miss it.
+const CLAIM_SKIP_DIRS = new Set(['node_modules', '.git', '.claude', 'lib', 'out', 'cache', 'broadcast', 'coverage', 'logs', 'data']);
+const CLAIM_EXTS = ['.md', '.mjs', '.js', '.ps1', '.json', '.txt', '.html'];
+const NOT_STARTED_SHAPES = [
+  /run-soak(\.ps1)?\s+(does not|doesn.t|will not|won.t|cannot|can.t|never)\s+(start|launch|run)/i,
+  /(not|never)\s+(started|launched|run)\s+by\s+run-soak/i,
+];
+
+test('no file still claims run-soak.ps1 does not start the companion', () => {
+  const files = [];
+  (function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!CLAIM_SKIP_DIRS.has(entry.name)) walk(path.join(dir, entry.name));
+      } else if (CLAIM_EXTS.some((e) => entry.name.endsWith(e))) {
+        files.push(path.join(dir, entry.name));
+      }
+    }
+  })(LIB_ROOT);
+  assert.ok(files.length > 50, `the walker found only ${files.length} files — it is not walking the repo`);
+
+  const offenders = [];
+  for (const file of files) {
+    if (path.resolve(file) === path.resolve(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'))) continue;
+    const normalized = fs.readFileSync(file, 'utf8')
+      .replace(/\\n/g, ' ').replace(/['"`+]/g, ' ').replace(/\s+/g, ' ');
+    for (const shape of NOT_STARTED_SHAPES) {
+      const m = shape.exec(normalized);
+      if (m) offenders.push(`${path.relative(LIB_ROOT, file)}: "${m[0]}"`);
+    }
+  }
+  assert.deepEqual(offenders, [], 'run-soak.ps1 starts drill5-gov-companion.mjs — these say otherwise');
+});

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer,
@@ -30,7 +31,7 @@ const LINK = '0xE4aB69C077896252FAFBD49EFD26B5D171A32410';
 
 /** For the selector drift guard: viem and the compiled ABIs, both optional in a bare checkout. */
 const viem = await import('viem').catch(() => null);
-const OUT = path.join(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..', '..', 'contracts', 'out');
+const OUT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'contracts', 'out');
 const abiOf = (rel) => {
   const p = path.join(OUT, rel);
   return fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')).abi ?? [] : [];
@@ -1169,7 +1170,7 @@ test('no file still claims run-soak.ps1 does not start the companion', () => {
 
   const offenders = [];
   for (const file of files) {
-    if (path.resolve(file) === path.resolve(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'))) continue;
+    if (path.resolve(file) === path.resolve(fileURLToPath(import.meta.url))) continue;
     const normalized = fs.readFileSync(file, 'utf8')
       .replace(/\\n/g, ' ').replace(/['"`+]/g, ' ').replace(/\s+/g, ' ');
     for (const shape of NOT_STARTED_SHAPES) {


### PR DESCRIPTION
## What changed

**1. `run-soak.ps1` starts the governance companion.** #174 taught drill 5 to say "no votable
round" instead of stalling for 40 ticks. Its message names
`scripts/soak/drill5-gov-companion.mjs` as the script that raises one — and said, truthfully, that
`run-soak.ps1` did not start it. Track B now does.

**2. `SOAK_AGENT_CAP_USDC` default `0.25` → `5.00`**, set and echoed by `run-soak.ps1`, and added
to drill 5's `Env (optional):` docstring (a reviewer flagged it missing) and to a new env block in
`run-soak.ps1`'s header.

## Why the ordering is forced, not chosen

The two scripts are each other's precondition:

- `drill5-gov-companion.mjs:54-56` refuses to propose until the agent holds shares — voting weight
  snapshots at `createdAt - 1`, so an earlier round would give the agent zero weight.
- `drill5-agent-execute.mjs`'s vote phase refuses to tick until a votable round exists.

Satisfying both needs a foreground synchronisation point *between* drill 5's activate and its vote,
and `SOAK_PHASE` (already documented, `drill5-agent-execute.mjs:222-223`) is the only lever that
makes one. So track B splits drill 5:

```
drill2 → drill5(join) → drill5(activate) → gov-companion (background) → drill5(vote+exit)
       → wait for the companion
```

Track B waits for the companion **last**, because it finalizes, executes and settles the agent's
queued exit *after* drill 5's exit phase.

The launcher also waits (bounded, 10 min) for the companion's own state file to record
`steps.propose.done` before starting drill 5. Backgrounding it and immediately running drill 5
loses a race the vote gate would report as a governance problem — the companion needs ~30 s of
preflight and a transaction, drill 5 reaches its gate in seconds.

**Failure is logged, never masked.** Every exit from that wait (round raised / companion exited /
deadline) prints a line, and none of them abort the track. If the companion could not raise a
round, drill 5 still runs and its own round-availability diagnostic is what lands on the record.
`New-NodeStep`'s `exit $LASTEXITCODE` is deliberately absent from that region, and a test pins it.

## On "stopped before the wipe"

There is no automatic password-file wipe to be stopped before — `run-soak.ps1` **prints** a
`Remove-Item` instruction for the operator. So "must not outlive the run" reduces to one thing:
`Start-Process` detaches the companion, so stopping track B's powershell does not reach it; its pid
is appended to `logs/soak-pids.txt`, which is the file `-Stop` reads. The closing banner now says
to `-Stop` **before** deleting the password files, because the companion signs with the
`--password-file` named in `SOAK_SIGNER_ARGS`. The parent clears the pid file at line 133, before
the tracks start, so the child appending hours later cannot be clobbered.

## The funding assert had to move with it

`drill5-agent-execute.mjs`'s `usdc >= 1_000_000n` sat above every `want(...)` phase guard, so it
also gated activate, vote and exit — none of which spend USDC, all of which now run in their own
invocation *after* the deposit has left the wallet.

Measured, not assumed: on 2026-09-04 the agent (`0x290caf00…15a6d`) reads **995,100 USDC units**
while holding **1e18 shares** on the smoke vault. The unqualified form therefore aborts before the
guard that would have skipped `join`, on the current chain state, today. It now accepts an escrowed
or minted deposit as evidence the vault minimum was met — the same reads the join phase already
makes. This is scoping a precondition to what it guards, not weakening a gate (SWARM §10).

## The cap, and its arithmetic

- One tick pays for `2 + vaultCount` metered reads (`perceive.mjs:127, 133, 144`) at **$0.01** each
  (`apps/api/src/serve.mjs:70`, `PRICE_AMOUNT` default `'10000'`).
- The 2026-09-04 run burned **$0.05/tick** — three indexed vaults — and went blind at tick 5 of 40.
  40 ticks at that rate needs **$2.00**, which is exactly what `budgetExhaustedFailure` computes.
- **$5.00** buys 40 ticks at $0.125/tick, i.e. **ten** indexed vaults. Drill 1 creates vault B and
  drill 2 creates the child vault during the run, so the count grows; 2.5× the observed rate is the
  headroom.

Two things a reviewer should not read past:

- It is **per session, not per drill**. `createBudget` runs inside `createAgent`
  (`agent.mjs:52`) and `tickUntil` builds a fresh agent per phase window
  (`drill5-agent-execute.mjs:151`), so five windows can each spend up to $5.00 — a ceiling of $25 testnet USDC per full drill-5 run, which is the amount the owner authorised.
- Whether that is settled USDC or local accounting depends on `FACILITATOR` in the operator's
  `.env` (`apps/api/src/serve.mjs:48`; `.env.example:115` defaults to `stub`, which accepts without
  on-chain settlement). **I cannot see that file and am not claiming which mode it carries.**

`maxSingleReadUsdc: '0.05'` and the shipped default at `packages/reference-agent/src/config.mjs:53`
are untouched — the shipped CLI's `--cap` default of `0.25` documented in `docs/REFERENCE-AGENT.md`
remains true.

## Testing

**The PowerShell cannot be unit-tested in CI** — `.github/workflows/ci.yml` runs `ubuntu-latest`.
So the 7 new tests in `scripts/test/soak-drills.test.mjs` are text-and-order pins over
`run-soak.ps1`, which is what actually catches the defect class here: a launcher edit that drops a
step, reorders one, or leaves a stale claim standing.

- step order — join < activate < companion < vote < wait
- the bounded wait keys on `.state-drill5gov.json` / `steps.propose.done`, and `$compState`
  resolves the way the companion does (`SOAK_STATE_DIR`, else `<repo>/scripts/soak`)
- no `exit $LASTEXITCODE` in the companion region; `HasExited` handled; "running drill 5 anyway"
- companion logs under `$LogDir`; its pid appended to the file `-Stop` reads
- cap ≥ the $2.00 the observed rate needs, **derived in the test from $0.25 / 5 ticks × 40**, and
  launcher and drill agreeing on the number
- drill 5's docstring names `SOAK_AGENT_CAP_USDC`
- a **negative** guard that walks the repo from the filesystem (never a list, per
  `config-doc-truth.test.mjs`'s header) and fails any file still claiming `run-soak.ps1` does not
  start the companion. It normalizes `\n`/quote/`+` artifacts first, because the claim it replaces
  lived across two string concatenations.

**Scope boundary of that last guard, so nobody over-reads it:** both shapes require the literal
token `run-soak`. It catches "run-soak.ps1 does not start it" in any file and any phrasing of the
negation, but *not* a launcher claim written without naming the launcher ("the operator must raise
a round first"). Widening it to unnamed subjects would match ordinary prose. There is also no
`RECORD_DIRS`-style exemption for dated records quoting old failure text, as
`config-doc-truth.test.mjs` has — checked, and nothing under `docs/reviews/` or `docs/audit/`
mentions the companion or a votable round today, so none is needed yet.

**Manual checks on the landing SHA** (Windows, local):

```
[System.Management.Automation.Language.Parser]::ParseFile(run-soak.ps1)   → PARSE OK
# then, with Start-Bg stubbed, the generated trackB child command:
ParseInput(<generated -Command string>)                                   → PARSE OK
ORDER OK: activate(474) < companion(892) < vote(2009) < wait(2373)
cap echoed as: 5.00
```

**Counts:**

```
node --test --test-reporter=tap scripts/test/soak-drills.test.mjs \
  scripts/test/soak-deployment.test.mjs scripts/test/config-doc-truth.test.mjs
  → tests 115, pass 115, fail 0
node --test --test-reporter=tap scripts/test/soak-drills.test.mjs
  → tests 80, pass 80, fail 0   (73 before; 7 new)
npm run gate → GATE PASSED (409.9s), 1 advisory (slither, pre-existing)
```

## Prose that became false, and was fixed

- `drill5-agent-execute.mjs` — "run-soak.ps1 does not start it"; the §"Governance serializes per
  VAULT" paragraph describing a manual choice the launcher now makes; the cap comment's "Default
  unchanged at $0.25".
- `drill5-gov-companion.mjs` — its `Env:` / `Run:` block presented it as manual-only.
- `run-soak.ps1` — the track diagram, and the closing banner's password-file instruction.
- `docs/SOAK-REPORT.md:188-189` deliberately left alone: they record the 2026-08-24→25 Sprint-12 run and carry no claim about the launcher.

## Could not verify

- **The wiring has not been run end to end.** It needs a live soak, which I was told not to start,
  and the agent's 995,100 USDC units would need a faucet top-up first for a cold `join` to proceed.
- Whether the operator's `.env` sets `FACILITATOR=stub` or `http`, i.e. whether the raised cap
  moves real testnet USDC.
- `-Status` / `-Stop` behaviour against a live `gov-companion` pid line; verified only by reading
  the existing loops at `run-soak.ps1:50-78`, which are unchanged.

## Dependency

Built on #174, which merged as `67ccf647` while this was in flight. Rebased onto `protocol/main` —
this branch now carries **one commit** and is `behind_by 0`.

