### PR TITLE
fix(soak): pin the proposal decode that feeds votableNow, and correct three false statements in lib.mjs

### DIFF
--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -296,14 +296,17 @@ if (want('vote') && !state.phases?.vote?.done) {
       account.address, String(prop.createdAt - 1),
     );
     const cur = callU(VAULT, 'votingEligibleShares(address)(uint256)', account.address);
-    const snapshotWeight = snap < cur ? snap : cur;
+    // Named for what it holds. Calling this local `snapshotWeight` put that word on the bounded
+    // minimum one line above the argument spelled `snapshotWeight:`, which takes `snap` — two
+    // meanings, three lines apart, for the confusion this whole gate exists to remove.
+    const boundedWeight = snap < cur ? snap : cur;
 
     const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight: snap, currentWeight: cur });
     assert(votable,
       `proposal ${pid} on the smoke vault is NOT votable by this agent: ${reason}.\n`
         + `  status=${prop.status} ptype=${prop.ptype} createdAt=${prop.createdAt} `
         + `commitDeadline=${prop.commitDeadline} revealDeadline=${prop.revealDeadline} `
-        + `snapshot=${snap} current=${cur} boundedWeight=${snapshotWeight}\n`
+        + `snapshot=${snap} current=${cur} boundedWeight=${boundedWeight}\n`
         + '  This is a HARNESS/round-availability failure, not evidence about governance or the\n'
         + '  contracts, and no amount of ticking will change it. A fresh round must be raised on this\n'
         + '  vault AFTER the agent holds shares (voting weight snapshots at createdAt-1), and any\n'
@@ -312,7 +315,7 @@ if (want('vote') && !state.phases?.vote?.done) {
         + '  it in the background before this phase — so read logs/gov-companion.log and\n'
         + '  logs/gov-companion.err.log for why no round is there. Running this drill standalone,\n'
         + '  start the companion yourself first.');
-    log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} boundedWeight=${snapshotWeight}`);
+    log(`proposal ${pid} is votable: status=${prop.status} commitDeadline=${prop.commitDeadline} boundedWeight=${boundedWeight}`);
   } else {
     log(`proposal ${pid} already carries this agent's commitment — skipping the votability gate and going to reveal`);
   }

--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -284,6 +284,10 @@ if (want('vote') && !state.phases?.vote?.done) {
     // votable and then watch `commitVote` revert NoWeight for forty ticks. Drill 5 queues an exit
     // in its own next phase, so a re-run or reset reaches this exact state.
     //
+    // Both terms go to `votableNow` UNBOUNDED. It applies the same minimum for its verdict, but
+    // keeping them apart is what lets it say WHICH one is zero: minimising here first would make
+    // a queued-exit voter indistinguishable from one whose shares postdate the proposal.
+    //
     // NOTE THE `uint64`. VaultCore.sol:1040 declares `pastVotingEligibleShares(address, uint64)`;
     // the `uint256` spelling is a DIFFERENT SELECTOR (0xab46cdef vs 0xc5a88eb3) and reverts, which
     // is how the first version of this guard aborted the phase 100% of the time.
@@ -294,7 +298,7 @@ if (want('vote') && !state.phases?.vote?.done) {
     const cur = callU(VAULT, 'votingEligibleShares(address)(uint256)', account.address);
     const snapshotWeight = snap < cur ? snap : cur;
 
-    const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight });
+    const { votable, reason } = votableNow(prop, { now: chainNow(), snapshotWeight: snap, currentWeight: cur });
     assert(votable,
       `proposal ${pid} on the smoke vault is NOT votable by this agent: ${reason}.\n`
         + `  status=${prop.status} ptype=${prop.ptype} createdAt=${prop.createdAt} `

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -420,9 +420,11 @@ export const PTYPE = { Rebalance: 0, RuleChange: 1, ChildAllocation: 2 };
  * exit has snapshot weight and zero current weight, because `votingEligibleShares` is
  * `sharesOf - queuedExitShares` (VaultCore.sol:1025-1028); handed only the already-minimised
  * weight, this function cannot tell that apart from "the proposal predates this account" and
- * would state the wrong cause with full confidence. `currentWeight` is REQUIRED, not defaulted:
- * a caller that omits it gets a refusal naming the missing input, never a silent fallback to the
- * snapshot-only story.
+ * would state the wrong cause with full confidence. BOTH terms are REQUIRED, not defaulted: a
+ * caller that omits either gets a refusal naming the missing one, never a silent fallback to a
+ * one-term story. `undefined <= 0n` is `false`, so a missing term left unchecked would skip its
+ * branch and be read as a healthy weight — the fail-OPEN direction, and the reason the null test
+ * is separate from the zero test rather than folded into it.
  *
  * @param {{status: string, ptype: number, commitDeadline: number}} p a `readProposal` result
  * @param {{now: number, snapshotWeight: bigint, currentWeight: bigint, wantPtype?: number}} ctx
@@ -442,14 +444,17 @@ export function votableNow(p, { now, snapshotWeight, currentWeight, wantPtype })
   if (wantPtype != null && p.ptype !== wantPtype) {
     return { votable: false, reason: `ptype is ${p.ptype}, not the expected ${wantPtype}` };
   }
-  if (currentWeight == null) {
-    return { votable: false, reason: 'currentWeight was not supplied — commitVote gates on min(snapshot, current) (Governance.sol:352-356, :365), so a snapshot-only answer cannot be given' };
+  if (snapshotWeight == null || currentWeight == null) {
+    const missing = snapshotWeight == null
+      ? (currentWeight == null ? 'snapshotWeight and currentWeight were' : 'snapshotWeight was')
+      : 'currentWeight was';
+    return { votable: false, reason: `${missing} not supplied — commitVote gates on min(snapshot, current) (Governance.sol:352-356, :365), so a one-term answer cannot be given` };
   }
   if (snapshotWeight <= 0n) {
     return { votable: false, reason: 'the voter had zero voting-eligible stake at the proposal\'s snapshot — it was raised before this account held shares, so commitVote would revert NoWeight' };
   }
   if (currentWeight <= 0n) {
-    return { votable: false, reason: `the voter holds no voting-eligible shares NOW (snapshot weight ${snapshotWeight}, current ${currentWeight}) — votingEligibleShares is sharesOf minus queuedExitShares (VaultCore.sol:1025-1028), so a queued exit zeroes it, and commitVote gates on min(snapshot, current) (Governance.sol:352-356) and would revert NoWeight` };
+    return { votable: false, reason: `the voter holds no voting-eligible shares NOW (snapshot weight ${snapshotWeight}, current ${currentWeight}) — votingEligibleShares returns 0 for the parent vault and otherwise sharesOf minus queuedExitShares (VaultCore.sol:1026-1027), so a queued exit zeroes it, and commitVote gates on min(snapshot, current) (Governance.sol:352-356) and would revert NoWeight` };
   }
   return { votable: true, reason: '' };
 }

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -143,9 +143,12 @@ export { classifyCallError };
 /**
  * Is a paid-perception agent permanently blind, and if so what should the operator be told?
  *
- * The reference agent perceives through PAID x402 reads. Once its session spend cap is exhausted
- * it can no longer read the vault list or the leaderboard, so it reports "perception gaps" and
- * "no action warranted" on every subsequent tick — forever. No later tick can satisfy the goal.
+ * The reference agent perceives through PAID x402 reads. Once its session spend cap can no longer
+ * fund one, it can no longer read the vault list or the leaderboard, so it reports "perception
+ * gaps" and "no action warranted" on every subsequent tick — forever. No later tick can satisfy
+ * the goal. "Can no longer fund one" is not the same as "spent to zero": the budget refuses a read
+ * when `spent + price > cap`, so a positive remainder smaller than the next read's price is
+ * already terminal.
  *
  * On 2026-09-04 drill 5 hit the cap at tick 5 of 40 and then polled a blind agent for the
  * remaining 35 ticks — 17.5 minutes — before failing with "vote:commit: not satisfied after 40
@@ -154,6 +157,11 @@ export { classifyCallError };
  *
  * Pure, and in lib.mjs rather than in the drill, because the drill executes at import and so
  * anything defined there cannot be tested.
+ *
+ * The NAME is narrower than the predicate — it also fires below exhaustion, on the
+ * cannot-fund-one-more case above. Kept because renaming it touches sixteen occurrences across
+ * this file, drill5-agent-execute.mjs and soak-drills.test.mjs, which is a different change from
+ * this one; the JSDoc and the message it returns both state the wider rule.
  *
  * @param {{enabled:boolean,spentUsdc:string,capUsdc:string,remainingUsdc:string,paidReads:number}|undefined} spend
  * @param {number} tick 1-based tick just completed
@@ -170,15 +178,24 @@ export function budgetExhaustedFailure(spend, tick, maxTicks, label) {
   // the misleading failure this function exists to replace; the 2026-09-04 run landed on exactly
   // zero only because its reads happened to divide the cap evenly.
   //
-  // The average price paid so far is the best floor available from `summary()` — it exposes no
-  // per-read price — and it is the right shape: if what remains cannot buy an average read, the
-  // next perception is already refused.
+  // THE THRESHOLD IS A MEAN, NOT A BOUND. `summary()` exposes no per-read price, so the only
+  // price this can compute is `spentUsdc / paidReads` — the average of the reads already paid
+  // for. An average is not a floor on the next read's price, and it is wrong in both directions:
+  // if the next read is cheaper than the mean, this aborts a run that could still have perceived;
+  // if it is dearer and `remaining >= avgRead`, this keeps polling an agent that is already
+  // blind. Erring toward the early abort is the deliberate choice, because that direction names
+  // the cause, while waiting produces the governance-shaped failure this function exists to
+  // replace.
   const remaining = Number(spend.remainingUsdc);
   const avgRead = spend.paidReads > 0 ? Number(spend.spentUsdc) / spend.paidReads : 0;
   if (remaining > 0 && !(avgRead > 0 && remaining < avgRead)) return null;
 
   const perTick = Number(spend.spentUsdc) / Math.max(tick, 1);
-  return `${label}: the agent exhausted its x402 session spend cap at tick ${tick}/${maxTicks} `
+  // "can no longer fund" rather than "exhausted": this fires on a zero remainder AND on a
+  // positive remainder too small to buy one average read, and only the first of those is
+  // exhaustion. The parenthetical prints the remainder, so the operator sees which case it is.
+  return `${label}: the agent can no longer fund an x402 read from its session spend cap at `
+    + `tick ${tick}/${maxTicks} `
     + `($${spend.spentUsdc} of $${spend.capUsdc} spent, $${spend.remainingUsdc} left, `
     + `${spend.paidReads} paid reads averaging $${avgRead.toFixed(3)}). It perceives through `
     + `paid reads, so from here it is BLIND and no further tick can satisfy the goal — this is a `
@@ -386,18 +403,34 @@ export const PTYPE = { Rebalance: 0, RuleChange: 1, ChildAllocation: 2 };
  * "vote:commit: not satisfied after 40 ticks", a GOVERNANCE-shaped message for a
  * NO-VOTABLE-PROPOSAL cause. The guard was not too weak; it asked the wrong question.
  *
- * Four conjuncts, and the fourth is not theoretical: proposal 3 was raised BEFORE the agent
- * activated, so the agent's snapshot weight reads zero and `commitVote` would revert `NoWeight`.
- * A predicate that checked only status and deadline would attach to it and reproduce the same
- * forty-tick stall wearing a different costume.
+ * Five conjuncts, and the last two are not theoretical: proposal 3 was raised BEFORE the agent
+ * activated, so the agent's snapshot weight reads zero and `commitVote` would revert `NoWeight`;
+ * and drill 5 queues an exit in its own next phase, so a re-run reaches a state where the
+ * snapshot weight is positive and the CURRENT weight is zero. A predicate that checked only
+ * status and deadline would attach to either and reproduce the same forty-tick stall wearing a
+ * different costume.
  *
  * Pure so it can be tested: the drill executes at import, so a predicate defined there could not be.
  *
+ * BOTH WEIGHT TERMS, TESTED SEPARATELY. `commitVote` (Governance.sol:365) gates on
+ * `_boundedWeight` (Governance.sol:352-356), which is `min(pastVotingEligibleShares(member,
+ * createdAt-1), votingEligibleShares(member))`. For the verdict, "either term is zero" and
+ * "the minimum is zero" are the same test — but they are not the same EXPLANATION, so the two
+ * terms are taken as separate arguments and checked one at a time. A voter who has queued an
+ * exit has snapshot weight and zero current weight, because `votingEligibleShares` is
+ * `sharesOf - queuedExitShares` (VaultCore.sol:1025-1028); handed only the already-minimised
+ * weight, this function cannot tell that apart from "the proposal predates this account" and
+ * would state the wrong cause with full confidence. `currentWeight` is REQUIRED, not defaulted:
+ * a caller that omits it gets a refusal naming the missing input, never a silent fallback to the
+ * snapshot-only story.
+ *
  * @param {{status: string, ptype: number, commitDeadline: number}} p a `readProposal` result
- * @param {{now: number, snapshotWeight: bigint, wantPtype?: number}} ctx
+ * @param {{now: number, snapshotWeight: bigint, currentWeight: bigint, wantPtype?: number}} ctx
+ *   `snapshotWeight` is `pastVotingEligibleShares(voter, createdAt-1)` and `currentWeight` is
+ *   `votingEligibleShares(voter)` — the two terms unbounded, not their minimum.
  * @returns {{votable: boolean, reason: string}} reason is '' when votable
  */
-export function votableNow(p, { now, snapshotWeight, wantPtype }) {
+export function votableNow(p, { now, snapshotWeight, currentWeight, wantPtype }) {
   if (!p) return { votable: false, reason: 'no proposal was read' };
   if (p.status !== 'Active') {
     return { votable: false, reason: `status is ${p.status}, not Active — activeProposalOf still names it because Governance never clears that mapping on settlement` };
@@ -409,15 +442,33 @@ export function votableNow(p, { now, snapshotWeight, wantPtype }) {
   if (wantPtype != null && p.ptype !== wantPtype) {
     return { votable: false, reason: `ptype is ${p.ptype}, not the expected ${wantPtype}` };
   }
+  if (currentWeight == null) {
+    return { votable: false, reason: 'currentWeight was not supplied — commitVote gates on min(snapshot, current) (Governance.sol:352-356, :365), so a snapshot-only answer cannot be given' };
+  }
   if (snapshotWeight <= 0n) {
     return { votable: false, reason: 'the voter had zero voting-eligible stake at the proposal\'s snapshot — it was raised before this account held shares, so commitVote would revert NoWeight' };
+  }
+  if (currentWeight <= 0n) {
+    return { votable: false, reason: `the voter holds no voting-eligible shares NOW (snapshot weight ${snapshotWeight}, current ${currentWeight}) — votingEligibleShares is sharesOf minus queuedExitShares (VaultCore.sol:1025-1028), so a queued exit zeroes it, and commitVote gates on min(snapshot, current) (Governance.sol:352-356) and would revert NoWeight` };
   }
   return { votable: true, reason: '' };
 }
 
-/** Read a proposal into a named object. */
-export function readProposal(governance, pid) {
-  const p = call(governance, PROPOSAL_SIG, pid);
+/**
+ * Decode one `proposals(uint256)` tuple into a named object. Pure — no chain, no `cast`.
+ *
+ * SPLIT OUT OF `readProposal` SO IT CAN BE TESTED. `readProposal` reaches the chain through
+ * `call()`, i.e. a live `cast` subprocess, so nothing in the suite could reach this arithmetic:
+ * `status` is `STATUS[Number(p[P.STATUS])]`, and `votableNow` compares that string against
+ * `'Active'`. Respell an entry in `STATUS`, or shift one index in `P`, and `votableNow` rejects
+ * every proposal for a reason it states confidently and wrongly, while the whole suite stays
+ * green — the same silent-failure shape PR #177 closed for the budget guard (issue #178).
+ *
+ * @param {string[]} p one decoded `cast call` output line per tuple member, in `P` order —
+ *   exactly what `call()` returns (its `.map(clean)` has already run)
+ * @returns {object} the named proposal, with `raw` carrying the input lines unchanged
+ */
+export function decodeProposal(p) {
   return {
     raw: p,
     vault: p[P.VAULT], ptype: Number(p[P.PTYPE]), proposer: p[P.PROPOSER],
@@ -430,6 +481,11 @@ export function readProposal(governance, pid) {
     revealedWeight: BigInt(p[P.REVEALED_WEIGHT]),
     revealedVoterCount: Number(p[P.REVEALED_VOTER_COUNT]),
   };
+}
+
+/** Read a proposal into a named object. The decode is `decodeProposal`; this adds only the call. */
+export function readProposal(governance, pid) {
+  return decodeProposal(call(governance, PROPOSAL_SIG, pid));
 }
 
 /** Event topics, computed from the Solidity signatures rather than hardcoded. */

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -1063,11 +1063,29 @@ test('votableNow refuses rather than guesses when currentWeight is not supplied'
   assert.match(r.reason, /currentWeight was not supplied/, 'name the missing input, not a symptom');
 });
 
+test('votableNow refuses on a missing snapshotWeight too, rather than falling through it', () => {
+  // THE SAME FAIL-CLOSED RULE, APPLIED TO THE FIRST TERM. `undefined <= 0n` is `false`, so before
+  // the null check covered both terms an omitted `snapshotWeight` skipped its own branch and the
+  // predicate answered "votable" on an input it had never been given — fail OPEN on one term while
+  // the other failed closed, three lines apart. Nothing in the suite caught it: every case above
+  // either supplies both terms or omits `currentWeight`, so no test ever reached this path.
+  const p = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 };
+  const r = votableNow(p, { now: 100, currentWeight: 5n });
+  assert.equal(r.votable, false, 'an unanswerable question must not be answered "yes"');
+  assert.match(r.reason, /snapshotWeight was not supplied/, 'name the term that is missing, not the other one');
+  assert.doesNotMatch(r.reason, /currentWeight was not supplied/, 'currentWeight WAS supplied — naming it sends the reader to the wrong caller');
+
+  // And with neither term, the refusal names both rather than picking one.
+  const neither = votableNow(p, { now: 100 });
+  assert.equal(neither.votable, false);
+  assert.match(neither.reason, /snapshotWeight and currentWeight were not supplied/);
+});
+
 // ───────── decodeProposal: the impure step that feeds votableNow (issue #178) ─────────
 //
 // Every votableNow case above hands the predicate a hand-built literal. In production its
 // argument is a `readProposal` result, and `readProposal` derives `status` from
-// `STATUS[Number(p[P.STATUS])]` (lib.mjs:473) after a live `cast` subprocess — so nothing in this
+// `STATUS[Number(p[P.STATUS])]` (lib.mjs:483) after a live `cast` subprocess — so nothing in this
 // file could reach that lookup. Respell an entry in STATUS and votableNow states a confident,
 // wrong reason on every proposal while the suite stays green: the same silent failure the budget
 // guard had before PR #177.
@@ -1180,10 +1198,17 @@ test('decodeProposal produces the exact Active string votableNow compares agains
   );
 });
 
-test('the P index map still matches the arity and order of PROPOSAL_SIG', () => {
+test('the P index map still matches the arity of PROPOSAL_SIG and uses each index exactly once', () => {
   // A fixture is only evidence if it has the shape the signature returns. `cast call` prints one
   // line per return value, so the tuple length and the highest index in `P` must agree with the
   // signature `readProposal` actually sends.
+  //
+  // ORDER IS NOT ASSERTED HERE, and the name no longer says it is: `PROPOSAL_SIG` is parsed for
+  // its comma count only, so swapping two entries in `P` leaves every assertion below green. The
+  // order pin is the sibling test above — `decodeProposal maps every tuple index to its named
+  // field` — which reds on exactly that swap because the fixture's sixteen values are distinct.
+  // A positional type check could not replace it anyway: the signature has five `uint64`s and six
+  // `uint256`s, so same-typed neighbours are indistinguishable from the type list.
   const returns = /\)\(([^)]*)\)$/.exec(PROPOSAL_SIG);
   assert.ok(returns, 'PROPOSAL_SIG must still declare a return tuple');
   const arity = returns[1].split(',').length;
@@ -1211,7 +1236,7 @@ test('the two seams the fixture cannot execute are pinned as source text instead
   const drill5 = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'drill5-agent-execute.mjs'), 'utf8');
   assert.match(drill5, /votableNow\(prop, \{ now: chainNow\(\), snapshotWeight: snap, currentWeight: cur \}\)/,
     'drill 5 must pass BOTH terms unbounded — handing it the min again restores the wrong-cause message');
-  assert.match(drill5, /const snapshotWeight = snap < cur \? snap : cur;/,
+  assert.match(drill5, /const boundedWeight = snap < cur \? snap : cur;/,
     'the local min is still what the diagnostic line prints as boundedWeight');
 });
 

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -979,7 +979,7 @@ test('votableNow rejects a settled proposal that activeProposalOf still names', 
   // the drill blamed governance 20 minutes later.
   const r = votableNow(
     { status: 'Executed', ptype: 0, createdAt: 1788479808, commitDeadline: 1788483408 },
-    { now: 1788534622, snapshotWeight: 0n },
+    { now: 1788534622, snapshotWeight: 0n, currentWeight: 0n },
   );
   assert.equal(r.votable, false);
   assert.match(r.reason, /status is Executed/);
@@ -989,7 +989,7 @@ test('votableNow rejects a settled proposal that activeProposalOf still names', 
 test('votableNow rejects an Active proposal whose commit window has closed', () => {
   const r = votableNow(
     { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 1000 },
-    { now: 1600, snapshotWeight: 5n },
+    { now: 1600, snapshotWeight: 5n, currentWeight: 5n },
   );
   assert.equal(r.votable, false);
   assert.match(r.reason, /commit window closed 600s ago/, 'say how stale, not just that it is stale');
@@ -999,9 +999,13 @@ test('votableNow rejects a proposal raised before the voter held shares', () => 
   // The conjunct a status+deadline check would miss. Proposal 3 was raised before the agent
   // activated, so its snapshot weight is zero and commitVote reverts NoWeight — attaching to it
   // reproduces the same 40-tick stall in a different costume.
+  //
+  // `currentWeight: 5n` is the faithful shape of that account: it holds shares NOW, it just did
+  // not hold them at `createdAt - 1`. It also proves the snapshot branch is reached on its own
+  // merits rather than by a healthy current weight being absent.
   const r = votableNow(
     { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 },
-    { now: 100, snapshotWeight: 0n },
+    { now: 100, snapshotWeight: 0n, currentWeight: 5n },
   );
   assert.equal(r.votable, false);
   assert.match(r.reason, /zero voting-eligible stake/);
@@ -1010,13 +1014,13 @@ test('votableNow rejects a proposal raised before the voter held shares', () => 
 
 test('votableNow accepts a genuinely votable round, and only then', () => {
   const good = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 };
-  assert.deepEqual(votableNow(good, { now: 100, snapshotWeight: 1n }), { votable: true, reason: '' });
+  assert.deepEqual(votableNow(good, { now: 100, snapshotWeight: 1n, currentWeight: 1n }), { votable: true, reason: '' });
   // and the ptype filter is opt-in, so it cannot silently reject when unused
-  assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 0 }).votable, true);
-  const wrongType = votableNow(good, { now: 100, snapshotWeight: 1n, wantPtype: 3 });
+  assert.equal(votableNow(good, { now: 100, snapshotWeight: 1n, currentWeight: 1n, wantPtype: 0 }).votable, true);
+  const wrongType = votableNow(good, { now: 100, snapshotWeight: 1n, currentWeight: 1n, wantPtype: 3 });
   assert.equal(wrongType.votable, false);
   assert.match(wrongType.reason, /ptype is 0, not the expected 3/, 'the ptype reason must be asserted too, or it can be emptied unnoticed');
-  assert.equal(votableNow(null, { now: 100, snapshotWeight: 1n }).votable, false);
+  assert.equal(votableNow(null, { now: 100, snapshotWeight: 1n, currentWeight: 1n }).votable, false);
 });
 
 test('votableNow rejects at the EXACT commit deadline, matching commitVote', () => {
@@ -1024,8 +1028,191 @@ test('votableNow rejects at the EXACT commit deadline, matching commitVote', () 
   // Unpinned, `>=` could be relaxed to `>` and the suite would stay green while the drill
   // attached to a round one second past its window.
   const p = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 1000 };
-  assert.equal(votableNow(p, { now: 1000, snapshotWeight: 5n }).votable, false, 'now === deadline is CLOSED');
-  assert.equal(votableNow(p, { now: 999, snapshotWeight: 5n }).votable, true, 'one second earlier is open');
+  assert.equal(votableNow(p, { now: 1000, snapshotWeight: 5n, currentWeight: 5n }).votable, false, 'now === deadline is CLOSED');
+  assert.equal(votableNow(p, { now: 999, snapshotWeight: 5n, currentWeight: 5n }).votable, true, 'one second earlier is open');
+});
+
+test('votableNow names the QUEUED EXIT, not the snapshot, when only the current weight is zero', () => {
+  // The two zero-weight causes are opposite in time and the message used to state only one of
+  // them. `commitVote` gates on `_boundedWeight` (Governance.sol:365 -> :352-356), which is
+  // min(snapshot, current); handed only that minimum, this predicate saw `0` and blamed the
+  // proposal for predating the account. A voter who has queued an exit is the reverse case:
+  // `votingEligibleShares` is `sharesOf - queuedExitShares` (VaultCore.sol:1025-1028), so the
+  // snapshot is positive and the CURRENT term is what went to zero. Drill 5 queues an exit in its
+  // own next phase (drill5-agent-execute.mjs), so a re-run reaches this exact state, and an
+  // operator told "raised before this account held shares" would go looking at the wrong end of
+  // the timeline.
+  const p = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 };
+  const r = votableNow(p, { now: 100, snapshotWeight: 7n, currentWeight: 0n });
+  assert.equal(r.votable, false, 'min(7, 0) is 0, so commitVote would revert NoWeight');
+  assert.match(r.reason, /no voting-eligible shares NOW/, 'the cause is present-tense, not the snapshot');
+  assert.match(r.reason, /queuedExitShares/, 'name the mechanism that zeroed it');
+  assert.match(r.reason, /snapshot weight 7, current 0/, 'print both terms, or the operator cannot see which one is zero');
+  assert.doesNotMatch(r.reason, /raised before this account held shares/,
+    'the snapshot story is FALSE here — snapshot weight is 7');
+});
+
+test('votableNow refuses rather than guesses when currentWeight is not supplied', () => {
+  // FAIL CLOSED ON A MISSING INPUT. Defaulting the second term — to the snapshot, or to infinity —
+  // would hand a future caller the exact wrong-cause message this pair of branches exists to
+  // prevent, and nothing would go red. That is the shape of the inert SOAK_VAULTS leg: a guard
+  // wired to an input nobody supplies reads identically to a guard with nothing to report.
+  const p = { status: 'Active', ptype: 0, createdAt: 1, commitDeadline: 9999 };
+  const r = votableNow(p, { now: 100, snapshotWeight: 5n });
+  assert.equal(r.votable, false, 'an unanswerable question must not be answered "yes"');
+  assert.match(r.reason, /currentWeight was not supplied/, 'name the missing input, not a symptom');
+});
+
+// ───────── decodeProposal: the impure step that feeds votableNow (issue #178) ─────────
+//
+// Every votableNow case above hands the predicate a hand-built literal. In production its
+// argument is a `readProposal` result, and `readProposal` derives `status` from
+// `STATUS[Number(p[P.STATUS])]` (lib.mjs:473) after a live `cast` subprocess — so nothing in this
+// file could reach that lookup. Respell an entry in STATUS and votableNow states a confident,
+// wrong reason on every proposal while the suite stays green: the same silent failure the budget
+// guard had before PR #177.
+//
+// `decodeProposal` is the pure half, split out of `readProposal` for exactly this. The two
+// fixtures below are its input.
+//
+// PROVENANCE, stated precisely because a fixture that claims to be captured and is not is worse
+// than no fixture. NEITHER TUPLE WAS CAPTURED FROM A CHAIN OR A LOG. `PROPOSAL_3_EXECUTED` is
+// CONSTRUCTED around the four values this file already pins for the smoke vault's proposal 3 —
+// createdAt 1788479808, commitDeadline 1788483408 and status Executed from the regression test
+// above, and ptype 2 (ChildAllocation) from that test's own comment, which is a comment and not a
+// chain read. The `vault` field is soak-vaults.json's `smokeVault.address`. The remaining ELEVEN
+// fields, revealDeadline included, are synthetic: chosen only so that all sixteen decoded values
+// are pairwise distinct, which is what makes an index shift in `P` change an asserted value
+// instead of swapping two equal ones.
+
+import { decodeProposal, STATUS, P, PROPOSAL_SIG } from '../soak/lib.mjs';
+
+/** One cleaned `cast call` output line per tuple member, in `P` order — what `call()` returns. */
+const PROPOSAL_3_EXECUTED = [
+  '0xb940d71b0d695e2ba2b5853bf565c69daa3e3c98',                         // 0 vault
+  '2',                                                                  // 1 ptype (ChildAllocation)
+  '0x00000000000000000000000000000000000000b2',                         // 2 proposer (synthetic)
+  '1788479808',                                                         // 3 createdAt
+  '1788483408',                                                         // 4 commitDeadline
+  '1788487008',                                                         // 5 revealDeadline (synthetic)
+  '1788487009',                                                         // 6 executableAt (synthetic)
+  '1788573408',                                                         // 7 expiresAt (synthetic)
+  '4',                                                                  // 8 status (Executed)
+  `0x${'ab'.repeat(32)}`,                                               // 9 actionHash (synthetic)
+  '7000000000000000000',                                                // 10 snapshotTotal (synthetic)
+  '5',                                                                  // 11 memberCount (synthetic)
+  '6000000000000000000',                                                // 12 forWeight (synthetic)
+  '1000000000000000000',                                                // 13 againstWeight (synthetic)
+  '8000000000000000000',                                                // 14 revealedWeight (synthetic)
+  '3',                                                                  // 15 revealedVoterCount (synthetic)
+];
+
+/** Wholly synthetic. Status byte 1, so it is the tuple that exercises `STATUS[1] === 'Active'`. */
+const PROPOSAL_ACTIVE = [
+  '0x00000000000000000000000000000000000000a1', '0',
+  '0x00000000000000000000000000000000000000b2',
+  '1000', '4600', '8200', '8201', '94600',
+  '1',
+  `0x${'11'.repeat(32)}`,
+  '9000', '4', '0', '0', '0', '0',
+];
+
+test('decodeProposal maps every tuple index to its named field, and no two land on the same one', () => {
+  const p = decodeProposal(PROPOSAL_3_EXECUTED);
+  assert.deepEqual(
+    {
+      vault: p.vault, ptype: p.ptype, proposer: p.proposer, createdAt: p.createdAt,
+      commitDeadline: p.commitDeadline, revealDeadline: p.revealDeadline,
+      executableAt: p.executableAt, expiresAt: p.expiresAt, status: p.status,
+      actionHash: p.actionHash, snapshotTotal: p.snapshotTotal, memberCount: p.memberCount,
+      forWeight: p.forWeight, againstWeight: p.againstWeight, revealedWeight: p.revealedWeight,
+      revealedVoterCount: p.revealedVoterCount,
+    },
+    {
+      vault: '0xb940d71b0d695e2ba2b5853bf565c69daa3e3c98',
+      ptype: 2,
+      proposer: '0x00000000000000000000000000000000000000b2',
+      createdAt: 1788479808,
+      commitDeadline: 1788483408,
+      revealDeadline: 1788487008,
+      executableAt: 1788487009,
+      expiresAt: 1788573408,
+      status: 'Executed',
+      actionHash: `0x${'ab'.repeat(32)}`,
+      snapshotTotal: 7000000000000000000n,
+      memberCount: 5,
+      forWeight: 6000000000000000000n,
+      againstWeight: 1000000000000000000n,
+      revealedWeight: 8000000000000000000n,
+      revealedVoterCount: 3,
+    },
+  );
+  // The numeric fields are Numbers and the weight fields BigInts; `deepEqual` above is strict
+  // about that, so a `Number`/`BigInt` swap in the decode is caught rather than coerced away.
+  assert.equal(p.raw, PROPOSAL_3_EXECUTED, 'raw must carry the input lines through unchanged');
+});
+
+test('decodeProposal feeds votableNow the Executed status that stalled the 2026-09-04 run', () => {
+  // END TO END ACROSS THE SEAM, which is the whole point of issue #178: the decoded object goes
+  // straight into the predicate, so `STATUS[4]` and `p.status !== 'Active'` are pinned to each
+  // other rather than each to a literal.
+  const p = decodeProposal(PROPOSAL_3_EXECUTED);
+  const r = votableNow(p, { now: 1788534622, snapshotWeight: 0n, currentWeight: 0n });
+  assert.equal(r.votable, false);
+  assert.match(r.reason, /status is Executed/,
+    'a respelt STATUS[4] would print "status is undefined" here');
+});
+
+test('decodeProposal produces the exact Active string votableNow compares against', () => {
+  // THE MUTATION ISSUE #178 DESCRIBES. `votableNow` tests `p.status !== 'Active'` against a string
+  // that only `STATUS` produces. Respell `STATUS[1]` — 'Active' -> 'Activ' — and every proposal
+  // becomes unvotable with the confident reason "status is Activ, not Active"; before this test
+  // the whole suite stayed green through that mutation, because no test ever produced a status
+  // string with the decoder.
+  assert.equal(STATUS[1], 'Active', 'the literal the predicate compares against, at its source');
+
+  const p = decodeProposal(PROPOSAL_ACTIVE);
+  assert.equal(p.status, 'Active');
+  assert.deepEqual(
+    votableNow(p, { now: 1200, snapshotWeight: 3n, currentWeight: 3n }),
+    { votable: true, reason: '' },
+    'a decoded Active proposal inside its commit window must be votable',
+  );
+});
+
+test('the P index map still matches the arity and order of PROPOSAL_SIG', () => {
+  // A fixture is only evidence if it has the shape the signature returns. `cast call` prints one
+  // line per return value, so the tuple length and the highest index in `P` must agree with the
+  // signature `readProposal` actually sends.
+  const returns = /\)\(([^)]*)\)$/.exec(PROPOSAL_SIG);
+  assert.ok(returns, 'PROPOSAL_SIG must still declare a return tuple');
+  const arity = returns[1].split(',').length;
+  assert.equal(arity, 16, 'proposals(uint256) returns sixteen values');
+  assert.equal(PROPOSAL_3_EXECUTED.length, arity, 'the fixture must be one line per return value');
+  assert.equal(PROPOSAL_ACTIVE.length, arity);
+  assert.equal(Math.max(...Object.values(P)), arity - 1, 'P must not index past the tuple');
+  assert.equal(new Set(Object.values(P)).size, arity, 'every index used exactly once');
+  assert.equal(new Set(PROPOSAL_3_EXECUTED).size, arity,
+    'the fixture values must be pairwise distinct, or an index swap decodes identically');
+});
+
+test('the two seams the fixture cannot execute are pinned as source text instead', () => {
+  // WHAT A FIXTURE CANNOT REACH. `readProposal` runs `cast` in a subprocess and drill 5 executes
+  // at import, so neither can be driven in-process. Mutation confirmed the gap is real: making
+  // `readProposal` drop the first output line before decoding, and making drill 5 pass its
+  // already-minimised weight again, each left all other tests in this file green. These are
+  // text-and-order pins over the source, the same instrument the run-soak.ps1 tests below use,
+  // and they catch the defect that actually happens here — an edit that re-introduces the
+  // pre-#178 shape in a file no test executes.
+  const lib = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'lib.mjs'), 'utf8');
+  assert.match(lib, /return decodeProposal\(call\(governance, PROPOSAL_SIG, pid\)\);/,
+    'readProposal must hand call()\'s lines to decodeProposal unaltered, or the fixture pins a decoder nothing uses');
+
+  const drill5 = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'drill5-agent-execute.mjs'), 'utf8');
+  assert.match(drill5, /votableNow\(prop, \{ now: chainNow\(\), snapshotWeight: snap, currentWeight: cur \}\)/,
+    'drill 5 must pass BOTH terms unbounded — handing it the min again restores the wrong-cause message');
+  assert.match(drill5, /const snapshotWeight = snap < cur \? snap : cur;/,
+    'the local min is still what the diagnostic line prints as boundedWeight');
 });
 
 // ───────── the launcher wiring: run-soak.ps1 must actually start the companion ─────────


### PR DESCRIPTION
Closes #178, and fixes three message-accuracy defects in the same file. One PR because they are one file's correctness — `scripts/soak/lib.mjs` — plus its only `votableNow` call site and its tests.

## What changed

**1. #178 — the decode that feeds `votableNow` is now pinned.**

`votableNow` takes "a `readProposal` result", but all its tests handed it a hand-built literal. In production that object comes out of `readProposal`, whose `status` is `STATUS[Number(p[P.STATUS])]` — reached only through `call()`, i.e. a live `cast` subprocess. So respelling an entry in `STATUS`, or shifting one index in `P`, made `votableNow` reject every proposal with a confident and wrong reason, and the whole suite stayed green.

- The decode is now a pure `decodeProposal(lines)`; `readProposal` is `return decodeProposal(call(governance, PROPOSAL_SIG, pid));`.
- `cast` is invoked with byte-identical arguments. The returned object is unchanged field-for-field, `raw` included, so `drill2-subvault.mjs`, `drill3-modef.mjs`, `drill5-agent-execute.mjs` and `drill5-gov-companion.mjs` are untouched by it.
- Two fixtures drive it: an Executed tuple built around proposal 3's pinned values, and a wholly synthetic Active tuple. The Active one exists because proposal 3's status byte is 4 — respelling `STATUS[1]` cannot move a fixture that never decodes index 1, so a proposal-3-only fixture would have stayed green through the exact mutation #178 describes.

**2. `lib.mjs:168` (pre-change) called the average read price "the best floor available".** A mean is not a floor. `summary()` exposes no per-read price, so the mean is all this can compute — and it is wrong in both directions: a cheaper-than-mean next read aborts a run that could still perceive; a dearer one with `remaining >= avgRead` keeps polling an agent that is already blind. The comment now says that, and says the early abort is the deliberate direction because it names the cause while waiting produces the governance-shaped failure the function exists to replace. (Flagged by the reviewer on #177.)

**3. `lib.mjs:176` (pre-change) said the agent "exhausted its x402 session spend cap"** on a branch that also fires with a positive remainder too small for one average read — the branch #177 added a test for. It now reads "the agent can no longer fund an x402 read from its session spend cap at tick N/M". The JSDoc gained the same distinction, and a comment records that the *function name* is still narrower than the predicate (renaming it touches sixteen occurrences across three files — a different change).

**4. `votableNow`'s zero-weight reason stated the wrong cause for a queued-exit voter.** It hardcoded "at the proposal's snapshot / raised before this account held shares", but its argument was the BOUNDED weight `min(snapshot, current)` (drill 5 minimised before calling). A voter who has queued an exit has positive snapshot weight and zero current weight — `votingEligibleShares` is `sharesOf - queuedExitShares` (`VaultCore.sol:1025-1028`) — and was told the proposal predated their shares. `votableNow` now takes `snapshotWeight` and `currentWeight` unbounded and checks them separately, so the reason names which term is zero. Drill 5 passes `snapshotWeight: snap, currentWeight: cur` and keeps its local min for the `boundedWeight=` diagnostic.

`currentWeight` is **required**, not defaulted. Omitting it returns `votable:false` with a reason naming the missing input. A silent default would hand a future caller the exact wrong-cause message this change removes, and nothing would go red — the inert-`SOAK_VAULTS` shape.

## What was measured

In this worktree, `node --test --test-reporter=tap`:

| | before | after |
|---|---|---|
| `scripts/test/soak-drills.test.mjs` | 82 tests, 82 pass, 0 fail | **89 tests, 89 pass, 0 fail** |
| `scripts/test/soak-deployment.test.mjs` | 16 tests, 16 pass, 0 fail | **16 tests, 16 pass, 0 fail** |

`npm run test:backend` after: 1054 tests, 1052 pass, 2 skipped, 0 fail.
`npm run gate` after: **GATE PASSED (554.5s)**, one advisory warning (slither, which does not fail the gate).

## Mutation proof

Seven mutations applied one at a time, suite re-run, mutation reverted. Every one names the single test it turned red (the `STATUS[4]` case reds two, because both the index-map test and the end-to-end test read that entry):

| mutation | tests red |
|---|---|
| `STATUS[1]` `'Active'` → `'Activ'` | 1 — *decodeProposal produces the exact Active string votableNow compares against* |
| `STATUS[4]` `'Executed'` → `'Execute'` | 2 — *…maps every tuple index…* and *…feeds votableNow the Executed status…* |
| `P.COMMIT_DEADLINE`/`P.REVEAL_DEADLINE` swapped | 1 — *decodeProposal maps every tuple index to its named field* |
| `votableNow`'s `currentWeight <= 0n` branch disabled | 1 — *votableNow names the QUEUED EXIT, not the snapshot* |
| `currentWeight = snapshotWeight` default added | 1 — *votableNow refuses rather than guesses when currentWeight is not supplied* |
| `readProposal` drops the first output line before decoding | 1 — *the two seams the fixture cannot execute are pinned as source text* |
| drill 5 passes its already-minimised weight for both terms | 1 — same test |

The last two are why that source-text test exists: run against the fixture tests alone, **both left all 88 tests green**. `readProposal` shells out and drill 5 executes at import, so neither seam can be driven in-process; they are pinned as text-and-order assertions over the source, the instrument the `run-soak.ps1` tests in the same file already use.

## What I swept

The rule about fixing the shape rather than the instance in view. Three greps, results stated whether or not they found anything:

- **`grep -rn "STATUS\[\|Number(p\[" scripts/ packages/`** — two siblings decode a proposal status by enum index outside this file: `scripts/smoke-test.mjs:359` and `:416` (`STATUS[Number(p[P_STATUS])]`, the same unpinned shape) and `packages/reference-agent/src/chain.mjs:136` (`PROPOSAL_STATUS[n(at(8,'status'))] ?? 'Unknown'`, which at least fails to a named value). **Left alone deliberately** — each needs its own fixture and its own consumer analysis, and folding them in would make this three files' correctness instead of one. Worth a follow-up issue.
- **`grep -rni "floor" scripts/soak/`** — the only mean-described-as-a-bound was the one fixed here. The other hits are `Math.floor`, a real quorum floor (drill1, soak-vaults.json), and a real price floor (oracle-sampler.mjs:341).
- **`grep -rn "\.raw\b" scripts/ packages/`** — **no consumer reads `readProposal(...).raw`.** Kept anyway: dropping it would change the returned shape, which is not this change.

## What I could not verify

- **The fixtures are CONSTRUCTED, not captured.** No `cast` output for proposal 3 exists anywhere in the tree, and no soak state file carries it. The comment above them says so in those words. Of proposal 3's sixteen fields, five have in-repo provenance — `createdAt 1788479808`, `commitDeadline 1788483408` and status Executed from the regression test at `soak-drills.test.mjs:981`, ptype 2 from that test's own *comment* (a comment, not a chain read), and `vault` from `soak-vaults.json`'s `smokeVault.address`. The other eleven are synthetic, chosen only to be pairwise distinct so an index shift changes an asserted value.
- **The task brief listed `revealDeadline 1788487008` as encoded by the regression test. It is not.** That number appears nowhere in the repository; I grepped all three timestamps and got one hit total. It is in the fixture as a constructed value and is labelled as one.
- **The fixture starts *after* `clean` (lib.mjs:49).** Its lines are what `call()` returns, so `cast`'s ` [1.23e9]` scientific-notation annotations are not exercised. I could have written them in, but I cannot verify `cast`'s annotation threshold offline and a guessed fixture is worse than a narrow one. Annotation-stripping remains unpinned.
- **`readProposal` and drill 5's call site are pinned as source text, not behaviour** — see the mutation table. A regex is a weaker instrument than an execution; it is what these two seams admit.
- Nothing here was run against a chain. No key, no funded account, no `--broadcast`.

---

## Round 2 — rebased over #190, and the four review nits taken

Head `aa0e7011`. Everything above this line describes `504097ea` and is left as written; the corrections it needs are stated here rather than edited into it, so the reviewed text and its errata stay distinguishable.

### The rebase

Rebased onto `protocol/main` at `f2ee7ed2` (#190, then #194 and #189). **#190 touched the same two files this PR does**, so the merge matters:

- `scripts/soak/lib.mjs` — #190 replaced the hand-rolled `ROOT` with `fileURLToPath(import.meta.url)` (now `lib.mjs:24`, `:27-30`). That change **left this PR's diff** and is now base. The merged file carries both it and this PR's `decodeProposal` (`lib.mjs:476`), with no conflict.
- `scripts/test/soak-drills.test.mjs` — #190's space-path test (`:1398` at this head) is likewise base now, and it is why the suite total moved: **89 → 91**, one test absorbed from #190 and one added below.

The diff is still exactly the three files this PR set out to touch. Against the new base: `+309/−29`.

**Errata caused by the rebase, since #190 inserted five lines above the cited ones.** The commit message on `f39fcd56` says the two corrected strings were at `lib.mjs:168` and `lib.mjs:176` "before this change". Those offsets were against the old merge base `3c10ced8`. Against the current base they are **`lib.mjs:173`** ("the best floor available") and **`lib.mjs:181`** ("exhausted its x402 session spend cap"). The strings and the corrections are unchanged; only the line numbers moved, and the commit message cannot be amended without discarding the reviewed commit.

Similarly, the sweep section above cites `scripts/smoke-test.mjs:359` and `:416`. At this head those hits are at **`:360`** and **`:417`**. `scripts/smoke-test.mjs` is not touched by this PR.

### The four nits

**1 — the only behaviour change. `votableNow` failed OPEN on a missing `snapshotWeight`.** `undefined <= 0n` is `false`, so an omitted first term skipped its own branch and `votableNow(p, { now, currentWeight: 5n })` returned `{ votable: true, reason: '' }` for an input it was never given — fail-open, three lines from a branch that fails closed, in the function whose own test comment says "FAIL CLOSED ON A MISSING INPUT". The null check at **`lib.mjs:447`** now covers both terms and the refusal names whichever is missing, or both. New test at **`soak-drills.test.mjs:1066`**; the existing `currentWeight` refusal test and its assertion are untouched.

Every call site was read before the behaviour changed, as the reviewer asked. **One production caller** — `drill5-agent-execute.mjs:304` — and it passes both terms. The only call omitting a term is `soak-drills.test.mjs:1061`, which omits `currentWeight` deliberately to assert the refusal. No caller legitimately omits `snapshotWeight`.

**2 — the test name that overclaimed.** `soak-drills.test.mjs:1201` was "the arity **and order** of PROPOSAL_SIG" and asserted no order at all: `PROPOSAL_SIG` is parsed for its comma count only. Renamed to "the P index map still matches the arity of PROPOSAL_SIG and uses each index exactly once", with a comment naming the sibling test that *does* pin order (`decodeProposal maps every tuple index to its named field`, which reds on the reviewer's `COMMIT_DEADLINE`/`REVEAL_DEADLINE` swap) and recording why a positional type check cannot replace it — five `uint64`s and six `uint256`s, so same-typed neighbours are indistinguishable. **No assertion weakened or removed.**

**3 — one word, two meanings, three lines apart.** `drill5-agent-execute.mjs:302` called the bounded minimum `snapshotWeight`, two lines above the argument spelled `snapshotWeight:` that takes `snap`. The local is now `boundedWeight` — which is what the diagnostic at `:309` and the log at `:318` already printed it as — and the source-text pin at `soak-drills.test.mjs:1239` follows it.

**4 — the reason string that skipped a branch.** `lib.mjs:457` said `votingEligibleShares` "is `sharesOf` minus `queuedExitShares`". `VaultCore.sol:1026` returns 0 for the parent vault *before* the subtraction. It now reads "returns 0 for the parent vault and otherwise sharesOf minus queuedExitShares", citing **`VaultCore.sol:1026-1027`**, the two lines that are true.

Not swept, and why: `lib.mjs:421`, `drill5-agent-execute.mjs:282` and `soak-drills.test.mjs:1040` carry the same short form in **comments**, each scoped to a voter ("a voter who has queued an exit …"), where the parent-vault branch cannot apply. Only the runtime string stated it as a definition. This is a scoped decision, not a claim that the file is clean of the phrase.

**Also corrected:** `soak-drills.test.mjs:1088` cited `lib.mjs:473` for the `STATUS[Number(p[P.STATUS])]` lookup. The rebase and nit 1 both moved it; it is `lib.mjs:483` now.

**Nit 5** (`decodeProposal` is the third function of that name — `packages/canary/src/signals/governance-watch.mjs:103` and `packages/reference-agent/src/chain.mjs:121`) was information only. Confirmed, no change: different modules, no collision.

### Nit 6 — follow-up filed

**#198** — *Pin the two remaining proposal-status decodes: smoke-test.mjs:360/:417 and reference-agent chain.mjs:136.* Line numbers stated in the issue as of `protocol/main` at filing time; neither file is touched by this PR.

### Verification at `aa0e7011`

| suite | result |
|---|---|
| `scripts/test/soak-drills.test.mjs` | **91 tests, 91 pass, 0 fail, 0 skipped** |
| `scripts/test/soak-deployment.test.mjs` | **16 tests, 16 pass, 0 fail, 0 skipped** |
| `scripts/test/*.test.mjs` | **223 tests, 222 pass, 0 fail, 1 skipped** |
| `npm run test:backend` | **1056 tests, 1054 pass, 0 fail, 2 skipped** |

`node --check` clean on all three changed files. `npm run gate` **not run**: it invokes `forge`, `~/.foundry` is shared across sessions on this machine and deadlocks, and this change touches no Solidity and no build config.

The reviewer's four `contracts-size-truth` failures did **not** reproduce here and are not expected to: they were an artifact of reviewing from a `git archive`, which carries no `contracts/out`. This worktree has `contracts/out`, so those tests ran and passed.

### Mutations — four, each applied alone, run, and restored by file copy, with the working tree confirmed clean afterwards

| mutation | expected | observed |
|---|---|---|
| revert `lib.mjs:447` to `if (currentWeight == null)` | 1 red | **1** — 90 pass / 1 fail: *votableNow refuses on a missing snapshotWeight too, rather than falling through it* |
| misname the missing term: the ternary's single-`snapshotWeight` arm returns `currentWeight was` | 1 red | **1** — 90 pass / 1 fail: same test, on its `doesNotMatch` assertion |
| drill 5 passes `boundedWeight` for both terms | 1 red | **1** — 90 pass / 1 fail: *the two seams the fixture cannot execute are pinned as source text instead* |
| rename drill 5's local back to `snapshotWeight` | 1 red | **1** — same test, so the renamed pin still bites rather than having gone inert |

The first two are the new test failing without each half of its fix — the widened null check, and the ternary that names which term is missing rather than the other one. The last two are the round-1 source-text pin, re-proven live after the rename moved one of its two anchors.
