### PR TITLE
fix(canary): an empty-returndata revert was reported as an "unrecognized revert" of the probe's own address

### DIFF
--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -567,8 +567,21 @@ re-assert on a backoff until fixed:
 | `… check ERRORED on vault … and measured nothing` | the signal threw (usually an RPC fault) | read the error in `detail`; the vault is unmonitored for that signal until it clears |
 | `FEED IDENTITY DETECTOR BLIND … did not answer description() / decimals()` | the proxy stopped answering the two reads the harm checks compare against | the asset is unmonitored for aggregator-swap drift. A feed that has stopped answering the calls `ChainlinkOracle`'s own constructor made has itself changed shape — check it against Chainlink's feed registry |
 | `FEED IDENTITY DETECTOR BLIND … answered neither aggregator() nor phaseId()` | the feed is not an `EACAggregatorProxy`, or both reads are failing | the harm checks (decimals, denomination) **did** run and passed; it is the swap *notice* that is blind |
+| `exit-liveness sentinel BLIND … did not reach the chain` | the `requestExit` probe failed in transit (rate limit, timeout, dropped socket) — no revert was observed | check the RPC's rate limit and `RPC_URL`. **This is not an H-1 finding**: nothing about `requestExit` was learned. It clears on the next sweep that reaches the chain |
+| `ORACLE DETECTOR BLIND … priceWad() … could not be read` | the ground-truth price read failed in transit | as above. Whether the asset is frozen is unknown, so it is not reported either way |
+| `ORACLE FRESHNESS DETECTOR BLIND … price sources could not be read` | enough sources were unreachable that the quorum margin cannot be stated | the verdict is still given whenever it holds on a bound — this line means the unreadable sources are what decides it |
+| `SEQUENCER GATE DETECTOR BLIND … could not be read` | the uptime feed read failed in transit | as above. It does **not** mean the sequencer gate tripped |
+| `… DETECTOR BLIND … could not be probed` / `neither probe … could be read` | both oracle-flavor probes failed in transit | which oracle is deployed is unknown; this says nothing about the oracle's ABI |
 
-**These three damp against RPC noise, and none of the others do.** Every blind branch in
+**Transport failures never become findings.** Every line in the second half of that table exists
+because an RPC failure and a contract revert both surface as a failed read, and code that treats
+"the read failed" as "the contract refused" turns a busy network into a security incident. The
+reader tags each failure `revert` or `transport` (`packages/canary/src/call-error.mjs`); only a
+`revert` can produce a verdict, and a `transport` routes here — visible, re-asserted on a backoff,
+and explicitly not evidence of a fault.
+
+**The three `FEED IDENTITY DETECTOR BLIND` lines damp against RPC noise, and none of the others
+do.** Every blind branch in
 `feed-identity` is triggered by an `eth_call` coming back empty, and one empty return is noise while
 three consecutive is the feed — so they carry `minConsecutive: 3` and only escalate on the third
 sweep. The exception is the very first sighting of an asset, which reports immediately: a monitor

--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -276,6 +276,14 @@ Three-way classification:
 Empty returndata is the actual H-1 signature — a creator-chosen module that ran out of its 300k gas
 cap or bombed returndata. There is deliberately **no** "could not classify, assume healthy" branch.
 
+The two fault labels are backed differently, and neither can come from the canary's own request.
+`EMPTY returndata (out-of-gas or returndata bomb)` means neither viem's structured fields nor the
+node's own error text carried any returndata. `unrecognized revert 0x…` names the first four bytes
+of returndata the node did return. The reader never scrapes viem's composed message, which quotes
+the `from`, `to` and `data` it was asked to send: on an empty-returndata revert that scrape used to
+report the probe member's address as an "unrecognized revert" (`packages/canary/src/reader.mjs`,
+`scrapedRevertData`; pinned against a real viem client in `test/exit-liveness.test.mjs`).
+
 **Threshold.** No non-gate revert.
 
 **When it fires.** Members cannot leave. Check the `module-events` signal on the same vault: a

--- a/packages/canary/README.md
+++ b/packages/canary/README.md
@@ -30,7 +30,8 @@ its own `CANARY_STATE_PATH`.
 | File | Role |
 |---|---|
 | `src/canary-runner.mjs` | entrypoint: env config, the sweep, the poll loop |
-| `src/reader.mjs` | the only file that talks to an RPC; lazy/optional viem, same pattern as the indexer's `rpc.mjs` |
+| `src/reader.mjs` | the only file that talks to an RPC; lazy/optional viem, same pattern as the indexer's `rpc.mjs`. Tags every failure `kind: 'revert' \| 'transport'` |
+| `src/call-error.mjs` | the `revert` vs `transport` classifier, imported with zero dependencies. `scripts/soak/lib.mjs` re-exports it so the two harnesses cannot drift |
 | `src/abis.mjs` | views, watched events, and the embedded revert selectors — kept separate from the indexer's table on purpose (see the file header) |
 | `src/signal.mjs` | the `ok` / `alert` / `skipped` result vocabulary, the `detectorBroken` marker, and integer bps math |
 | `src/transitions.mjs` | pure transition detection — the piece that makes the canary quiet, and the one rule that keeps a blind detector loud |

--- a/packages/canary/src/call-error.mjs
+++ b/packages/canary/src/call-error.mjs
@@ -1,0 +1,52 @@
+// @ts-check
+/**
+ * Is a failed read EVIDENCE ABOUT THE CONTRACT, or missing evidence?
+ *
+ * A leaf module with NO imports, because two callers that must never disagree live on opposite
+ * sides of the repo: `packages/canary` (viem, deployed) and `scripts/soak` (`cast`, dev-only).
+ * It lives under `packages/` rather than under `scripts/` because the Dockerfile copies only
+ * `packages` and `apps` into the runtime image — a canary that imported `scripts/soak/lib.mjs`
+ * would resolve fine on a developer's checkout and fail with MODULE_NOT_FOUND in production.
+ * `scripts/soak/lib.mjs` imports and re-exports it, the same way `scripts/soak/oracle-sampler.mjs`
+ * already re-exports from `lib.mjs`, so there is exactly one definition.
+ *
+ * This exists because a soak drill asserted `!result.ok` to prove a call was REFUSED, and
+ * `ok:false` is also what a rate limit produces — so a 429 satisfied a security assertion
+ * (PR #173). The canary had the same shape in more places: a transport failure reached the pager
+ * as "EXIT LIVENESS BROKEN … (H-1 regression)".
+ *
+ * ── What 'transport' does and does not mean ──
+ * It means ONLY "this is not a confirmed contract-level revert". It is deliberately the default
+ * for unrecognized wording, so a failure nobody has seen before is treated as missing evidence
+ * rather than as a finding. It does NOT mean "the chain was unreachable": `missing trie node`,
+ * which a pruned node returns for a read pinned below its history window, classifies 'transport'
+ * — the node answered, it just could not answer THAT question. `share-conservation.mjs` relies on
+ * that string reaching its unpinned-retry path, which is why that retry is not gated on `kind`.
+ */
+
+// REDUNDANT WITH THE TERNARY BELOW, and kept only as documentation of what "transport" means in
+// practice. Trace it: if REVERTED matches, this cannot fire; if it does not, both paths already
+// return 'transport'. Deleting it changes no behaviour and no test. It is labelled rather than
+// removed because in a file whose whole subject is that this classification is security-relevant,
+// a decorative regex reading as load-bearing logic is its own hazard.
+const TRANSPORT_ERR = /429|rate.?limit|max retries exceeded|timed out|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket|connection|dns|502|503|504|521/i;
+/** The wording for a contract-level revert, in the JSON-RPC, local-decode and viem spellings. */
+const REVERTED = /execution reverted|revert(ed)?:/i;
+
+/**
+ * Classify a failed call. ONLY a recognised revert is evidence about the contract; anything else
+ * is missing evidence and must be recorded as such.
+ *
+ * Takes the flattened error TEXT, not an Error object, so one implementation serves both callers:
+ * `cast` hands it stderr, and the canary's reader hands it `shortMessage ?? message ?? String(err)`.
+ * Measured against viem 2.x wording: a genuine revert reaches this as "Execution reverted for an
+ * unknown reason." (matches), an HTTP 429 as "HTTP request failed." and a JSON-RPC rate limit as
+ * "Request exceeds defined limit." (neither matches).
+ *
+ * @param {string} err
+ * @returns {'revert'|'transport'}
+ */
+export function classifyCallError(err) {
+  if (TRANSPORT_ERR.test(err) && !REVERTED.test(err)) return 'transport';
+  return REVERTED.test(err) ? 'revert' : 'transport';
+}

--- a/packages/canary/src/reader.mjs
+++ b/packages/canary/src/reader.mjs
@@ -20,9 +20,25 @@
  *   getLogs({address, event, args, fromBlock, toBlock})-> Promise<Log[]>
  *   staticCall({to, from, data})                       -> Promise<CallResult>   (never throws)
  *
- * @typedef {{ok:boolean, value?:any, revertData?:string|null, error?:string}} ReadResult
- * @typedef {{ok:boolean, data:string|null, error?:string}} CallResult
+ * ── `kind` on a failure: is this evidence about the contract? ──
+ * `ok:false` alone says only that a read did not produce a value. A 429, a timeout and a genuine
+ * revert all reach a caller that way, so a signal branching on `!ok` turns a busy network into a
+ * finding about the protocol. Every failure therefore carries `kind`: `'revert'` when the chain
+ * refused the call, `'transport'` when it is not a confirmed revert (see call-error.mjs — that
+ * word does NOT mean the node was unreachable). Signals route `'transport'` to a blind-detector
+ * result and keep their verdicts for `'revert'`.
+ *
+ * A transport failure also carries NO returndata. `extractRevertData` falls back to scraping hex
+ * out of the error text, and viem's transport errors quote the request — so on an HTTP 429 it
+ * returns the canary's OWN `requestExit` calldata, whose first four bytes then read as an
+ * unrecognized revert selector. That is measured, not hypothetical (test/reader.test.mjs), and it
+ * is why `revertData`/`data` is forced to null when `kind === 'transport'`: a call that never
+ * reached the chain produced no returndata, so reporting scraped hex would be a lie at the source.
+ *
+ * @typedef {{ok:boolean, value?:any, revertData?:string|null, error?:string, kind?:'revert'|'transport'}} ReadResult
+ * @typedef {{ok:boolean, data:string|null, error?:string, kind?:'revert'|'transport'}} CallResult
  */
+import { classifyCallError } from './call-error.mjs';
 
 const HEX_RE = /0x[0-9a-fA-F]{8,}/;
 
@@ -39,6 +55,22 @@ const HEX_RE = /0x[0-9a-fA-F]{8,}/;
  * @returns {string|null} lowercased 0x-prefixed returndata, or null if there was none
  */
 export function extractRevertData(err) {
+  return structuredRevertData(err) ?? scrapedRevertData(err);
+}
+
+/**
+ * The STRUCTURED half of the walk: returndata viem actually handed us in a field, as opposed to
+ * hex found in prose. Split out (behaviour of `extractRevertData` unchanged — it is these two in
+ * the original order) because the two halves carry very different weight as evidence.
+ *
+ * Returndata in a field can only exist if the EVM executed and reverted, so a non-null answer here
+ * is positive proof of a revert and outranks the message text when `tryRead`/`staticCall` decide
+ * `kind`. That matters for a provider whose wording no pattern recognises: without this, a real
+ * revert carrying real returndata would be filed as unreadable.
+ * @param {any} err
+ * @returns {string|null}
+ */
+export function structuredRevertData(err) {
   const seen = new Set();
   let node = err;
   for (let depth = 0; node && typeof node === 'object' && depth < 12; depth += 1) {
@@ -54,11 +86,38 @@ export function extractRevertData(err) {
     }
     node = node.cause;
   }
+  return null;
+}
+
+/**
+ * The SCRAPED half: the first long hex run anywhere in the error prose. Weak evidence, and the
+ * reason `kind` exists — viem quotes the failing request in a transport error's message, so on an
+ * HTTP 429 this returns the CALLER'S OWN calldata. Never used to decide `kind`.
+ * @param {any} err
+ * @returns {string|null}
+ */
+function scrapedRevertData(err) {
   const text = [err?.details, err?.shortMessage, err?.message]
     .filter((s) => typeof s === 'string')
     .join(' ');
   const m = HEX_RE.exec(text);
   return m ? m[0].toLowerCase() : null;
+}
+
+/**
+ * Was a failed call EVIDENCE ABOUT THE CONTRACT, or did it never get there?
+ *
+ * Two sources, in order of how much they prove. Returndata viem handed us in a FIELD can only
+ * exist if the EVM executed and reverted, so it settles the question outright — that path also
+ * keeps a revert classifiable when a provider's wording matches no known pattern. Failing that,
+ * the message text decides, via the classifier `scripts/soak/lib.mjs` shares.
+ *
+ * The scraped hex is deliberately not consulted: it is the thing that made a 429 look like a
+ * revert in the first place.
+ * @param {any} err @param {string} errorText @returns {'revert'|'transport'}
+ */
+function classifyFailure(err, errorText) {
+  return structuredRevertData(err) != null ? 'revert' : classifyCallError(errorText);
 }
 
 /**
@@ -114,10 +173,13 @@ export function createChainReader({ client, rpcUrl, chainId = 8453, chainName = 
     try {
       return { ok: true, value: await read(address, abi, functionName, args, opts) };
     } catch (err) {
+      const error = err?.shortMessage ?? err?.message ?? String(err);
+      const kind = classifyFailure(err, error);
       return {
         ok: false,
-        revertData: extractRevertData(err),
-        error: err?.shortMessage ?? err?.message ?? String(err),
+        revertData: kind === 'revert' ? extractRevertData(err) : null,
+        error,
+        kind,
       };
     }
   }
@@ -148,10 +210,13 @@ export function createChainReader({ client, rpcUrl, chainId = 8453, chainName = 
       const res = await c.call({ to, account: from, data });
       return { ok: true, data: res?.data ?? '0x' };
     } catch (err) {
+      const error = err?.shortMessage ?? err?.message ?? String(err);
+      const kind = classifyFailure(err, error);
       return {
         ok: false,
-        data: extractRevertData(err),
-        error: err?.shortMessage ?? err?.message ?? String(err),
+        data: kind === 'revert' ? extractRevertData(err) : null,
+        error,
+        kind,
       };
     }
   }

--- a/packages/canary/src/reader.mjs
+++ b/packages/canary/src/reader.mjs
@@ -28,12 +28,22 @@
  * word does NOT mean the node was unreachable). Signals route `'transport'` to a blind-detector
  * result and keep their verdicts for `'revert'`.
  *
- * A transport failure also carries NO returndata. `extractRevertData` falls back to scraping hex
- * out of the error text, and viem's transport errors quote the request — so on an HTTP 429 it
- * returns the canary's OWN `requestExit` calldata, whose first four bytes then read as an
- * unrecognized revert selector. That is measured, not hypothetical (test/reader.test.mjs), and it
- * is why `revertData`/`data` is forced to null when `kind === 'transport'`: a call that never
- * reached the chain produced no returndata, so reporting scraped hex would be a lie at the source.
+ * A transport failure also carries NO returndata: `revertData`/`data` is forced to null when
+ * `kind === 'transport'`. A call that never reached the chain produced no returndata, and the
+ * fallback scrape below can still find hex in a node's own words for such a failure — a pruned
+ * node's `missing trie node <hash>` classifies 'transport' and carries a 64-hex-character hash
+ * (measured; test/reader.test.mjs).
+ *
+ * ── Returndata comes from the node, never from the request ──
+ * viem builds a `BaseError`'s `message` out of its `shortMessage`, `metaMessages` and `details`,
+ * and for a failed call the `metaMessages` quote the request: `call` prints `from`, `to` and
+ * `data` under "Raw Call Arguments", `readContract` prints the address and args under "Contract
+ * Call". Scraping hex out of `message` therefore returns something the canary itself sent
+ * whenever the node returned nothing — on a genuine empty-returndata revert, the H-1 signature,
+ * it returned the probe's `from` address as the "revert data". The scrape reads only `details`,
+ * which viem carries up the cause chain unchanged from the innermost error — for a revert, the
+ * node's JSON-RPC `error.message` (viem/errors/base.js, request.js) — and never `message` or
+ * `shortMessage`. Measured both ways in test/reader.test.mjs.
  *
  * @typedef {{ok:boolean, value?:any, revertData?:string|null, error?:string, kind?:'revert'|'transport'}} ReadResult
  * @typedef {{ok:boolean, data:string|null, error?:string, kind?:'revert'|'transport'}} CallResult
@@ -45,12 +55,15 @@ const HEX_RE = /0x[0-9a-fA-F]{8,}/;
 /**
  * Dig the raw revert returndata out of whatever the provider or viem threw.
  *
- * Pure and unit-tested, because the whole exit-liveness sentinel hinges on it: a bug here that
- * silently returned null would downgrade a real H-1 fault into "unclassifiable". Callers treat
- * `null` as "reverted with no data", which ALERTS — so the failure mode here is loud, not silent.
+ * Pure and unit-tested, because the exit-liveness sentinel classifies on it. `null` is a real
+ * answer, not a failure: it is what a revert with EMPTY returndata produces — the H-1 signature
+ * signals/exit-liveness.mjs names — and callers ALERT on it, so a miss here is loud, not silent.
+ * The hazard runs the other way, hex the node never sent: this function once scraped the probe's
+ * own `from` address out of viem's message on exactly that revert, so the pager line named an
+ * "unrecognized revert 0x22222222" instead of empty returndata (measured; test/reader.test.mjs).
  *
- * Walks the `cause` chain (viem nests RpcRequestError inside CallExecutionError inside
- * ContractFunctionExecutionError) and falls back to scraping a hex blob out of the message.
+ * Walks the `cause` chain for a structured field first (viem nests RpcRequestError inside
+ * CallExecutionError inside ContractFunctionExecutionError), then scrapes the node's own words.
  * @param {any} err
  * @returns {string|null} lowercased 0x-prefixed returndata, or null if there was none
  */
@@ -90,17 +103,24 @@ export function structuredRevertData(err) {
 }
 
 /**
- * The SCRAPED half: the first long hex run anywhere in the error prose. Weak evidence, and the
- * reason `kind` exists — viem quotes the failing request in a transport error's message, so on an
- * HTTP 429 this returns the CALLER'S OWN calldata. Never used to decide `kind`.
+ * The SCRAPED half: the first long hex run in the NODE'S OWN WORDS — `details`, and only
+ * `details`. Weak evidence, never used to decide `kind`.
+ *
+ * Not `message` and not `shortMessage`. viem composes `message` from `metaMessages`, and for a
+ * failed call those quote the request: `call` prints from/to/data under "Raw Call Arguments",
+ * `readContract` prints address/args under "Contract Call". On a revert whose returndata is
+ * empty there is no hex in the node's words, so a scrape over `message` finds the request's
+ * instead — the probe's `from` address in `call`'s message, the contract address in
+ * `readContract`'s. `details` is the innermost error's text carried up the chain unchanged
+ * (viem/errors/base.js); for a revert that is the node's JSON-RPC `error.message`, and viem does
+ * not quote the request there.
  * @param {any} err
  * @returns {string|null}
  */
 function scrapedRevertData(err) {
-  const text = [err?.details, err?.shortMessage, err?.message]
-    .filter((s) => typeof s === 'string')
-    .join(' ');
-  const m = HEX_RE.exec(text);
+  const details = err?.details;
+  if (typeof details !== 'string') return null;
+  const m = HEX_RE.exec(details);
   return m ? m[0].toLowerCase() : null;
 }
 
@@ -110,14 +130,24 @@ function scrapedRevertData(err) {
  * Two sources, in order of how much they prove. Returndata viem handed us in a FIELD can only
  * exist if the EVM executed and reverted, so it settles the question outright — that path also
  * keeps a revert classifiable when a provider's wording matches no known pattern. Failing that,
- * the message text decides, via the classifier `scripts/soak/lib.mjs` shares.
+ * the text decides, via the classifier `scripts/soak/lib.mjs` shares — given BOTH the node's own
+ * words (`details`) and viem's (`shortMessage`, or `message` when there is none).
+ *
+ * `details` is consulted because viem's wording differs by action. `call` says "Execution
+ * reverted for an unknown reason.", which the classifier recognises; `readContract` says 'The
+ * contract function "f" reverted.', which it does not. So a revert with empty returndata reached
+ * `tryRead` as 'transport' — a real revert filed as missing evidence — while `details` said
+ * "execution reverted" the whole time (measured; test/reader.test.mjs). The soak harness feeds
+ * the same classifier `cast`'s stderr, which is likewise the node's text.
  *
  * The scraped hex is deliberately not consulted: it is the thing that made a 429 look like a
  * revert in the first place.
  * @param {any} err @param {string} errorText @returns {'revert'|'transport'}
  */
 function classifyFailure(err, errorText) {
-  return structuredRevertData(err) != null ? 'revert' : classifyCallError(errorText);
+  if (structuredRevertData(err) != null) return 'revert';
+  const details = typeof err?.details === 'string' ? err.details : '';
+  return classifyCallError(`${details} ${errorText}`);
 }
 
 /**

--- a/packages/canary/src/signals/exit-liveness.mjs
+++ b/packages/canary/src/signals/exit-liveness.mjs
@@ -23,6 +23,9 @@
  *   FROZEN (StaleOracle) — the SF-2/K-4 breaker. By design, but it IS a live capital freeze, so it
  *           is `skipped` and attributed to the oracle signal, which pages for it. Never reported
  *           as OK — an operator must not read "exits fine" while capital is frozen.
+ *   BLIND  (the probe never reached the chain: 429, timeout, dropped socket) — DETECTOR BROKEN.
+ *           Nothing about the contract was observed, so there is no verdict to give. Told apart by
+ *           `kind` from the reader, never by `ok` alone: every one of these also yields `ok:false`.
  *   FAULT  (everything else: Reentrancy, Panic, Error(string), an unrecognized selector, or
  *           EMPTY returndata) — ALERT. Empty/unrecognized returndata is the actual H-1 signature
  *           (a module that ran out of its gas cap or bombed returndata), so it must land here.
@@ -34,7 +37,7 @@
  */
 
 import { REQUEST_EXIT_SELECTOR, EXIT_GATE_SELECTORS, EXIT_FROZEN_SELECTORS, EXIT_FAULT_SELECTORS } from '../abis.mjs';
-import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+import { ok, alert, skipped, detectorBroken, shortAddr } from '../signal.mjs';
 
 export const SIGNAL = 'exit-liveness';
 
@@ -100,6 +103,26 @@ export async function checkExitLiveness({ reader, vault, shareBook, creator, pro
       signal: SIGNAL, vault,
       message: `exits live on vault ${shortAddr(vault)}: requestExit(${shares}) static-calls clean as ${shortAddr(probe.member)}`,
       measured: 'no revert', threshold: 'no non-gate revert', detail,
+    })];
+  }
+
+  // THE PROBE DID NOT REACH THE CHAIN. `ok:false` is also what a 429, a timeout and a dropped
+  // socket produce, and none of them is evidence about `requestExit`. Before this branch existed
+  // all three landed in the FAULT alert below and paged "EXIT LIVENESS BROKEN … (H-1 regression)"
+  // — and worse than merely unclassified: `extractRevertData` scrapes hex out of the error text,
+  // viem's transport errors quote the request, so the "revert selector" it recovered was this
+  // module's OWN `encodeRequestExit` calldata. The reader now nulls `data` on a transport failure
+  // (reader.mjs), which is what makes the ordering here safe rather than the ordering itself: with
+  // no returndata to misread, the gate and frozen branches below cannot fire on a network error.
+  //
+  // This is `detectorBroken`, not `skipped`: the sentinel is blind, and transitions.mjs re-asserts
+  // a blind detector on a backoff instead of reporting it once. A rate-limited canary must stay
+  // visible — it just must not name a protocol fault it did not observe.
+  if (res.kind === 'transport') {
+    return [detectorBroken({
+      signal: SIGNAL, vault,
+      message: `exit-liveness sentinel BLIND on vault ${shortAddr(vault)}: the requestExit(${shares}) probe as ${shortAddr(probe.member)} did not reach the chain (${res.error ?? 'no error text'}), so no revert was observed and nothing was learned about H-1. This vault is UNMONITORED for exit liveness this sweep, it is not healthy — and this is NOT evidence of a fault`,
+      detail: { ...detail, kind: 'transport', reason: 'unreadable' },
     })];
   }
 

--- a/packages/canary/src/signals/fee-routing.mjs
+++ b/packages/canary/src/signals/fee-routing.mjs
@@ -60,7 +60,7 @@ export async function checkFeeRouting({ reader, vault, usdc, operatorRegistry, e
       return [skipped({
         signal: SIGNAL, vault,
         message: `fee routing skipped on vault ${shortAddr(vault)}: operatorOf() is unreadable on the registry: ${idRes.error}`,
-        detail: { vault, operatorRegistry },
+        detail: { vault, operatorRegistry, kind: idRes.kind ?? null },
       })];
     }
     const opId = BigInt(idRes.value ?? 0);

--- a/packages/canary/src/signals/feed-identity.mjs
+++ b/packages/canary/src/signals/feed-identity.mjs
@@ -153,22 +153,32 @@ export async function checkFeedIdentity({ reader, vault, oracle, assets, pins = 
   const seq = await reader.tryRead(oracle, CHAINLINK_ORACLE_VIEWS, 'sequencerUptimeFeed', []);
   if (!seq.ok) {
     const legacy = await reader.tryRead(oracle, ORACLE_VIEWS, 'assetConfig', [assets[0]]);
-    if (legacy.ok) {
+    if (legacy.ok && seq.kind === 'revert') {
       // A CONFIRMED retired `OracleAggregator`. There is no Chainlink proxy anywhere in that
       // regime, so feed identity is not a thing that exists to be blind about — its sources are
       // fixed addresses in an immutable config. Nothing to report is the honest answer, not a
       // suppressed one.
+      //
+      // "CONFIRMED" is carried by `seq.kind === 'revert'`, and that guard is the point: this is
+      // the one branch in the package that returns SILENCE. Reached on a transport failure it
+      // would conclude "retired aggregator, nothing to monitor" from a 429 that happened to hit
+      // the first probe and miss the second, and the signal would go quiet with no line at all.
       return [];
     }
-    // Neither ABI. This IS a blind detector, and it is reported here as well as under
+    const unreachable = seq.kind === 'transport' || legacy.kind === 'transport';
+    // Neither ABI answered. This IS a blind detector, and it is reported here as well as under
     // `oracle-freshness`: that signal's line says the vault is unmonitored for the staleness
     // FREEZE, which is a different capability from the one this signal provides.
     return [detectorBroken({
       signal: SIGNAL, vault, key: 'flavor',
-      message: `FEED IDENTITY DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig(), so no feed can be located to check. This vault is UNMONITORED for aggregator-swap drift, not clean`,
+      message: unreachable
+        ? `FEED IDENTITY DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} could not be probed (sequencerUptimeFeed: ${seq.error ?? 'no error text'}; assetConfig: ${legacy.error ?? 'no error text'}), so no feed can be located to check. This vault is UNMONITORED for aggregator-swap drift this sweep — this says nothing about the oracle's ABI`
+        : `FEED IDENTITY DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig(), so no feed can be located to check. This vault is UNMONITORED for aggregator-swap drift, not clean`,
       detail: {
         vault, oracle, minConsecutive: UNREADABLE_SWEEPS,
         chainlinkProbeError: seq.error ?? null, legacyProbeError: legacy.error ?? null,
+        chainlinkProbeKind: seq.kind ?? null, legacyProbeKind: legacy.kind ?? null,
+        unreachable,
       },
     })];
   }
@@ -192,8 +202,10 @@ async function assetIdentity({ reader, vault, oracle, asset, pins }) {
   const cfgRead = await reader.tryRead(oracle, CHAINLINK_ORACLE_VIEWS, 'feedOf', [asset]);
   if (!cfgRead.ok) {
     return blind(
-      `FEED IDENTITY DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} reverts (${cfgRead.error}) even though the oracle answered as a ChainlinkOracle, so the cached scale this check compares against cannot be read. This asset is UNMONITORED for aggregator-swap drift, not clean`,
-      { error: cfgRead.error ?? null },
+      cfgRead.kind === 'revert'
+        ? `FEED IDENTITY DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} reverts (${cfgRead.error}) even though the oracle answered as a ChainlinkOracle, so the cached scale this check compares against cannot be read. This asset is UNMONITORED for aggregator-swap drift, not clean`
+        : `FEED IDENTITY DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} could not be read (${cfgRead.error}) — the call did not reach the chain, so no revert was observed and the cached scale this check compares against is unavailable. This asset is UNMONITORED for aggregator-swap drift this sweep, not clean`,
+      { error: cfgRead.error ?? null, kind: cfgRead.kind ?? null },
     );
   }
   const cfg = normalizeFeedConfig(cfgRead.value);

--- a/packages/canary/src/signals/governance-watch.mjs
+++ b/packages/canary/src/signals/governance-watch.mjs
@@ -231,8 +231,8 @@ export async function checkGovernanceWatch({ reader, vault, fromBlock, toBlock, 
   if (!gov.ok || typeof gov.value !== 'string' || gov.value.toLowerCase() === ZERO_ADDR) {
     return [detectorBroken({
       signal: SIGNAL, vault,
-      message: `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: governance() ${gov.ok ? `returned ${gov.value}` : `did not answer (${gov.error ?? 'reverted'})`} — no proposal on this vault can be seen, so it is unmonitored for governance, not quiet`,
-      detail: { vault, error: gov.ok ? `governance() = ${gov.value}` : gov.error ?? 'reverted' },
+      message: `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: governance() ${gov.ok ? `returned ${gov.value}` : `${gov.kind === 'transport' ? 'could not be read' : 'reverted'} (${gov.error ?? 'reverted'})`} — no proposal on this vault can be seen, so it is unmonitored for governance, not quiet`,
+      detail: { vault, error: gov.ok ? `governance() = ${gov.value}` : gov.error ?? 'reverted', kind: gov.ok ? null : gov.kind ?? null },
     })];
   }
   const governance = gov.value;
@@ -241,8 +241,12 @@ export async function checkGovernanceWatch({ reader, vault, fromBlock, toBlock, 
   if (!active.ok) {
     return [detectorBroken({
       signal: SIGNAL, vault,
-      message: `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: Governance ${shortAddr(governance)} did not answer activeProposalOf() (${active.error ?? 'reverted'}) — it may not be a Governance contract; the vault is unmonitored for governance, not quiet`,
-      detail: { vault, governance, error: active.error ?? 'reverted' },
+      // "It may not be a Governance contract" is an inference from a REVERT. A transport failure
+      // supports no inference about what is deployed at that address, so it does not get one.
+      message: active.kind === 'transport'
+        ? `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: activeProposalOf() on Governance ${shortAddr(governance)} could not be read (${active.error ?? 'no error text'}) — the call did not reach the chain, so no revert was observed; the vault is unmonitored for governance this sweep, not quiet`
+        : `GOVERNANCE DETECTOR BLIND on vault ${shortAddr(vault)}: Governance ${shortAddr(governance)} did not answer activeProposalOf() (${active.error ?? 'reverted'}) — it may not be a Governance contract; the vault is unmonitored for governance, not quiet`,
+      detail: { vault, governance, error: active.error ?? 'reverted', kind: active.kind ?? null },
     })];
   }
   const pid = num(active.value);

--- a/packages/canary/src/signals/nav-backing.mjs
+++ b/packages/canary/src/signals/nav-backing.mjs
@@ -60,7 +60,10 @@ export async function checkNavBacking({ reader, vault, atBlock, thresholdBps = 5
       message: frozen
         ? `NAV check skipped on vault ${shortAddr(vault)}: navWad() reverts StaleOracle — the oracle breaker is tripped (see the oracle-freshness signal for the asset)`
         : `NAV check skipped on vault ${shortAddr(vault)}: navWad() is unreadable: ${reportedRes.error}`,
-      detail: { vault, revertData: reportedRes.revertData, attributedTo: frozen ? 'oracle-freshness' : null },
+      // `isFrozen` reads `revertData`, which the reader nulls on a transport failure, so a 429 can
+      // no longer be attributed to the oracle breaker by a scraped selector. Both branches already
+      // said "skipped"; `kind` records which one it was.
+      detail: { vault, revertData: reportedRes.revertData, kind: reportedRes.kind ?? null, attributedTo: frozen ? 'oracle-freshness' : null },
     }));
     return results;
   }

--- a/packages/canary/src/signals/oracle-freshness.mjs
+++ b/packages/canary/src/signals/oracle-freshness.mjs
@@ -28,7 +28,7 @@
  */
 
 import { ORACLE_VIEWS, PRICE_SOURCE_VIEWS } from '../abis.mjs';
-import { ok, alert, skipped, shortAddr } from '../signal.mjs';
+import { ok, alert, skipped, detectorBroken, shortAddr } from '../signal.mjs';
 
 export const SIGNAL = 'oracle-freshness';
 
@@ -72,8 +72,18 @@ export async function checkOracleFreshness({ reader, vault, oracle, assets, nowS
     const minUpdated = nowSec > maxStaleness ? nowSec - maxStaleness : 0;
     let fresh = 0;
     const stale = [];
+    const unreadable = [];
     for (const source of sources) {
       const res = await reader.tryRead(source, PRICE_SOURCE_VIEWS, 'latestPrice', []);
+      // THREE BUCKETS, NOT TWO. A source the canary could not reach is neither fresh nor stale.
+      // Counting it stale (what this line did before) walks `fresh` down until `margin < 0` and
+      // pages "oracle breaker TRIPPED … NAV and exits are frozen" off a rate limit; counting it
+      // fresh would fail open. The aggregator's own on-chain try/catch is not the precedent it
+      // was cited as here — that catches a REVERT, and no on-chain try/catch can catch a 429.
+      if (!res.ok && res.kind === 'transport') {
+        unreadable.push({ source, reason: res.error ?? 'unreadable' });
+        continue;
+      }
       // A reverting source is not fresh. Same rule the aggregator applies in its try/catch.
       if (!res.ok) { stale.push({ source, reason: 'reverted' }); continue; }
       const [priceWad, updatedAt] = normalizePrice(res.value);
@@ -85,9 +95,23 @@ export async function checkOracleFreshness({ reader, vault, oracle, assets, nowS
     const detail = {
       vault, asset, oracle, freshSources: fresh, totalSources: sources.length,
       quorum, margin, maxStalenessSec: maxStaleness, staleSources: stale,
+      unreadableSources: unreadable,
     };
 
-    if (margin < 0) {
+    // With `u` sources unreadable, the true fresh count lies in [fresh, fresh + u]. Both verdicts
+    // below are still SOUND on a bound — tripped is decided on the best case, a healthy margin on
+    // the worst — so an unreadable source never invents a freeze and never hides one. Only when
+    // the quorum sits inside the interval is there nothing honest to say, and that is the one
+    // case that goes blind.
+    if (unreadable.length > 0 && fresh + unreadable.length >= quorum && margin <= minMargin) {
+      out.push(detectorBroken({
+        signal: SIGNAL, vault, key: asset,
+        message: `ORACLE FRESHNESS DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${unreadable.length}/${sources.length} price sources could not be read (${unreadable[0].reason}), so the freshness margin cannot be stated — ${fresh} sources are confirmed fresh against quorum ${quorum}, and the unreadable ones decide it either way. This asset is UNMONITORED for the staleness freeze this sweep; nothing here says the breaker tripped`,
+        measured: `${fresh} confirmed fresh, ${unreadable.length} unreadable`,
+        threshold: `>= ${quorum} (quorum)`,
+        detail,
+      }));
+    } else if (margin < 0) {
       out.push(alert({
         signal: SIGNAL, vault, key: asset,
         message: `oracle breaker TRIPPED for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${fresh}/${sources.length} sources fresh, quorum ${quorum} — priceWad reverts StaleOracle, NAV and exits are frozen`,

--- a/packages/canary/src/signals/oracle-health.mjs
+++ b/packages/canary/src/signals/oracle-health.mjs
@@ -166,13 +166,22 @@ export async function checkOracleSignals(ctx) {
   const legacy = await reader.tryRead(oracle, ORACLE_VIEWS, 'assetConfig', [assets[0]]);
   if (legacy.ok) return checkOracleFreshness(ctx);
 
+  // Both probes failed, but WHY decides what may be said. Only a confirmed revert from both is
+  // evidence about the oracle's ABI; if either failed in transit the canary never got an answer to
+  // report, and claiming the contract "answers neither" would be a finding invented by a network.
+  const unreachable = seq.kind === 'transport' || legacy.kind === 'transport';
   return [detectorBroken({
     signal: SIGNAL, vault, key: 'flavor',
-    message: `ORACLE DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig(), so NO oracle check is running for this vault. It is UNMONITORED for the staleness freeze, not healthy`,
+    message: unreachable
+      ? `ORACLE DETECTOR BLIND on vault ${shortAddr(vault)}: neither probe of the oracle at ${shortAddr(oracle)} could be read (sequencerUptimeFeed: ${seq.error ?? 'no error text'}; assetConfig: ${legacy.error ?? 'no error text'}), so which oracle is deployed is UNKNOWN and no oracle check ran. The vault is UNMONITORED for the staleness freeze — this says nothing about the oracle's ABI`
+      : `ORACLE DETECTOR BLIND on vault ${shortAddr(vault)}: the oracle at ${shortAddr(oracle)} answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig(), so NO oracle check is running for this vault. It is UNMONITORED for the staleness freeze, not healthy`,
     detail: {
       vault, oracle,
       chainlinkProbeError: seq.error ?? null,
       legacyProbeError: legacy.error ?? null,
+      chainlinkProbeKind: seq.kind ?? null,
+      legacyProbeKind: legacy.kind ?? null,
+      unreachable,
     },
   })];
 }
@@ -247,9 +256,23 @@ async function sequencerLeg({ reader, vault, oracle, sequencerFeed, nowSec, grac
   }
 
   const rd = await reader.tryRead(sequencerFeed, AGGREGATOR_V3_VIEWS, 'latestRoundData', []);
+  if (!rd.ok && rd.kind === 'transport') {
+    // The canary could not reach the feed. That is a statement about this process's network, not
+    // about the sequencer gate, and the alert below would have claimed a vault-wide freeze from it.
+    return {
+      cause: null,
+      result: detectorBroken({
+        ...base,
+        message: `SEQUENCER GATE DETECTOR BLIND for vault ${shortAddr(vault)}: latestRoundData() on the uptime feed ${shortAddr(sequencerFeed)} could not be read (${rd.error ?? 'no error text'}) — no revert was observed, so nothing is known about the sequencer gate this sweep. The vault is UNMONITORED for it, and this is NOT evidence of a freeze`,
+        detail: { vault, oracle, sequencerUptimeFeed: sequencerFeed, error: rd.error ?? null, kind: 'transport' },
+      }),
+    };
+  }
   if (!rd.ok) {
-    // The contract try/catches this and reverts StaleOracle, so it is a live freeze, not a blind
-    // detector: we can see the cause perfectly well.
+    // A CONFIRMED revert. The contract try/catches this and reverts StaleOracle, so it is a live
+    // freeze, not a blind detector: we can see the cause perfectly well. (A transport failure
+    // cannot reach here — it is handled above — because an on-chain try/catch catches a revert,
+    // and no on-chain try/catch can catch a 429.)
     return {
       cause: 'the sequencer uptime feed itself reverts',
       result: alert({
@@ -327,11 +350,15 @@ async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequence
   if (!cfgRead.ok) {
     // `feedOf` is a public mapping getter: it answers for EVERY address, including unlisted ones.
     // A revert here means the contract is not the ChainlinkOracle the flavor probe said it was, so
-    // this detector is blind rather than looking at a broken vault.
+    // this detector is blind rather than looking at a broken vault. A transport failure lands in
+    // the same blind channel but must not be described as a revert — the call never arrived.
+    const reverted = cfgRead.kind === 'revert';
     return detectorBroken({
       ...base,
-      message: `ORACLE DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} reverts (${cfgRead.error}) even though the oracle answered as a ChainlinkOracle. This asset is UNMONITORED for the staleness freeze, not healthy`,
-      detail: { vault, oracle, asset, error: cfgRead.error ?? null },
+      message: reverted
+        ? `ORACLE DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} reverts (${cfgRead.error}) even though the oracle answered as a ChainlinkOracle. This asset is UNMONITORED for the staleness freeze, not healthy`
+        : `ORACLE DETECTOR BLIND for asset ${shortAddr(asset)} on vault ${shortAddr(vault)}: feedOf() on ${shortAddr(oracle)} could not be read (${cfgRead.error}) — the call did not reach the chain, so no revert was observed. This asset is UNMONITORED for the staleness freeze this sweep, not healthy`,
+      detail: { vault, oracle, asset, error: cfgRead.error ?? null, kind: cfgRead.kind ?? null },
     });
   }
 
@@ -360,9 +387,23 @@ async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequence
     minPriceWad: cfg.minPriceWad.toString(), maxPriceWad: cfg.maxPriceWad.toString(),
     bandEnabled: cfg.maxPriceWad !== 0n,
     priceWad: price.ok ? String(price.value) : null,
-    priceWadReverts: !price.ok,
+    // Only a CONFIRMED revert may set this. It used to be `!price.ok`, which reported a rate limit
+    // as the contract refusing to price the asset.
+    priceWadReverts: !price.ok && price.kind === 'revert',
+    priceWadUnreadable: !price.ok && price.kind === 'transport',
     ...facts.detail,
   };
+
+  // GROUND TRUTH WAS NOT REACHED. The whole leg below rests on `priceWad` having actually
+  // answered, so a call that never got to the chain yields no verdict at all — it must not become
+  // "ORACLE FROZEN … NAV, deposits, rebalances and EXITS are all frozen".
+  if (!price.ok && price.kind === 'transport') {
+    return detectorBroken({
+      ...base,
+      message: `ORACLE DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: priceWad() on ${shortAddr(oracle)} could not be read (${price.error ?? 'no error text'}) — no revert was observed, so whether this asset is frozen is UNKNOWN this sweep. It is unmonitored, not healthy, and nothing here says the breaker tripped`,
+      detail: { ...detail, kind: 'transport' },
+    });
+  }
 
   if (!price.ok) {
     const isStaleOracle = typeof price.revertData === 'string'
@@ -426,6 +467,16 @@ async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequence
 function describe({ cfg, round, nowSec }) {
   if (isZero(cfg.feed)) {
     return { cause: 'the asset is not listed on this oracle (feedOf returns address(0))', ageSec: null, detail: { listed: false } };
+  }
+  if (!round.ok && round.kind === 'transport') {
+    // The feed was not reached, so it is not known to be dead. Returning no cause is what keeps
+    // this honest: the caller falls back to its "the attribution is missing" wording rather than
+    // naming a deprecated feed the canary never actually asked.
+    return {
+      cause: null,
+      ageSec: null,
+      detail: { listed: true, feedReverts: false, feedUnreadable: true, feedError: round.error ?? null },
+    };
   }
   if (!round.ok) {
     return {

--- a/packages/canary/src/signals/share-conservation.mjs
+++ b/packages/canary/src/signals/share-conservation.mjs
@@ -43,6 +43,9 @@ export async function checkShareConservation({ reader, vault, projectedTotalShar
 
   if (!res.ok && pinned) {
     // Almost always "missing trie node" / "state unavailable" on a pruned node, not a real fault.
+    // DELIBERATELY NOT GATED ON `kind`. Those strings classify as 'transport' (call-error.mjs is
+    // explicit that the word means "not a confirmed revert", not "the node was unreachable"), so
+    // a `kind !== 'transport'` guard here would disable the archive fallback this retry exists for.
     pinned = false;
     res = await reader.tryRead(vault, VAULT_VIEWS, 'totalShares', []);
   }
@@ -50,7 +53,7 @@ export async function checkShareConservation({ reader, vault, projectedTotalShar
     return [skipped({
       signal: SIGNAL, vault,
       message: `share conservation skipped on vault ${shortAddr(vault)}: totalShares() is unreadable: ${res.error}`,
-      detail: { vault },
+      detail: { vault, kind: res.kind ?? null },
     })];
   }
 

--- a/packages/canary/test/exit-liveness.test.mjs
+++ b/packages/canary/test/exit-liveness.test.mjs
@@ -11,7 +11,10 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createPublicClient, http as httpTransport } from 'viem';
 import { checkExitLiveness, pickProbeMember, encodeRequestExit } from '../src/signals/exit-liveness.mjs';
+import { createChainReader } from '../src/reader.mjs';
 import { mockReader, VAULT, MEMBER, CREATOR } from './helpers.mjs';
 
 const REENTRANCY = '0xab143c06';
@@ -139,4 +142,59 @@ test('probe amount is clamped to the member balance so it never self-inflicts In
   });
   const call = reader.calls.find((c) => c.kind === 'staticCall');
   assert.equal(BigInt(`0x${call.data.slice(10)}`), 1n);
+});
+
+// ── transport is not a verdict ───────────────────────────────────────────────
+//
+// These two run the REAL adapter over a REAL viem client against a local node, because the defect
+// they pin lives in the wiring and not in any one function: `ok:false` alone cannot tell a 429
+// from a revert, and every stub in this file that hands the signal a pre-made `{ok:false}` would
+// keep passing while the deployed canary paged on a rate limit.
+
+/** A node that answers every JSON-RPC request the same way. */
+async function rpcServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return {
+    url: `http://127.0.0.1:${/** @type {any} */ (server.address()).port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+/** The real reader over a real viem client — nothing stubbed between the socket and the signal. */
+const liveReader = (url) => createChainReader({
+  client: createPublicClient({ transport: httpTransport(url, { retryCount: 0 }) }),
+});
+
+test('WIRING: a real HTTP 429 reaches the sentinel as BLIND, never as the H-1 breach', async () => {
+  const node = await rpcServer((_req, res) => { res.writeHead(429); res.end('Too Many Requests'); });
+  try {
+    const [r] = await checkExitLiveness({
+      reader: liveReader(node.url), vault: VAULT, shareBook: book, creator: CREATOR,
+    });
+    assert.equal(r.status, 'skipped', 'a rate limit is not a verdict about requestExit');
+    assert.doesNotMatch(r.message, /EXIT LIVENESS BROKEN/);
+    assert.match(r.message, /BLIND/);
+    // Visible, not merely quiet: detectorBroken is re-asserted on a backoff by transitions.mjs,
+    // where a plain `skipped` would be reported once and then fall silent.
+    assert.equal(r.detail.detectorBroken, true);
+    assert.equal(r.detail.kind, 'transport');
+    assert.equal(r.detail.revertData, null,
+      'viem quotes the request in a transport error, so the scrape recovers this probe\'s own calldata');
+  } finally { await node.close(); }
+});
+
+test('WIRING: a genuine revert over the same live path still ALERTS — the sentinel was not disabled', async () => {
+  const node = await rpcServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: 3, message: 'execution reverted', data: REENTRANCY } }));
+  });
+  try {
+    const [r] = await checkExitLiveness({
+      reader: liveReader(node.url), vault: VAULT, shareBook: book, creator: CREATOR,
+    });
+    assert.equal(r.status, 'alert');
+    assert.match(r.message, /EXIT LIVENESS BROKEN/);
+    assert.equal(r.detail.revertName, 'Reentrancy');
+  } finally { await node.close(); }
 });

--- a/packages/canary/test/exit-liveness.test.mjs
+++ b/packages/canary/test/exit-liveness.test.mjs
@@ -198,3 +198,28 @@ test('WIRING: a genuine revert over the same live path still ALERTS — the sent
     assert.equal(r.detail.revertName, 'Reentrancy');
   } finally { await node.close(); }
 });
+
+test('WIRING: a genuine EMPTY-returndata revert over the live path ALERTS as EMPTY returndata, not as the probe member\'s own address', async () => {
+  // The H-1 signature itself: the node says code 3 and returns no `data`. viem's message then
+  // quotes the request under "Raw Call Arguments" with `from` first, and the reader's scrape used
+  // to read that back as returndata — so this exact line said "unrecognized revert 0x66666666",
+  // MEMBER's first four bytes. The verdict was already right (both branches ALERT); what this pins
+  // is the diagnosis, because docs/CANARY.md §3(d) names empty returndata as the thing an
+  // operator is meant to recognise.
+  const node = await rpcServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: 3, message: 'execution reverted' } }));
+  });
+  try {
+    const [r] = await checkExitLiveness({
+      reader: liveReader(node.url), vault: VAULT, shareBook: book, creator: CREATOR,
+    });
+    assert.equal(r.status, 'alert');
+    assert.match(r.message, /EXIT LIVENESS BROKEN/);
+    assert.match(r.message, /EMPTY returndata \(out-of-gas or returndata bomb\)/);
+    assert.doesNotMatch(r.message, /unrecognized revert/);
+    assert.doesNotMatch(r.message, new RegExp(MEMBER.slice(0, 10)), 'the probe member\'s address is the request, not the revert');
+    assert.equal(r.detail.revertName, 'EMPTY returndata (out-of-gas or returndata bomb)');
+    assert.equal(r.detail.revertData, null);
+  } finally { await node.close(); }
+});

--- a/packages/canary/test/feed-identity.test.mjs
+++ b/packages/canary/test/feed-identity.test.mjs
@@ -376,3 +376,40 @@ test('applyIdentityObservations ignores results from every other signal', () => 
   const foreign = [{ id: 'oracle-freshness|v|a', signal: 'oracle-freshness', detail: { observedIdentity: { aggregator: AGGREGATOR } } }];
   assert.deepEqual(applyIdentityObservations({}, foreign), {});
 });
+
+// ── transport is not a verdict ───────────────────────────────────────────────
+
+const UNREACHABLE = () => ({ transport: 'HTTP request failed.' });
+
+test('a 429 on the FIRST flavor probe must not be read as a confirmed retired aggregator', async () => {
+  // The only branch in this package that returns SILENCE. Reached when `sequencerUptimeFeed()`
+  // merely failed in transit while `assetConfig()` happened to answer, it concluded "retired
+  // OracleAggregator, no feed identity to watch" and emitted nothing at all — a signal switched
+  // off by one unlucky request. "Confirmed" now means a revert, and only a revert.
+  const reader = readerFor({
+    overrides: { [ORACLE]: { sequencerUptimeFeed: UNREACHABLE, assetConfig: () => [[FEED], 3600, 1] } },
+  });
+  const results = await run(reader);
+  assert.notEqual(results.length, 0, 'a transport failure must never silence this signal');
+  assert.equal(results[0].detail.detectorBroken, true);
+  assert.match(results[0].message, /could not be probed/);
+  assert.doesNotMatch(results[0].message, /answers neither/);
+});
+
+test('a genuine revert on the first probe with a live assetConfig IS a retired aggregator, and stays silent', async () => {
+  const reader = readerFor({
+    overrides: {
+      [ORACLE]: { sequencerUptimeFeed: () => ({ revert: '0xdeadbeef' }), assetConfig: () => [[FEED], 3600, 1] },
+    },
+  });
+  assert.deepEqual(await run(reader), [], 'the retired-aggregator path is unchanged for a real revert');
+});
+
+test('an unreadable feedOf() says the call did not arrive, not that the oracle reverted', async () => {
+  const reader = readerFor({ overrides: { [ORACLE]: { feedOf: UNREACHABLE } } });
+  const [r] = await run(reader);
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.detail.kind, 'transport');
+  assert.match(r.message, /could not be read/);
+  assert.doesNotMatch(r.message, /reverts \(/);
+});

--- a/packages/canary/test/helpers.mjs
+++ b/packages/canary/test/helpers.mjs
@@ -3,10 +3,15 @@
  * Mocked chain plumbing shared by the canary tests. NO LIVE RPC ANYWHERE — every test in this
  * package injects one of these readers, which is exactly the interface reader.mjs exposes.
  *
- * A contract is declared as `{ address: { fnName: value | fn(args) | {revert: '0xselector…'} } }`.
+ * A contract is declared as
+ * `{ address: { fnName: value | fn(args) | {revert: '0xselector…'} | {transport: 'message'} } }`.
  * Returning `{revert}` makes tryRead/read behave the way viem does on a revert, carrying the
- * returndata, so the signals' revert-classification paths are exercised for real.
+ * returndata, so the signals' revert-classification paths are exercised for real. `{transport}`
+ * is the counterpart for a read that never reached the chain — no returndata, `kind: 'transport'`,
+ * and no evidence about the contract.
  */
+
+import { classifyCallError } from '../src/call-error.mjs';
 
 export const A = (c) => `0x${String(c).repeat(40).slice(0, 40)}`;
 
@@ -102,6 +107,12 @@ export function mockReader({ contracts, logs = [], head = 1000, nowSec = 1_700_0
     const entry = c[fn];
     const value = typeof entry === 'function' ? entry(...args) : entry;
     if (value && typeof value === 'object' && 'revert' in value) throw new MockRevert(value.revert);
+    // `{transport}` is the OTHER way a read fails, and the reason `kind` exists: the call never
+    // reached the chain, so there is no returndata and nothing was learned about the contract.
+    // Default wording is what viem 2.x produces for an HTTP 429.
+    if (value && typeof value === 'object' && 'transport' in value) {
+      throw new Error(typeof value.transport === 'string' ? value.transport : 'HTTP request failed.');
+    }
     return value;
   }
 
@@ -112,11 +123,17 @@ export function mockReader({ contracts, logs = [], head = 1000, nowSec = 1_700_0
       calls.push({ kind: 'read', address: lc(address), fn, args, blockNumber: opts.blockNumber ?? null });
       return resolve(address, fn, args, opts);
     },
+    // Mirrors reader.mjs's tryRead exactly, INCLUDING the `kind` tag and the rule that a transport
+    // failure carries no returndata. Using the real classifier rather than hardcoding 'revert' is
+    // what keeps the mock honest: `MockRevert` says "execution reverted" and classifies 'revert',
+    // while the `missing trie node` thrown for an unavailable archive height classifies
+    // 'transport' — which is the shape share-conservation's unpinned retry actually sees.
     async tryRead(address, _abi, fn, args = [], opts = {}) {
       try {
         return { ok: true, value: await reader.read(address, _abi, fn, args, opts) };
       } catch (err) {
-        return { ok: false, revertData: err.data ?? null, error: err.message };
+        const kind = classifyCallError(err.message);
+        return { ok: false, revertData: kind === 'revert' ? err.data ?? null : null, error: err.message, kind };
       }
     },
     async getLogs({ address, event, args, fromBlock, toBlock }) {

--- a/packages/canary/test/oracle-freshness.test.mjs
+++ b/packages/canary/test/oracle-freshness.test.mjs
@@ -150,3 +150,40 @@ test('DEGRADED, not OK, when the oracle config itself is unreadable', async () =
   assert.equal(r.status, 'skipped');
   assert.notEqual(r.status, 'ok');
 });
+
+// ── transport is not a verdict ───────────────────────────────────────────────
+
+const UNREACHABLE = { latestPrice: { transport: 'HTTP request failed.' } };
+
+test('a source the canary could not READ is neither fresh nor stale — a 429 must not trip the breaker', async () => {
+  // Two unreadable sources against quorum 2 used to count as two STALE sources, walking the margin
+  // to -1 and paging "oracle breaker TRIPPED … NAV and exits are frozen" off a rate limit.
+  const [r] = await run(withSources(FRESH, UNREACHABLE, UNREACHABLE));
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true, 'blindness must stay visible, not collapse into ok');
+  assert.match(r.message, /BLIND/);
+  assert.doesNotMatch(r.message, /TRIPPED/);
+  assert.equal(r.detail.unreadableSources.length, 2);
+  assert.equal(r.detail.staleSources.length, 0, 'unreadable is its own bucket, not a stale source');
+});
+
+test('an unreadable source cannot HIDE a freeze either: quorum out of reach in the best case still ALERTS', async () => {
+  // quorum 3, one fresh, one unreadable, one genuinely stale: even counting the unreadable one as
+  // fresh leaves 2 < 3, so the verdict is sound on the best case and must still be given.
+  const [r] = await run(withSources(FRESH, UNREACHABLE, STALE, { quorum: 3 }));
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /TRIPPED/);
+});
+
+test('a healthy margin is still reported when it holds on the WORST case, unreadable sources and all', async () => {
+  // quorum 1, two fresh, one unreadable: the margin is at least 1 whatever the unreadable one is.
+  const [r] = await run(withSources(FRESH, FRESH, UNREACHABLE, { quorum: 1 }));
+  assert.equal(r.status, 'ok');
+});
+
+test('a source that genuinely REVERTS is still counted stale — the fix did not blind the detector', async () => {
+  const [r] = await run(withSources(FRESH, BROKEN, BROKEN));
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /TRIPPED/);
+  assert.equal(r.detail.staleSources.length, 2);
+});

--- a/packages/canary/test/oracle-health.test.mjs
+++ b/packages/canary/test/oracle-health.test.mjs
@@ -442,3 +442,54 @@ test('when the sequencer AND the heartbeat are both blown, the SEQUENCER is name
   assert.equal(r.detail.staleBySec, 6000);
   assert.equal(forSequencer(results).status, 'alert');
 });
+
+// ── transport is not a verdict ───────────────────────────────────────────────
+
+const UNREACHABLE = () => ({ transport: 'HTTP request failed.' });
+
+test('an unreadable priceWad() is BLIND, not "ORACLE FROZEN" — a 429 must not claim exits are frozen', async () => {
+  const reader = readerFor({ overrides: { [ORACLE]: { priceWad: UNREACHABLE } } });
+  const r = forAsset(await run(reader));
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true, 'the detector is blind, and blindness must stay visible');
+  assert.match(r.message, /BLIND/);
+  assert.doesNotMatch(r.message, /ORACLE FROZEN/);
+  assert.equal(r.detail.priceWadReverts, false, 'only a confirmed revert may set this');
+  assert.equal(r.detail.priceWadUnreadable, true);
+});
+
+test('a genuine priceWad revert still ALERTS as ORACLE FROZEN — the fix did not disable the check', async () => {
+  const r = forAsset(await run(readerFor({ priceWadReverts: true })));
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /ORACLE FROZEN/);
+  assert.equal(r.detail.priceWadReverts, true);
+});
+
+test('an unreadable sequencer uptime feed does not claim the vault is frozen vault-wide', async () => {
+  const reader = readerFor({
+    sequencerUptimeFeed: SEQ_FEED,
+    overrides: { [SEQ_FEED]: { latestRoundData: UNREACHABLE } },
+  });
+  const r = forSequencer(await run(reader));
+  assert.equal(r.status, 'skipped');
+  assert.equal(r.detail.detectorBroken, true);
+  assert.match(r.message, /BLIND/);
+  assert.doesNotMatch(r.message, /frozen/);
+});
+
+test('a sequencer uptime feed that genuinely reverts still ALERTS — the contract really does freeze on it', async () => {
+  const reader = readerFor({ sequencerUptimeFeed: SEQ_FEED, sequencerReverts: true });
+  const r = forSequencer(await run(reader));
+  assert.equal(r.status, 'alert');
+  assert.match(r.message, /UNREADABLE/);
+});
+
+test('when both flavor probes fail in transit, the line does not assert what ABI the oracle has', async () => {
+  const reader = readerFor({ overrides: { [ORACLE]: { sequencerUptimeFeed: UNREACHABLE, assetConfig: UNREACHABLE } } });
+  const [r] = await run(reader);
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.detail.unreachable, true);
+  assert.match(r.message, /neither probe of the oracle .* could be read/);
+  assert.match(r.message, /says nothing about the oracle's ABI/);
+  assert.doesNotMatch(r.message, /answers neither/);
+});

--- a/packages/canary/test/reader.test.mjs
+++ b/packages/canary/test/reader.test.mjs
@@ -11,7 +11,8 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractRevertData, createChainReader } from '../src/reader.mjs';
+import { extractRevertData, structuredRevertData, createChainReader } from '../src/reader.mjs';
+import { classifyCallError } from '../src/call-error.mjs';
 
 test('pulls returndata off a flat error', () => {
   assert.equal(extractRevertData({ data: '0xAB143C06' }), '0xab143c06');
@@ -91,4 +92,72 @@ test('staticCall passes no explicit gas — a low cap would manufacture failures
   const reader = createChainReader({ client: { call: async (args) => { seen.push(args); return { data: '0x' }; } } });
   await reader.staticCall({ to: '0x1', from: '0x2', data: '0x3' });
   assert.equal('gas' in seen[0], false, 'VaultCore gas-caps its own module calls; the probe must not add a second cap');
+});
+
+// ── `kind`: was a failed read evidence about the contract, or did it never get there? ──
+
+test('classifyCallError: a revert whose text also carries a transport-ish token is still a revert', () => {
+  assert.equal(classifyCallError('execution reverted, data: "0x429" timeout'), 'revert');
+  assert.equal(classifyCallError('reverted: DeadlineTimeout()'), 'revert');
+  // The wording viem 2.x actually produces for a revert with no decodable reason.
+  assert.equal(classifyCallError('Execution reverted for an unknown reason.'), 'revert');
+});
+
+test('classifyCallError: transport wording is never a contract verdict, and neither is an unknown string', () => {
+  // The wordings measured out of viem 2.x for an HTTP 429 and a JSON-RPC rate limit respectively.
+  assert.equal(classifyCallError('HTTP request failed.'), 'transport');
+  assert.equal(classifyCallError('Request exceeds defined limit.'), 'transport');
+  assert.equal(classifyCallError('ECONNRESET'), 'transport');
+  // Fail-safe: an unrecognised failure is missing evidence, not a finding.
+  assert.equal(classifyCallError('something nobody has seen before'), 'transport');
+});
+
+test('a transport failure carries kind:transport and NO returndata — the scrape would return our OWN calldata', async () => {
+  // Measured shape: viem quotes the failing request back in the message, so `extractRevertData`'s
+  // hex fallback recovers the calldata the canary just sent. Its first four bytes then read as an
+  // unrecognized revert selector, which is how a 429 used to page "EXIT LIVENESS BROKEN".
+  const calldata = `0x721c6513${'0'.repeat(63)}1`;
+  const client = {
+    call: async () => {
+      const e = new Error(`HTTP request failed.\n\nRaw Call Arguments:\n  data: ${calldata}`);
+      // @ts-ignore — viem sets this
+      e.shortMessage = 'HTTP request failed.';
+      throw e;
+    },
+  };
+  const res = await createChainReader({ client }).staticCall({ to: '0x1', from: '0x2', data: calldata });
+  assert.equal(res.ok, false);
+  assert.equal(res.kind, 'transport');
+  assert.equal(res.data, null, 'a call that never reached the chain produced no returndata');
+});
+
+test('tryRead tags a transport failure the same way, and drops the scraped returndata with it', async () => {
+  const client = {
+    readContract: async () => {
+      const e = new Error('The request took too long to respond. Raw Call Arguments: data: 0xa2671f4b');
+      // @ts-ignore — viem sets this
+      e.shortMessage = 'The request took too long to respond.';
+      throw e;
+    },
+  };
+  const res = await createChainReader({ client }).tryRead('0x1', [], 'navWad', []);
+  assert.equal(res.kind, 'transport');
+  assert.equal(res.revertData, null,
+    'scraping StaleOracle out of a timeout would attribute a network fault to the oracle breaker');
+});
+
+test('structured returndata outranks the wording: a revert no pattern recognises is still a revert', () => {
+  // `structuredRevertData` only answers for returndata viem handed over in a FIELD, which cannot
+  // exist unless the EVM executed and reverted. It is what keeps an odd-worded provider's genuine
+  // revert out of the blind channel.
+  assert.equal(structuredRevertData({ data: '0xab143c06' }), '0xab143c06');
+  assert.equal(structuredRevertData({ message: 'reverted 0xab143c06' }), null,
+    'hex found in prose is not structured returndata and must not decide kind');
+});
+
+test('a revert reported only in a field, with wording that matches nothing, is classified revert', async () => {
+  const client = { call: async () => { throw { data: '0xab143c06', shortMessage: 'provider said something new' }; } };
+  const res = await createChainReader({ client }).staticCall({ to: '0x1', from: '0x2', data: '0x3' });
+  assert.equal(res.kind, 'revert');
+  assert.equal(res.data, '0xab143c06');
 });

--- a/packages/canary/test/reader.test.mjs
+++ b/packages/canary/test/reader.test.mjs
@@ -5,12 +5,16 @@
  * 1. extractRevertData — the whole exit-liveness classification rests on it. viem nests the raw
  *    returndata several `cause` levels deep and the shape differs by transport, so a miss here
  *    would turn a real H-1 fault into "no data". That still ALERTS (empty returndata is a fault),
- *    so the failure is loud rather than silent — but it would lose the diagnosis, and these cases
- *    pin the shapes viem actually produces.
+ *    so the failure is loud rather than silent — but it would lose the diagnosis. The reverse
+ *    miss is the one that was actually shipped: hex that IS in viem's text but is the canary's
+ *    own request, reported as returndata. The LIVE block at the bottom runs the real adapter over
+ *    a real viem client against a local node, because only the real client writes that text.
  * 2. The read-only guarantee: the reader exposes no way to send a transaction.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createPublicClient, http as httpTransport } from 'viem';
 import { extractRevertData, structuredRevertData, createChainReader } from '../src/reader.mjs';
 import { classifyCallError } from '../src/call-error.mjs';
 
@@ -27,11 +31,15 @@ test('handles the nested { data: { data } } shape', () => {
   assert.equal(extractRevertData({ cause: { data: { data: '0x08c379a0' } } }), '0x08c379a0');
 });
 
-test('falls back to scraping the message when no structured field carries it', () => {
-  assert.equal(
-    extractRevertData({ message: 'execution reverted, data: 0xab143c06 (Reentrancy)' }),
-    '0xab143c06',
-  );
+test('scrapes returndata out of the node\'s own words (`details`) only — never out of viem\'s message', () => {
+  // A node that writes the returndata into its JSON-RPC error message reaches us as `details`,
+  // which viem carries up the cause chain unchanged and never quotes the request in.
+  assert.equal(extractRevertData({ details: 'execution reverted: 0xab143c06' }), '0xab143c06');
+  // `message` and `shortMessage` are viem's composition. For a failed call the message quotes the
+  // request the canary sent (proven against the real client in the LIVE block below), so hex found
+  // there is not returndata — even when the prose around it looks like a revert.
+  assert.equal(extractRevertData({ message: 'execution reverted, data: 0xab143c06 (Reentrancy)' }), null);
+  assert.equal(extractRevertData({ shortMessage: 'reverted 0xab143c06' }), null);
 });
 
 test('returns null when there is genuinely no returndata — callers treat that as a FAULT', () => {
@@ -160,4 +168,121 @@ test('a revert reported only in a field, with wording that matches nothing, is c
   const res = await createChainReader({ client }).staticCall({ to: '0x1', from: '0x2', data: '0x3' });
   assert.equal(res.kind, 'revert');
   assert.equal(res.data, '0xab143c06');
+});
+
+// ── LIVE: the real adapter over a real viem client against a local node ──────
+//
+// The defect these pin lives in viem's error TEXT, so no stub that hands the reader a pre-shaped
+// error can see it: viem quotes the request it just sent in the message of every failed call, and
+// a scrape over that message returned the canary's own addresses whenever the node returned
+// nothing. Only the real client writes that text, so only the real client can prove it is ignored.
+
+const TO = `0x${'a1'.repeat(18)}cafe`;
+const FROM = `0x${'22'.repeat(20)}`;
+const ORACLE = `0x${'11'.repeat(20)}`;
+const ASSET = `0x${'33'.repeat(20)}`;
+const REQUEST_EXIT_1 = `0x721c6513${'0'.repeat(63)}1`;
+const PRICE_WAD_ABI = [{
+  type: 'function', name: 'priceWad', stateMutability: 'view',
+  inputs: [{ name: 'asset', type: 'address' }], outputs: [{ type: 'uint256' }],
+}];
+const EMPTY_REVERT = { code: 3, message: 'execution reverted' };
+
+/** A node that answers every JSON-RPC request with `error`, or with an HTTP 429 when it is null. */
+async function rpcNode(error) {
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (c) => { raw += c; });
+    req.on('end', () => {
+      if (!error) { res.writeHead(429); res.end('Too Many Requests'); return; }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: JSON.parse(raw).id ?? 1, error }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `http://127.0.0.1:${/** @type {any} */ (server.address()).port}`;
+  return {
+    client: createPublicClient({ transport: httpTransport(url, { retryCount: 0 }) }),
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+/** Run a call that is expected to throw and hand back what it threw. */
+const caught = (p) => p.then(() => null, (e) => e);
+
+test('LIVE staticCall: an EMPTY-returndata revert is kind:revert with data:null — not the probe\'s own from address', async () => {
+  const node = await rpcNode(EMPTY_REVERT);
+  try {
+    // The vector, proven present before it is proven bypassed: viem's message quotes the request
+    // with `from` first, while the node's own words carry no hex at all.
+    const raw = await caught(node.client.call({ to: TO, account: FROM, data: REQUEST_EXIT_1 }));
+    assert.ok(raw, 'the node answered code 3, so call() must throw');
+    assert.ok(raw.message.includes(FROM), 'viem quotes the from address in message — the scrape used to read it from here');
+    assert.equal(raw.details, 'execution reverted');
+    assert.equal(structuredRevertData(raw), null, 'no field carries returndata: the node sent none');
+    assert.equal(extractRevertData(raw), null, 'hex in viem\'s message is the request, not returndata');
+
+    const res = await createChainReader({ client: node.client }).staticCall({ to: TO, from: FROM, data: REQUEST_EXIT_1 });
+    assert.equal(res.ok, false);
+    assert.equal(res.kind, 'revert');
+    assert.equal(res.data, null, `the node returned no returndata; this used to be ${FROM}`);
+  } finally { await node.close(); }
+});
+
+test('LIVE tryRead: the same EMPTY-returndata revert is kind:revert with revertData:null — readContract\'s wording alone reads as transport', async () => {
+  const node = await rpcNode(EMPTY_REVERT);
+  try {
+    const raw = await caught(node.client.readContract({ address: ORACLE, abi: PRICE_WAD_ABI, functionName: 'priceWad', args: [ASSET] }));
+    assert.equal(raw.shortMessage, 'The contract function "priceWad" reverted.');
+    // Why `details` is consulted: this wording matches neither pattern in call-error.mjs, so on
+    // shortMessage alone a genuine revert was filed 'transport' — missing evidence, not a revert.
+    assert.equal(classifyCallError(raw.shortMessage), 'transport');
+    assert.equal(raw.details, 'execution reverted');
+    assert.ok(raw.message.includes(ORACLE), 'readContract quotes the contract address under "Contract Call"');
+    assert.equal(extractRevertData(raw), null, 'the contract address in message is not returndata');
+
+    const res = await createChainReader({ client: node.client }).tryRead(ORACLE, PRICE_WAD_ABI, 'priceWad', [ASSET]);
+    assert.equal(res.ok, false);
+    assert.equal(res.kind, 'revert', 'the node said "execution reverted": that is evidence about the contract, not a blind detector');
+    assert.equal(res.revertData, null);
+  } finally { await node.close(); }
+});
+
+test('LIVE tryRead: a revert WITH returndata still surfaces it, structured, on the readContract chain', async () => {
+  const node = await rpcNode({ code: 3, message: 'execution reverted', data: '0xa2671f4b' });
+  try {
+    const res = await createChainReader({ client: node.client }).tryRead(ORACLE, PRICE_WAD_ABI, 'priceWad', [ASSET]);
+    assert.equal(res.kind, 'revert');
+    assert.equal(res.revertData, '0xa2671f4b', 'viem parks undecodable returndata in ContractFunctionRevertedError.raw');
+  } finally { await node.close(); }
+});
+
+test('LIVE tryRead: an HTTP 429 is still kind:transport with no returndata — consulting details did not widen revert', async () => {
+  const node = await rpcNode(null);
+  try {
+    const res = await createChainReader({ client: node.client }).tryRead(ORACLE, PRICE_WAD_ABI, 'priceWad', [ASSET]);
+    assert.equal(res.ok, false);
+    assert.equal(res.kind, 'transport');
+    assert.equal(res.revertData, null);
+  } finally { await node.close(); }
+});
+
+test('LIVE: a pruned node\'s "missing trie node <hash>" is transport, and the hash in its own words is NOT returndata', async () => {
+  // `details` here IS the node's own text and it carries 64 hex characters, so the narrowed scrape
+  // still finds them. The reader's `kind === 'transport'` nulling is what keeps that hash out of
+  // `revertData` — this is why the nulling stays load-bearing after the scrape was narrowed.
+  const hash = `0x${'ab'.repeat(32)}`;
+  const node = await rpcNode({ code: -32000, message: `missing trie node ${hash} (path ) state ${hash} is not available` });
+  try {
+    const raw = await caught(node.client.readContract({ address: ORACLE, abi: PRICE_WAD_ABI, functionName: 'priceWad', args: [ASSET] }));
+    assert.equal(extractRevertData(raw), hash, 'the scrape alone WOULD report the hash');
+
+    const reader = createChainReader({ client: node.client });
+    const read = await reader.tryRead(ORACLE, PRICE_WAD_ABI, 'priceWad', [ASSET], { blockNumber: 1 });
+    assert.equal(read.kind, 'transport');
+    assert.equal(read.revertData, null);
+    const call = await reader.staticCall({ to: TO, from: FROM, data: REQUEST_EXIT_1 });
+    assert.equal(call.kind, 'transport');
+    assert.equal(call.data, null);
+  } finally { await node.close(); }
 });

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -21,6 +21,7 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { classifyCallError } from '../../packages/canary/src/call-error.mjs';
 
 export const ROOT = path.resolve(
   path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..', '..',
@@ -125,30 +126,14 @@ export function call(to, sig, ...args) {
 }
 export const callU = (to, sig, ...args) => BigInt(call(to, sig, ...args)[0]);
 
-// REDUNDANT WITH THE TERNARY BELOW, and kept only as documentation of what "transport" means in
-// practice. Trace it: if REVERTED matches, this cannot fire; if it does not, both paths already
-// return 'transport'. Deleting it changes no behaviour and no test. It is labelled rather than
-// removed because in a file whose whole subject is that this classification is security-relevant,
-// a decorative regex reading as load-bearing logic is its own hazard.
-const TRANSPORT_ERR = /429|rate.?limit|max retries exceeded|timed out|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket|connection|dns|502|503|504|521/i;
-/** cast's wording for a contract-level revert, in both the JSON-RPC and the local-decode spellings. */
-const REVERTED = /execution reverted|revert(ed)?:/i;
-
-/**
- * Classify a failed `cast` call. ONLY a recognised revert is evidence about the contract; anything
- * else is missing evidence and must be recorded as such.
- *
- * This exists because a drill asserted `!result.ok` to prove a call was REFUSED, and `ok:false` is
- * also what a rate limit produces — so a 429 satisfied a security assertion. "It failed" and "the
- * contract refused it" are different claims, and only one of them is a finding.
- *
- * @param {string} err
- * @returns {'revert'|'transport'}
- */
-export function classifyCallError(err) {
-  if (TRANSPORT_ERR.test(err) && !REVERTED.test(err)) return 'transport';
-  return REVERTED.test(err) ? 'revert' : 'transport';
-}
+// ONE DEFINITION, TWO HARNESSES. `classifyCallError` moved to packages/canary/src/call-error.mjs
+// when the canary needed the same rule: "it failed" and "the contract refused it" are different
+// claims there too, and a second copy of a security-relevant classifier is a copy that drifts.
+// It lives under packages/ rather than here because the Dockerfile copies only `packages` and
+// `apps` into the runtime image, so a canary importing this file would fail in production.
+// Re-exported so every `import { classifyCallError } from './lib.mjs'` in scripts/soak and
+// scripts/test keeps working — the same shape oracle-sampler.mjs already uses to re-export it.
+export { classifyCallError };
 
 /**
  * Is a paid-perception agent permanently blind, and if so what should the operator be told?

--- a/scripts/verify-mainnet-config.mjs
+++ b/scripts/verify-mainnet-config.mjs
@@ -33,6 +33,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { classifyCallError } from '../packages/canary/src/call-error.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const RPC = process.env.BASE_MAINNET_RPC ?? 'https://mainnet.base.org';
@@ -55,7 +56,14 @@ function sleepSync(ms) {
 /** Transport failure (rate limit, timeout, DNS) as distinct from a contract-level revert. */
 export class RpcError extends Error {}
 
-const RATE_LIMITED = /429|rate.?limit|Max retries exceeded|timed out|ECONNRESET|ETIMEDOUT|502|503|521/i;
+// Was a third private copy of the transport regex, narrower than the other two: it lacked
+// ENOTFOUND, EAI_AGAIN, dns, socket, connection and 504, so a DNS failure was thrown straight
+// through as a contract-level failure and printed FAIL. Single-sourced now. The one behaviour
+// change is for wording none of the patterns recognise: `classifyCallError` calls that
+// 'transport', so an unrecognised error is retried and finally reported ERR (an un-run check)
+// instead of FAIL (a finding about the config) — which is the rule this whole file already
+// states at line 61.
+const isTransport = (detail) => classifyCallError(detail) === 'transport';
 
 /**
  * Public RPCs throttle hard and this script makes ~80 calls. A 429 must NEVER be reported as a
@@ -77,7 +85,7 @@ function cast(args, { attempts = 5 } = {}) {
       const detail = String(e.stderr ?? e.message);
       lastErr = detail;
       // A genuine contract-level failure — surface it now, never retry it.
-      if (!RATE_LIMITED.test(detail)) throw new Error(detail.split('\n')[0].slice(0, 200));
+      if (!isTransport(detail)) throw new Error(detail.split('\n')[0].slice(0, 200));
     }
   }
   throw new RpcError(`RPC unavailable after ${attempts} attempts: ${String(lastErr).split('\n')[0].slice(0, 160)}`);
@@ -85,9 +93,24 @@ function cast(args, { attempts = 5 } = {}) {
 function call(to, sig, ...args) {
   return cast(['call', to, sig, ...args.map(String)]).split('\n').map(clean);
 }
+/**
+ * `call()` that reports a REVERT as data. A transport failure is deliberately NOT data: it is
+ * re-thrown so `check()` below can tag it ERR (an un-run check) the way it already does for a
+ * direct `call()`.
+ *
+ * This swallowed both into `{ok:false}`, so the `e instanceof RpcError` test in `check()` below
+ * could never fire for a `tryCall` site, and all four callers printed a config verdict — "observe
+ * reverted", "wrong price id for this chain?" — for a 429 that never reached the pool. `kind` is
+ * on the returned
+ * object for the same reason `scripts/soak/lib.mjs` puts it there: so a caller cannot read
+ * `ok:false` as a finding without saying which failure it means.
+ */
 function tryCall(to, sig, ...args) {
   try { return { ok: true, lines: call(to, sig, ...args) }; }
-  catch (e) { return { ok: false, err: String(e.stderr ?? e.message).split('\n')[0].slice(0, 160) }; }
+  catch (e) {
+    if (e instanceof RpcError) throw e;
+    return { ok: false, err: String(e.stderr ?? e.message).split('\n')[0].slice(0, 160), kind: 'revert' };
+  }
 }
 
 function check(label, fn) {


### PR DESCRIPTION
Follow-up 1 from #179, left out of it on purpose: the **revert** side of `extractRevertData`. **Stacked on #179's head `eb253f9b`** (still open), because the fix lands inside the `structuredRevertData` / `kind` split that PR introduced; the first commit in this PR's diff is #179's and this PR needs a rebase once #179 merges. `protocol/main` has since moved to `299ff3c9` (#177).

## Measured, not theorised

Against a real viem 2.55.19 `createPublicClient` (`retryCount: 0`) and a local `http` node answering `eth_call` with `{jsonrpc:'2.0', id, error:{code:3, message:'execution reverted'}}` and **no `data`**:

| path | before (`eb253f9b`) | after |
|---|---|---|
| `staticCall({from: 0x2222…2222, data: encodeRequestExit(1n)})` | `{kind:'revert', data:'0x2222222222222222222222222222222222222222'}` | `{kind:'revert', data:null}` |
| `checkExitLiveness` pager line | `… reverts with unrecognized revert 0x66666666` (MEMBER's first four bytes) | `… reverts with EMPTY returndata (out-of-gas or returndata bomb)` |
| `tryRead(oracle, …, 'priceWad', [asset])` | `{kind:'transport', revertData:null}` | `{kind:'revert', revertData:null}` |
| same, node adds `data:'0xa2671f4b'` | `{kind:'revert', revertData:'0xa2671f4b'}` | unchanged |
| `staticCall` / `tryRead` on HTTP 429 | `{kind:'transport', data:null}` | unchanged |

**Row 1 is the defect in the brief.** viem's `CallExecutionError` composes its `message` from `metaMessages` that quote the request under "Raw Call Arguments", `from` first (`node_modules/viem/_esm/errors/contract.js`, the `prettyPrint({from, to, …, data})` in its constructor), and `scrapedRevertData` ran `/0x[0-9a-fA-F]{8,}/` over `details + shortMessage + message`. With no returndata anywhere, the first hex it met was the probe's own `from`. The verdict was ALERT on both branches already; the diagnosis was wrong, and `signals/exit-liveness.mjs:29-32` and `docs/CANARY.md` §3(d) both name empty returndata as the H-1 signature an operator is meant to recognise.

**Row 3 is a second defect the same reproduction exposed**, on the read path, and it sits in #179's classifier *input* rather than in the scrape. viem's `readContract` wording for the same node answer is `The contract function "priceWad" reverted.` — no colon, no "execution reverted" — which matches neither pattern in `call-error.mjs`, so `classifyCallError(shortMessage)` said `'transport'` and a genuine revert was filed as missing evidence. Meanwhile `err.details` said `execution reverted` the whole time. #179's live revert test carried returndata (`data: REENTRANCY`), where the structured field decides `kind` before any wording is read, so it could not see this. The unit suite could not either: `test/helpers.mjs:106` throws `MockRevert(null)` for a function the mock contract lacks, whose message is `execution reverted` and classifies `'revert'`, while the real client says the sentence above. Taken here rather than filed because the brief's deliverable — a genuine empty-returndata revert reports as one — was only half true without it, and the fix is one input to a function this PR already rewrites.

## What changed — `packages/canary/src/reader.mjs`

1. **`scrapedRevertData` reads `details` only** (`reader.mjs:120-125`). viem sets `details` from the innermost cause and carries it up the chain unchanged (`errors/base.js:14-18`: `cause instanceof BaseError ? cause.details : cause.message ?? args.details`); for a revert it is the node's JSON-RPC `error.message` (`errors/request.js:92`: `details: error.message`). viem does not quote the request there. `message` and `shortMessage` are no longer scraped.
2. **`classifyFailure` hands the classifier `details` as well as `shortMessage`** (`reader.mjs:147-151`). `call-error.mjs` is untouched, so the soak harness sees no change (73/73 below).
3. **The transport nulling from #179 stays** (`reader.mjs:210`, `:247`) and gains its own live guard: a pruned node's `missing trie node <hash>` classifies `'transport'`, and `details` there is the node's own words carrying a 64-hex hash the narrowed scrape still finds (`test/reader.test.mjs:270-288`). See the mutation table — with the scrape narrowed, #179's two 429 tests no longer fail when the nulling is removed; this test is now what pins it.

## The judgement call: what the scrape is still for

- **Drop it.** Simplest, and on every viem path measured here it changes nothing: viem lifts the node's `data` into a field (`RpcRequestError.data`, `ContractFunctionRevertedError.raw`) whenever the node sends one. Rejected because it also removes the only path by which a node that writes returndata into its error *message* and omits `data` could still be attributed — and attribution is what turns StaleOracle into `skipped`/attributed instead of a spurious ALERT in `exit-liveness`, `nav-backing` and `oracle-health`. I cannot name such a node; I also cannot rule one out, and the cost of keeping a scrape over text that by construction does not contain the request is one regex.
- **Keep it, exclude hex equal to the call's `to`/`from`/`data`.** Rejected. `readContract`'s message also quotes `args` (addresses for `priceWad(asset)`, `feedOf(asset)`, `assetConfig(asset)`), `RpcRequestError`'s quotes the whole request body, and `extractRevertData` would need the request threaded through a signature that is exported and tested as a pure function of the error. An allowlist of "hex we sent" chases viem's formatting.
- **Scope it to text that is not a quoted request.** Taken. `details` is that text by viem's own construction, not by pattern-matching viem's prose, so it holds across viem's actions (`call`, `readContract`) and across wording changes. `reader.test.mjs:34` pins the contract: hex in `details` is returndata; hex in `message` or `shortMessage` is not.

## Pinned against the real client

`test/reader.test.mjs:213-288` (five LIVE tests) and `test/exit-liveness.test.mjs:202` (one WIRING test). Each empty-returndata test first proves the vector is present — `raw.message.includes(FROM)`, `raw.details === 'execution reverted'`, `classifyCallError(raw.shortMessage) === 'transport'` — and then that the reader ignores it, so a future viem that stops quoting the request fails the test loudly rather than passing vacuously. #179's two WIRING tests (429 → BLIND; revert with returndata → ALERT `Reentrancy`) are unchanged and green.

## Mutation-checked, each mechanism alone

Over `reader.test.mjs` + `exit-liveness.test.mjs` (41 tests); each restore verified byte-identical against a backup.

| mutation | where | result |
|---|---|---|
| scrape widened back to `details + shortMessage + message` | `reader.mjs:121-122` | **4 fail**: `exit-liveness` EMPTY-returndata WIRING; `reader` `details`-only unit; LIVE staticCall; LIVE tryRead |
| classifier given `shortMessage` only (#179's input) | `reader.mjs:150` | **1 fail**: LIVE tryRead empty-returndata (`kind` came back `'transport'`) |
| transport nulling removed on both paths | `reader.mjs:210`, `:247` | **1 fail**: LIVE missing-trie-node (the hash was reported as returndata) |

## Who now receives `kind:'revert'` where they received `'transport'`

Only empty-returndata reverts on `tryRead`, and only into the branch each signal already had for a confirmed revert:

- `oracle-health.mjs:408-432` — `priceWad` reverting with no data is `ORACLE FROZEN … priceWad reverts with no data …` (ALERT, `attributionGap: true` when no cause is found) instead of `ORACLE DETECTOR BLIND … could not be read`. That is the branch #179 wrote for a confirmed revert.
- `oracle-health.mjs:355-361`, `feed-identity.mjs:205` — `feedOf` reverting takes the "reverts" wording instead of "could not be read".
- `feed-identity.mjs:156` — the confirmed-legacy silence requires `seq.kind === 'revert'`. A Solidity contract with no fallback reverts with empty returndata on an unknown selector, so through the real client a retired `OracleAggregator` answering `sequencerUptimeFeed()` produced exactly this shape and was filed `'transport'`, landing in `FEED IDENTITY DETECTOR BLIND … could not be probed` every sweep rather than the designed silence. Reachable now. Reasoned from the code path, not measured on-chain: the live deployment is a `ChainlinkOracle`, and the aggregator's source is no longer in `contracts/src`.
- `nav-backing.mjs:56-69` said "unreadable" for both kinds already and only records `kind` in `detail`.

## Measured on this tree

| suite | result |
|---|---|
| `packages/canary/test/*` (`node --test --test-reporter=tap`) | **310 tests, 310 pass, 0 fail, 0 skipped** (#179 reported 304 pass / 0 fail on its tree; six tests are new here) |
| `scripts/test/soak-drills.test.mjs` | **73 pass / 0 fail** |
| `npm run gate` from the worktree root | **GATE PASSED (40.3s)**, slither advisory only (pre-existing) |

## Not verified

- No live RPC. Every shape is a local `http` node plus viem 2.55.19's real error objects; the `details` invariant is read from `errors/base.js` and `errors/request.js` at that version and is pinned only by these tests.
- A node that reports returndata neither in `data` nor as `0x…` inside its error message is outside both the old and the new behaviour; such a revert reports as EMPTY returndata (ALERT) as before.
- The retired-`OracleAggregator` path above is reasoned, not run.
- `docs/CANARY.md` gains one paragraph in §3(d) (`:279-285`). I re-read §3(d) and the CANNOT RUN and BLIND rows of the DETECTOR BROKEN table (`:559`, `:578`) and found no other line describing the scraped label; I did not re-read the rest of the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
