### PR TITLE
fix(scripts): resolve module paths with fileURLToPath, not a hand-rolled pathname

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -33,9 +33,10 @@ import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { classifyProposal } from './proposal-recovery.mjs';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
 const CAST = process.env.CAST ?? 'cast';
 const DEPLOY_JSON = process.env.DEPLOY_JSON

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -21,15 +21,20 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { classifyCallError } from '../../packages/canary/src/call-error.mjs';
 
-export const ROOT = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..', '..',
-);
+// fileURLToPath, not `new URL(...).pathname`: a checkout path containing a space arrives here
+// percent-encoded, so the raw pathname yields a directory that does not exist and every drill
+// dies at load resolving the address book under it.
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 export const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
 const CAST = process.env.CAST ?? 'cast';
 
-/** Tokenize SOAK_SIGNER_ARGS respecting double quotes (Windows paths contain spaces). */
+/**
+ * Tokenize SOAK_SIGNER_ARGS respecting double quotes, so a quoted argument containing spaces —
+ * a `--keystore` or `--password-file` path, say — survives as one token instead of splitting.
+ */
 export function tokenize(s) {
   const out = [];
   const re = /"([^"]*)"|(\S+)/g;

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -59,9 +59,10 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadDeployment } from './deployment.mjs';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..', '..');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
 const CAST = process.env.CAST ?? 'cast';
 const SERIES = process.env.SOAK_SERIES ?? path.join(ROOT, 'data', 'oracle-series.jsonl');
@@ -499,7 +500,7 @@ function sample(env) {
 // Runner guard: the pure classifiers above are unit-tested, and an infinite sampling loop at
 // import time would hang the test process. Only sample when invoked as a script.
 const invokedDirectly = process.argv[1]
-  && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'));
+  && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
 if (invokedDirectly) {
   const { sequencerFeed } = probeOracle();

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer,
@@ -1179,4 +1179,59 @@ test('no file still claims run-soak.ps1 does not start the companion', () => {
     }
   }
   assert.deepEqual(offenders, [], 'run-soak.ps1 starts drill5-gov-companion.mjs — these say otherwise');
+});
+
+// ───────── ROOT survives a checkout path containing a space ─────────
+
+test('lib.mjs ROOT resolves a checkout whose path contains a space to a real directory', () => {
+  // `new URL(import.meta.url).pathname` hands back the path PERCENT-ENCODED, so a checkout at
+  // `.../sp ace/` yields `.../sp%20ace/` — a directory that does not exist. Every drill joins ROOT
+  // to reach the address book at module scope (`scripts/soak/drill1-multivault.mjs:37`), so
+  // `loadDeployment` throws "deployment: address book not found at ..."
+  // (`scripts/soak/deployment.mjs:134`) at load, before any drill's own skip logic can run. The
+  // encoding is not Windows-only: only the drive-letter strip in the old expression was, so this
+  // asserts nothing platform-shaped.
+  //
+  // Reproduced by copying lib.mjs and its single non-builtin import into a scratch tree whose
+  // path contains a space, then reading ROOT back out of a child process. The child's import
+  // specifier is built with pathToFileURL rather than string concatenation, so the harness cannot
+  // reintroduce the very encoding bug under test.
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'soak-space-'));
+  const root = path.join(scratch, 'sp ace');
+  const copies = [
+    ['scripts', 'soak', 'lib.mjs'],
+    ['packages', 'canary', 'src', 'call-error.mjs'],
+  ];
+  try {
+    const repo = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+    for (const rel of copies) {
+      fs.mkdirSync(path.join(root, ...rel.slice(0, -1)), { recursive: true });
+      fs.copyFileSync(path.join(repo, ...rel), path.join(root, ...rel));
+    }
+    // A file reachable ONLY by joining onto ROOT, standing in for the address book.
+    fs.writeFileSync(path.join(root, 'marker.txt'), 'root-relative read');
+
+    const target = pathToFileURL(path.join(root, 'scripts', 'soak', 'lib.mjs')).href;
+    const src = `
+      import fs from 'node:fs';
+      import path from 'node:path';
+      const m = await import(${JSON.stringify(target)});
+      const exists = fs.existsSync(m.ROOT);
+      console.log(JSON.stringify({
+        root: m.ROOT,
+        exists,
+        marker: exists ? fs.readFileSync(path.join(m.ROOT, 'marker.txt'), 'utf8') : null,
+      }));
+    `;
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', src], { encoding: 'utf8' });
+    const r = JSON.parse(out.trim().split('\n').pop());
+
+    assert.equal(r.root, root, 'ROOT must be the real directory, not a percent-encoded twin of it');
+    assert.ok(!r.root.includes('%20'), 'a space must arrive decoded — %20 names no directory');
+    assert.equal(r.exists, true, 'ROOT must exist, or every path joined onto it is unreadable');
+    assert.equal(r.marker, 'root-relative read',
+      'a file addressed through ROOT must open — this is the read the address book load performs');
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #184.

## What changed

`new URL(import.meta.url).pathname` hands back the path **percent-encoded**, so from a checkout
whose path contains a space it names a directory that does not exist. The four remaining copies of
the hand-rolled `new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')` are replaced
with `fileURLToPath` from `node:url` — already the convention in 23 other files under `scripts/`,
`packages/` and `apps/` (`scripts/gate.mjs:36`, `scripts/lib/project-status.mjs:18`,
`scripts/merge-preflight.mjs:36`, …).

| pre-change site | what it computed | effect of the fix |
|---|---|---|
| `scripts/soak/lib.mjs:26` | exported `ROOT` | the real defect — see below |
| `scripts/smoke-test.mjs:38` | `ROOT` | same shape; `ROOT` feeds `DEPLOY_JSON`, `SMOKE_CONFIG` and `SMOKE_STATE` (now `:41`–`:44`) |
| `scripts/soak/oracle-sampler.mjs:64` | `ROOT` | same shape; `ROOT` feeds `loadDeployment` at `:101`, at module scope |
| `scripts/soak/oracle-sampler.mjs:502` | the main-module guard | unreachable while `:64` was broken, because `loadDeployment` at `:101` throws first; swept so the guard cannot desync from `:64` |

## Why — the failure mode

`lib.mjs` exports `ROOT`, and all seven drills join it to reach the address book at module scope
(`drill1-multivault.mjs:37`, `drill2-subvault.mjs:53`, `drill3-modef.mjs:58`,
`drill4-oraclefreeze.mjs:58`, `drill5-agent-execute.mjs:76`, `drill5-fasttrack.mjs:37`,
`drill5-gov-companion.mjs:38`). From a checkout under `.../sp ace/` the encoded `ROOT` makes
`loadDeployment` throw `deployment: address book not found at ...\sp%20ace\...`
(`scripts/soak/deployment.mjs:134`) at **load** — before any drill's own skip logic can run, which
is why the suite failed identically either side of #180's N7.

The percent-encoding is **not** Windows-specific. `URL.pathname` does not decode, measured directly:
`new URL('file:///tmp/sp%20ace/x.mjs').pathname` is `/tmp/sp%20ace/x.mjs`, and the old expression's
`/^\/([A-Za-z]:)/` does not match it, so `%20` survives into `ROOT` unchanged. Only the drive-letter
strip was Windows-specific. The new test therefore asserts nothing platform-shaped — no drive
letters, no platform skip — and its mutation sensitivity transfers to CI's runner.

## Sweep

`grep -rn "import\.meta\.url" scripts packages apps | grep -v fileURLToPath` on this head returns
exactly the four sites above, plus five that are not this defect:

- `scripts/test/soak-drills.test.mjs:33` — the fifth copy named in the issue. It was **already
  converted on `protocol/main`** before this branch was cut, so there was nothing to change.
- `packages/canary/test/sinks.test.mjs:23` and `packages/reference-agent/test/chain.test.mjs:27`
  build `URL` objects with `new URL(rel, import.meta.url)` and hand them straight to `fs` and
  `import()`, both of which accept file URLs. No string munging, no defect.
- `scripts/test/soak-drills.test.mjs:959` — a URL-relative import specifier, same reason.
- `packages/reference-agent/fixtures/seed-snapshot.mjs:106` — the **inverse** conversion: it builds
  a `file://` URL out of `process.argv[1]` by string replacement and compares it to
  `import.meta.url`. Same class of hand-rolled path↔URL translation, and it would also mis-compare
  from a space path. Left alone deliberately: it is a different shape from the one #184 names, an
  `|| process.argv[1]?.endsWith('seed-snapshot.mjs')` fallback on the same line keeps it working,
  and #184 asks that this PR stay narrow so the blob identity of concurrent PRs is untouched. Worth
  its own issue.

## The comment at `lib.mjs:31`

It read `(Windows paths contain spaces)` — a universal that `C:\Windows` falsifies in one example.
It now says what the tokenizer actually does: a quoted argument containing spaces survives as one
token instead of splitting on the `\S+` branch of `/"([^"]*)"|(\S+)/g`.

## What was measured

- `node --test --test-reporter=tap scripts/test/soak-drills.test.mjs` → **83 tests, 83 pass,
  0 fail** (82 before; this PR adds exactly one).
- `node --test --test-reporter=tap scripts/test/*.test.mjs` → **215 tests, 210 pass, 4 fail,
  1 skipped**. The 4 are `scripts/test/contracts-size-truth.test.mjs` asserting that `contracts/out`
  exists; this is a fresh worktree with no `forge build` in it. They fail the same way without this
  change and are unrelated to it.
- **Mutation proof.** Restoring the hand-rolled expression on `lib.mjs`'s `ROOT` alone and re-running
  that same 215-test set: **209 pass, 5 fail** — the same 4 `contracts/out` failures plus *exactly*
  the new test, `lib.mjs ROOT resolves a checkout whose path contains a space to a real directory`.
  Restored afterwards; the committed tree is the fixed one.
- `node --check` passes on all three changed runtime scripts. `node scripts/gate.mjs --only
  syntax,opscheck,backend` reports `pass syntax`, `pass opscheck`, and a `backend` failure that is
  only those same 4 `contracts/out` assertions.

The new test copies `scripts/soak/lib.mjs` and its one non-builtin import
(`packages/canary/src/call-error.mjs`) into `<os.tmpdir()>/soak-space-*/sp ace/`, then reads `ROOT`
back out of a child process. It builds the child's import specifier with `pathToFileURL` rather than
by concatenation, so the harness cannot reintroduce the encoding bug it is testing. It asserts four
things — `ROOT` equals the real directory, carries no `%20`, exists, and that a file joined onto it
opens — because `!includes('%20')` on its own would be satisfied by wrapping the old expression in
`decodeURIComponent`.

## What I could **not** verify

- **The gate's contracts steps did not run here.** `forge` sat at 0.17 s of CPU for three minutes on
  the shared `~/.foundry` — the known cross-session deadlock — so `fmt`, `build`, `test`, `snapshot`
  and `sizes` were not exercised locally. This change touches no Solidity and no gas, so those steps
  are a regression check only; CI runs them.
- **The end-to-end soak failure was not reproduced.** Booting a drill needs a keystore, a funded
  account and a live RPC, all out of bounds under `docs/SWARM.md` §10. The fix is proven at its root
  cause, `ROOT`, and by reading the seven call sites that join onto it — not by watching a drill
  start from a space path.
- **Only `lib.mjs` is covered by a test.** The other three sites are swept by shape and verified by
  reading; nothing pins `smoke-test.mjs` or either `oracle-sampler.mjs` site. In particular, the
  claim that leaving `:502` hand-rolled would make the sampler import cleanly and then sample
  nothing from a space path is derived from the code — `path.resolve(argv[1])` is decoded while the
  hand-rolled right-hand side is not — and was **not** measured; exercising it needs the address
  book and a live RPC.

## Rebase note

Another session may be changing `scripts/smoke-test.mjs` around the bare `catch { /* expected
revert */ }` (line 231 before this change, 232 after). My only edit to that file adds the `node:url`
import at line 36 and rewrites `ROOT` at line 39 — roughly 190 lines away, so the two are separate
hunks and should rebase cleanly. Worth a look if that PR lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
