### PR TITLE
fix(canary): three blind lines worded a transport failure as a revert (#181, #186)

### DIFF
--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -565,8 +565,8 @@ re-assert on a backoff until fixed:
 | `ORACLE DETECTOR BLIND … answers neither ChainlinkOracle.sequencerUptimeFeed() nor OracleAggregator.assetConfig()` | the vault's oracle is a flavor this canary does not know | the canary needs a new oracle implementation before this vault is monitored at all — do not treat the vault as healthy |
 | `vault … is unreadable` | wrong address, wrong chain, or the RPC is failing | check `RPC_URL`/`CHAIN_ID` and the address. **Every** signal for that vault is suspended |
 | `… check ERRORED on vault … and measured nothing` | the signal threw (usually an RPC fault) | read the error in `detail`; the vault is unmonitored for that signal until it clears |
-| `FEED IDENTITY DETECTOR BLIND … did not answer description() / decimals()` | the proxy stopped answering the two reads the harm checks compare against | the asset is unmonitored for aggregator-swap drift. A feed that has stopped answering the calls `ChainlinkOracle`'s own constructor made has itself changed shape — check it against Chainlink's feed registry |
-| `FEED IDENTITY DETECTOR BLIND … answered neither aggregator() nor phaseId()` | the feed is not an `EACAggregatorProxy`, or both reads are failing | the harm checks (decimals, denomination) **did** run and passed; it is the swap *notice* that is blind |
+| `FEED IDENTITY DETECTOR BLIND … did not answer description() or decimals()`, or `… description() or decimals() … could not be read` | one branch, two wordings. `did not answer` needs every one of those reads that failed to be a confirmed revert — the proxy stopped answering the reads the harm checks compare against. `could not be read` means at least one of those reads failed without a confirmed revert — including an `eth_call` that came back empty, which classifies `transport` (`call-error.mjs:19-21`), so the feed may well have answered | the asset is unmonitored for aggregator-swap drift. On `did not answer`: a feed that has stopped answering the calls `ChainlinkOracle`'s own constructor made has itself changed shape — check it against Chainlink's feed registry. On `could not be read`: check the RPC's rate limit first, but an empty `eth_call` return lands here too — three consecutive sweeps is the feed, not the network (`feed-identity.mjs:72-76`) |
+| `FEED IDENTITY DETECTOR BLIND … answered neither aggregator() nor phaseId()`, or `… neither aggregator() nor phaseId() … could be read` | one branch, two wordings, same rule: `answered neither` needs both reads to be confirmed reverts — the feed is not an `EACAggregatorProxy`. `could be read` means at least one failed without a confirmed revert — an `eth_call` that came back empty classifies `transport` too (`call-error.mjs:19-21`) — and evidences neither | the harm checks (decimals, denomination) **did** run and passed either way; it is the swap *notice* that is blind |
 | `exit-liveness sentinel BLIND … did not reach the chain` | the `requestExit` probe failed in transit (rate limit, timeout, dropped socket) — no revert was observed | check the RPC's rate limit and `RPC_URL`. **This is not an H-1 finding**: nothing about `requestExit` was learned. It clears on the next sweep that reaches the chain |
 | `ORACLE DETECTOR BLIND … priceWad() … could not be read` | the ground-truth price read failed in transit | as above. Whether the asset is frozen is unknown, so it is not reported either way |
 | `ORACLE FRESHNESS DETECTOR BLIND … price sources could not be read` | enough sources were unreachable that the quorum margin cannot be stated | the verdict is still given whenever it holds on a bound — this line means the unreadable sources are what decides it |
@@ -581,8 +581,8 @@ reader tags each failure `revert` or `transport` (`packages/canary/src/call-erro
 and explicitly not evidence of a fault.
 
 **`feed-identity` is the only signal whose BLIND lines damp against RPC noise.** All four of its
-blind branches (`feed-identity.mjs:178, 210, 258, 289`) carry
-`minConsecutive: UNREADABLE_SWEEPS` (3, `feed-identity.mjs:100`), so they escalate only on the third
+blind branches (`feed-identity.mjs:179, 211, 266, 308`) carry
+`minConsecutive: UNREADABLE_SWEEPS` (3, `feed-identity.mjs:101`), so they escalate only on the third
 consecutive sweep. The case that earned the damping is an `eth_call` coming back empty — one empty
 return is noise where three consecutive is the feed — but that is the case it was written for, not
 the only one it covers: each branch is reachable on a confirmed revert too, and on a transport
@@ -596,8 +596,10 @@ consecutive observations before the tracker flips its status — `alert` and `ok
 `transitions.mjs:146` gates every status flip on `need`, not only the blind ones. A result is
 unpinned either because the caller passed no `atBlock` (`share-conservation.mjs:39`) or because the
 pinned read failed and the archive fallback re-read at chain head (`share-conservation.mjs:44-51`);
-that failure is transport-classified, so RPC noise is one of the two paths into this damping rather
-than something it is unrelated to.
+that retry is `if (!res.ok && pinned)` and is deliberately NOT gated on `kind` (`:46-48`), so it
+takes any failed pinned read — but the failure it exists for is the pruned node's "missing trie
+node", which classifies transport. RPC noise is therefore one of the two paths into this damping
+rather than something it is unrelated to.
 
 Do not read the branch count off the table, because rows and branches do not correspond one to one:
 only two rows above carry the literal `FEED IDENTITY DETECTOR BLIND` prefix, and the last row folds

--- a/packages/canary/src/signals/feed-identity.mjs
+++ b/packages/canary/src/signals/feed-identity.mjs
@@ -76,10 +76,11 @@
  * failure since the reader began telling those apart, and the damping applies to all three.
  *
  * `oracle-health` carries no such damping, but not for the reason this header used to give. Its
- * blind branches are FOUR, not one (`oracle-health.mjs:173, 264, 356, 401`), and only `:173`'s is
- * structural — an oracle answering neither known ABI. The other three turn on a per-asset or
- * per-feed read that did not come back, so “structural, not a transient read” never covered them;
- * they simply set no `minConsecutive`.
+ * blind branches are FOUR, not one (`oracle-health.mjs:173, 264, 356, 401`), and only `:173`'s CAN
+ * be structural — an oracle answering neither known ABI — its `:176` leg being the transport case.
+ * Of the rest, `:264` and `:401` fire only when the kind is transport (`:259`, `:400`), and `:356`
+ * on any failed `feedOf()`, a confirmed revert included (`:350`) — so “structural, not a transient
+ * read” never covered all of them; they simply set no `minConsecutive`.
  *
  * Fans out one result per (vault, asset), keyed by asset, like `oracle-freshness`.
  */
@@ -255,9 +256,23 @@ async function assetIdentity({ reader, vault, oracle, asset, pins }) {
   // HARM LEGS FIRST, in the constructor's own order (`_requireUsdQuote`, then `decimals`). Order
   // decides which cause a responder chases — the Dev11 lesson, applied here too.
   if (!desc.ok || !dec.ok) {
+    // "did not answer" is a claim about the FEED, so only a confirmed revert from every read that
+    // failed may make it — the same rule `:212` already applies to `feedOf()`. The guard is `||`
+    // above, so one of the two may have succeeded; a succeeded read carries no `kind` and must not
+    // drag the wording neutral on its own.
+    const answered = (desc.ok || desc.kind === 'revert') && (dec.ok || dec.kind === 'revert');
+    const which = `${!desc.ok ? 'description()' : ''}${!desc.ok && !dec.ok ? ' or ' : ''}${!dec.ok ? 'decimals()' : ''}`;
+    const why = (desc.error ?? dec.error) || 'no error text';
     return blind(
-      `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} did not answer ${!desc.ok ? 'description()' : ''}${!desc.ok && !dec.ok ? ' or ' : ''}${!dec.ok ? 'decimals()' : ''} (${(desc.error ?? dec.error) || 'no error text'}), so neither the denomination nor the cached-scale check could run. This asset is UNMONITORED for aggregator-swap drift, not clean`,
-      { ...detail, descriptionError: desc.error ?? null, decimalsError: dec.error ?? null },
+      answered
+        ? `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} did not answer ${which} (${why}), so neither the denomination nor the cached-scale check could run. This asset is UNMONITORED for aggregator-swap drift, not clean`
+        : `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: ${which} on the feed at ${shortAddr(cfg.feed)} could not be read (${why}), so neither the denomination nor the cached-scale check could run. This asset is UNMONITORED for aggregator-swap drift this sweep, not clean`,
+      {
+        ...detail,
+        descriptionError: desc.error ?? null, decimalsError: dec.error ?? null,
+        descriptionKind: desc.ok ? null : desc.kind ?? null,
+        decimalsKind: dec.ok ? null : dec.kind ?? null,
+      },
     );
   }
 
@@ -286,9 +301,19 @@ async function assetIdentity({ reader, vault, oracle, asset, pins }) {
 
   // IDENTITY LEG. Harm-free by itself, and only reached once both harm legs have passed.
   if (!agg.ok && !phase.ok) {
+    // "answered neither" is the same claim about the feed as the harm leg's "did not answer", and
+    // carries the same condition: both reads must have come back as confirmed reverts.
+    const answered = agg.kind === 'revert' && phase.kind === 'revert';
+    const why = (agg.error ?? phase.error) || 'no error text';
     return blind(
-      `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} answered neither aggregator() nor phaseId() (${(agg.error ?? phase.error) || 'no error text'}), so an aggregator swap cannot be observed at all. The denomination and cached-scale checks DID pass this sweep — the harm checks are running; it is the swap NOTICE that is blind`,
-      { ...detail, aggregatorError: agg.error ?? null, phaseIdError: phase.error ?? null },
+      answered
+        ? `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: the feed at ${shortAddr(cfg.feed)} answered neither aggregator() nor phaseId() (${why}), so an aggregator swap cannot be observed at all. The denomination and cached-scale checks DID pass this sweep — the harm checks are running; it is the swap NOTICE that is blind`
+        : `FEED IDENTITY DETECTOR BLIND for ${shortAddr(asset)} on vault ${shortAddr(vault)}: neither aggregator() nor phaseId() on the feed at ${shortAddr(cfg.feed)} could be read (${why}), so an aggregator swap cannot be observed this sweep. The denomination and cached-scale checks DID pass this sweep — the harm checks are running; it is the swap NOTICE that is blind`,
+      {
+        ...detail,
+        aggregatorError: agg.error ?? null, phaseIdError: phase.error ?? null,
+        aggregatorKind: agg.kind ?? null, phaseIdKind: phase.kind ?? null,
+      },
     );
   }
 

--- a/packages/canary/src/signals/nav-backing.mjs
+++ b/packages/canary/src/signals/nav-backing.mjs
@@ -214,7 +214,10 @@ function memoPrice(reader, oracle, at) {
     if (cache.has(k)) return cache.get(k);
     const res = await reader.tryRead(oracle, ORACLE_VIEWS, 'priceWad', [asset], at);
     if (!res.ok) {
-      const err = new Error(`priceWad(${asset}) reverted: ${res.error}`);
+      // Only a CONFIRMED revert may be worded as one. This message is not swallowed — `:92` puts
+      // it verbatim into the operator's `NAV recompute failed …` line — so the unconditional
+      // "reverted" it used to carry reported an HTTP 429 as a claim about priceWad.
+      const err = new Error(`priceWad(${asset}) ${res.kind === 'revert' ? 'reverted' : 'could not be read'}: ${res.error}`);
       // @ts-ignore — carried so the caller can attribute a StaleOracle revert to the oracle signal
       err.revertData = res.revertData;
       throw err;

--- a/packages/canary/test/feed-identity.test.mjs
+++ b/packages/canary/test/feed-identity.test.mjs
@@ -413,3 +413,27 @@ test('an unreadable feedOf() says the call did not arrive, not that the oracle r
   assert.match(r.message, /could not be read/);
   assert.doesNotMatch(r.message, /reverts \(/);
 });
+
+test('an unreadable decimals() says the read failed, not that the feed refused to answer', async () => {
+  // The harm leg's "did not answer decimals()" is a claim about the FEED. On a 429 the feed was
+  // never asked, so the line must not make it. The revert leg keeps the old wording, and its
+  // unqualified "UNMONITORED … not clean" tail is pinned at `:279`.
+  const reader = readerFor({ overrides: { [FEED]: { decimals: UNREACHABLE } } });
+  const [r] = await run(reader);
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.detail.decimalsKind, 'transport');
+  assert.match(r.message, /decimals\(\) on the feed at .* could not be read/);
+  assert.doesNotMatch(r.message, /did not answer/);
+});
+
+test('an unreadable aggregator() and phaseId() do not become "answered neither"', async () => {
+  const reader = readerFor({ overrides: { [FEED]: { aggregator: UNREACHABLE, phaseId: UNREACHABLE } } });
+  const [r] = await run(reader);
+  assert.equal(r.detail.detectorBroken, true);
+  assert.equal(r.detail.aggregatorKind, 'transport');
+  assert.equal(r.detail.phaseIdKind, 'transport');
+  assert.match(r.message, /neither aggregator\(\) nor phaseId\(\) on the feed at .* could be read/);
+  assert.doesNotMatch(r.message, /answered neither/);
+  // The harm legs still ran and still passed, which is the half of this line that is a finding.
+  assert.match(r.message, /denomination and cached-scale checks DID pass this sweep/);
+});

--- a/packages/canary/test/nav-backing.test.mjs
+++ b/packages/canary/test/nav-backing.test.mjs
@@ -144,3 +144,16 @@ test('custody ALERTS on a basket-asset shortfall and names the token', async () 
   assert.equal(c.detail.shortfalls[0].token, ASSET);
   assert.ok(c.message.includes(ASSET.slice(0, 6)), 'alert line must name the token');
 });
+
+test('a 429 on priceWad mid-recompute is worded as an unread call, not as a revert', async () => {
+  // memoPrice's Error text is not swallowed: nav-backing.mjs:92 puts it verbatim into the
+  // operator's "NAV recompute failed …" line, so an unconditional "reverted" there reported a
+  // network failure as a claim about priceWad. Non-paging either way — the result is `skipped`,
+  // and `isFrozen(null)` is false because the reader nulls returndata on a transport failure.
+  const contracts = healthyVault({ [ORACLE]: { priceWad: () => ({ transport: 'HTTP request failed.' }) } });
+  const c = composition(await checkNavBacking({ reader: mockReader({ contracts }), vault: VAULT, atBlock: 900 }));
+  assert.equal(c.status, 'skipped');
+  assert.equal(c.detail.attributedTo, null);
+  assert.match(c.message, /priceWad\(0x\w+\) could not be read: HTTP request failed\./);
+  assert.doesNotMatch(c.message, /revert/);
+});


### PR DESCRIPTION
Closes #181. Closes #186.

Both are prose-accuracy follow-ups to #179, in the same two files, so they land together.

**Round 2 (head `a02c29c4`, rebased onto `protocol/main` — `behind_by 0`).** Every `file:line` below resolves at this head; lines that describe the code *before* this change say so explicitly.

## What changed

**#181 — three messages worded ANY failed read as a revert.**

- `packages/canary/src/signals/nav-backing.mjs` threw ``priceWad(${asset}) reverted: ${res.error}`` for any `!res.ok` (that line was `:217` before this change; the replacement ternary is `:220`). That text is not swallowed: `:92` puts it verbatim into the operator's `NAV recompute failed on vault 0x…: …` line, so an HTTP 429 read as a claim about `priceWad`.
- `packages/canary/src/signals/feed-identity.mjs` said the feed "did not answer description() or decimals()" (`:259` before this change, now `:268`), and "answered neither aggregator() nor phaseId()" (`:290` before, now `:310`). Both are claims about the feed; neither consulted `kind`.

All three now branch on `kind`, in the direction the rest of the package already takes (`oracle-health.mjs:355` `const reverted = cfgRead.kind === 'revert'`; `:392` `priceWadReverts: !price.ok && price.kind === 'revert'`, under the comment at `:390` — "Only a CONFIRMED revert may set this") — **not** the `kind === 'transport' ? … : 'reverted'` shape sketched in #181, which makes "reverted" the default and would print a revert claim for any unset or future `kind`. On the two multi-read legs the condition is that *every read that failed* reverted: `desc`/`dec` guarded with `||` (one may have succeeded, and a succeeded read carries no `kind`), `agg`/`phase` with `&&` (both are known to have failed). `detail` now carries each failed read's `kind`.

The revert wording is unchanged on all three, and the existing assertions that pin it (`test/feed-identity.test.mjs:279`, `:307`) still pass untouched.

**#186 A — feed-identity.mjs's header block over-reached on `oracle-health.mjs:356`** (`:79-82` before this change, now `:78-83`). The header claimed the other three of oracle-health's four blind branches all "turn on a per-asset or per-feed read that did not come back". That is false for `:356`: it is gated on plain `!cfgRead.ok` (`:350`), derives `reverted` at `:355`, and prints "feedOf() … reverts" at `:359` on a confirmed revert. The header now states each branch's gate (`:264`/`:401` transport-only at `:259`/`:400`; `:356` on any failed `feedOf()`) and softens `:173` to the branch that *can* be structural, its `:176` leg being the transport case.

**#186 B — `docs/CANARY.md`** said the archive-fallback failure "is transport-classified" (`:599` before this change; the replacement block is `:599-602`). `share-conservation.mjs:44` retries on `if (!res.ok && pinned)` and is deliberately not gated on `kind` (`:46-48`), so it takes any failed pinned read. The premise is reworded to say that, keeping the conclusion (RPC noise is one of the two paths into the damping) and the fact that the "missing trie node" it exists for classifies transport.

## Round 2 — what the REJECT on `b20c6eb0` found, and what changed

**The blocker.** Both rewritten table rows explained the neutral wording as "failed in transit" / "so the feed was never asked". `packages/canary/src/call-error.mjs:19-21` contradicts that in as many words: `transport` means ONLY "this is not a confirmed contract-level revert", it is "deliberately the default for unrecognized wording", and it "does NOT mean 'the chain was unreachable'". (The verdict cited `:22-25`; at this head `:22-24` is the `missing trie node` example and `:25` closes the comment, while the three sentences quoted above are `:19-21`.)

That is false for the exact case the damping was built for. An `eth_call` that comes back empty carries no returndata, so `reader.mjs:121` (`structuredRevertData(err) != null ? 'revert' : classifyCallError(errorText)`) falls through to the classifier, whose `REVERTED` pattern (`call-error.mjs:34`) does not match viem's empty-return wording — so it lands on `transport` with the feed having answered `0x`. That this is the headline case is stated at `feed-identity.mjs:72-76` and `docs/CANARY.md:586`.

Both cause columns now read "failed without a confirmed revert" and name the empty-return case with its `call-error.mjs:19-21` citation, and `:568`'s remedy column keeps that case reachable — "check the RPC's rate limit first, but an empty `eth_call` return lands here too — three consecutive sweeps is the feed, not the network (`feed-identity.mjs:72-76`)" — instead of pointing only at the RPC.

**Three citation repairs, swept rather than patched.** The verdict named one off-by-one; grepping the whole list found three of the same shape:

- `oracle-health.mjs:360` and `feed-identity.mjs:182` are the **transport** leg of their ternary, not the claim. The claims are `:359` and `:183`.
- `feed-identity.mjs:212` was cited by its **gate** line while its siblings were cited by their claim line. The claim is `:213`.

The sweep list below is now restated under one convention, and the commit message carries the same list.

**Wording repairs.** Row `:569` explained the wording as `could not be read`, but `feed-identity.mjs:311` emits `could be read`; and row `:568`'s header wrote `description() / decimals()`, where `:264` builds `description() or decimals()`. Both rows now quote the emitted string byte for byte.

**Not changed, deliberately.** The mixed `desc`/`dec` case (one reverts, one transport-fails) puts the revert text under the neutral wording via `why = (desc.error ?? dec.error)` at `:265` — it under-claims rather than inventing a finding, it was already disclosed below, and it is record-only. The comment at `test/feed-identity.test.mjs:418-419` ("On a 429 the feed was never asked") is scoped to that test's own `UNREACHABLE = () => ({ transport: 'HTTP request failed.' })` fixture (`:382`), where it is literally true, and it does not define `transport`; it is left as written.

Round 2 changed prose only: `git diff b20c6eb0 HEAD -- docs/CANARY.md` is 2 lines replaced by 2, and no other file in this PR's diff was edited. (`git diff b20c6eb0 HEAD` lists 16 files, but 15 of them — under `apps/site/`, `docs/vault/`, `scripts/` and `llms.txt` — are `protocol/main`'s own commits pulled in by the two rebases, not edits of mine; the PR's diff against `protocol/main` is still the same 5 files.) `git diff b20c6eb0 HEAD` over the two signal files and their two tests is **empty** — they are byte-identical — so every mutation proof below still stands.

## What was measured

At `a02c29c4`, in this worktree, after `npm ci` and with **no `forge build`** (a cold `contracts/out`):

- `node --test --test-reporter=tap "packages/canary/test/*.test.mjs"` — **307 tests, 296 pass, 0 fail, 11 skipped**. All 11 skips are `contracts/out absent` guards that disappear once `npm run gate` has run `forge build`.
- `node --test --test-reporter=tap scripts/test/claims-lede-truth.test.mjs` — **6 tests, 6 pass, 0 fail, 0 skipped**.
- `node --test --test-reporter=tap scripts/test/config-doc-truth.test.mjs` — **19 tests, 19 pass, 0 fail, 0 skipped**. Both guards walk `docs/CANARY.md`.
- `git diff --stat origin/protocol/main...HEAD` — 5 files, +82 −15: `docs/CANARY.md`, the two signal files, and their two test files. Nothing else.

Round 1 additionally ran `npm run gate` from the worktree root — **GATE PASSED (591.7s)**, 1 advisory warning (slither, 236 results, advisory in CI and pre-existing). That was on the pre-rebase tree; it has **not** been re-run at `a02c29c4`.

No `src/` (Solidity) change, so no EIP-170 delta and no gas snapshot change.

**Mutation proof, one site at a time, three separate runs (Round 1; the source under test is byte-identical at `a02c29c4`):**

| Mutation | Result |
|---|---|
| `nav-backing.mjs` ternary → unconditional `reverted` | `nav-backing.test.mjs` 13 tests, 12 pass, **1 fail** — only "a 429 on priceWad mid-recompute is worded as an unread call, not as a revert" |
| `feed-identity.mjs` desc/dec `answered` → `true` | `feed-identity.test.mjs` 37 tests, 36 pass, **1 fail** — only "an unreadable decimals() says the read failed, not that the feed refused to answer" |
| `feed-identity.mjs` agg/phase `answered` → `true` | `feed-identity.test.mjs` 37 tests, 36 pass, **1 fail** — only "an unreadable aggregator() and phaseId() do not become \"answered neither\"" |

Each was restored by file copy afterwards; `git diff` confirms only the intended lines remain changed. The independent reviewer reproduced all three in their own scratch tree and hash-verified both files back to the head blobs.

## The sweeps

**1. Other instances of the shape** — every message in `packages/canary/src` containing `revert`/`reverts`/`answered neither`/`did not answer` that follows a failed read. One convention throughout: the **claim** line first, then in parentheses the line that guarantees only a confirmed revert reaches it — the `kind` test that selects the branch, or the transport early return above it.

- **Already gated on a confirmed revert:** `oracle-health.mjs:177` (`:172`), `:280` (`:259`), `:359` (`:355`), `:483` (`:471`); `oracle-freshness.mjs:88` (`:83`); `feed-identity.mjs:183` (`:175`), `:213` (`:212`); `exit-liveness.mjs:135`, `:143`, `:153` (all behind the `res.kind === 'transport'` return at `:121`).
- **Worded neutrally ("unreadable" / "could not be read"), no gate needed:** `canary-runner.mjs:268`, `fee-routing.mjs:62`, `nav-backing.mjs:62` and `:147`, `oracle-freshness.mjs:53`, `share-conservation.mjs:55`.

No further instances inside `packages/canary/src`.

**2. Stale line citations the edits moved.** `docs/CANARY.md:584-585` cited `feed-identity.mjs:178, 210, 258, 289` and `:100`; now `:179, :211, :266, :308` and `:101`. A repo-wide grep for `feed-identity.mjs:` / `nav-backing.mjs:` found no others.

**3. Stale *quotations* of the changed strings.** A grep for `did not answer` / `answered neither` / `reverted:` across `docs/`, `scripts/` and `packages/` found the blind-line table at `docs/CANARY.md:568-569`, which quotes both feed-identity messages verbatim and therefore described only the revert leg. Each row now carries both wordings and the rule that separates them; no row was added, so the count claim at `:605` ("only two rows … carry the literal `FEED IDENTITY DETECTOR BLIND` prefix") still holds — re-checked after the Round 2 edit. Nothing under `scripts/` pattern-matches canary output on these strings, so there is no functional consumer to break.

**4. The "transport means unreachable" shape (Round 2).** Grepped `in transit`, `never asked`, `did not reach`, `unreachable`, `the network`, `rate limit` and `RPC` across the PR diff, all of `docs/CANARY.md`, and `packages/canary/src`. The two rows this PR introduced are fixed. Pre-existing instances of the shape sit in lines this PR does not touch and are left alone per `docs/SWARM.md` §4 — `docs/CANARY.md:570-574` (five table rows), `exit-liveness.mjs:109` and `:124`, `feed-identity.mjs:214`, `governance-watch.mjs:247`, `oracle-health.mjs:170` and `:360`, and the mislabel at `test/feed-identity.test.mjs:317` that the verdict itself flagged as pre-existing. They are worth a follow-up issue; they are not this PR's diff.

## Found and deliberately not changed

`scripts/verify-chainlink-oracle.mjs:225` returns "proxy answered neither aggregator() nor phaseId()" — the same claim shape. It is out of reach of this fix by construction: `compareAggregatorPin` is a pure function whose inputs are already reduced to `implementation`/`phaseId` or `null`, with no `kind` in scope, and its own comment at `:235-237` records the same concern for the swap verdict. The file is also being changed concurrently by another session. Reported, not touched.

## What I could not verify

- **No live RPC.** Every test injects the mock reader, so this proves the wording against `mockReader`'s reproduction of `tryRead` (`test/helpers.mjs`, which calls the real `classifyCallError`), not against a real provider's 429 text. In particular no fixture models an empty `0x` return: `test/helpers.mjs:297` resolves every `feed*Reverts` fixture to `RV = { revert: '0xdeadbeef' }`, and `test/feed-identity.test.mjs:382` uses `UNREACHABLE = () => ({ transport: 'HTTP request failed.' })`. The empty-return claim now in the doc rows is verified by reading `reader.mjs:121` and `call-error.mjs:34, :49-51`, not by a test.
- **The mixed case is untested:** one of `description()`/`decimals()` reverting while the other fails in transit, on the same feed in the same `Promise.all`. The code takes the neutral wording there, which under-claims rather than inventing a finding, but no fixture exercises it.
- **CI on `a02c29c4` has not been observed** — the evidence here is the local suites listed above.
- `packages/canary/src/reader.mjs`, `scripts/smoke-test.mjs` and `scripts/verify-chainlink-oracle.mjs` are being changed concurrently by other sessions and are untouched here.
- Not merged, no merge-preflight dispatched and no verdict posted, per the task brief.
