### PR TITLE
site(risks): r14 said none of it is deployed anywhere yet — scope it to mainnet

### DIFF
--- a/apps/site/risks.html
+++ b/apps/site/risks.html
@@ -230,7 +230,7 @@
         <span class="severity severity--accepted">Structural</span>
         <h2>14. This is experimental software</h2>
         <dl class="rows">
-          <div><dt>What it is</dt><dd>New contracts, a new governance mechanism, a new operator model, none of it battle-tested by time or volume, and none of it deployed anywhere yet.</dd></div>
+          <div><dt>What it is</dt><dd>New contracts, a new governance mechanism, a new operator model, none of it battle-tested by time or volume, and none of it deployed on mainnet.</dd></div>
           <div><dt>Worst case</dt><dd>Something nobody on this page thought of.</dd></div>
           <div><dt>What is done</dt><dd>The first vault's planned capacity cap is 50,000 USDC, a deliberate limit on how much any single unknown can destroy. It is a planned parameter of a vault that has not been created. That is a bound on the blast radius, not a defence. Do not deposit what you cannot afford to lose entirely.</dd></div>
         </dl>


### PR DESCRIPTION
One phrase on the live site is an unscoped absolute that the repository's own deployment record falsifies. Found by the claims reviewer of the redesign build, which inherits the sentence byte-identically.

`apps/site/risks.html:233` (risk r14, "new code") said: "New contracts, a new governance mechanism, a new operator model, none of it battle-tested by time or volume, and **none of it deployed anywhere yet**." `contracts/config/deployments/base-sepolia.json` records a live Base Sepolia deployment (deployBlock 46,307,173; factory `0xc1cb7824…9743`; smoke vault `0xb940d71b…3c98` created in block 46,307,218), and the same page's launch-status block says a deployment of the current code runs on the Base Sepolia testnet. The site's own convention everywhere else is to scope the absolute to mainnet ("Nothing is deployed to mainnet" on five pages). The phrase now reads "none of it deployed on mainnet", the scoping the other six pages already use. The sentence-scoped "deployed" guard passed before and after because the sentence contains "none"; it did not catch the falsehood, which is why a reviewer had to.

## Sweep
`grep -rn -i "deployed anywhere\|deployed nowhere\|not deployed at all\|none of it deployed\|nothing.*deployed anywhere" apps/site llms.txt README.md docs/*.md docs/vault` at head: the only hit was this one. No pushed ref carries a second copy: `apps/site-next` on origin is still the scaffold. The redesign build, unpushed in the session's build worktree, inherits the sentence and takes the corrected wording through its copy-sync before its PR opens.

## Guards
`apps/site/test/site.test.mjs` 36 / 36, `scripts/test/claims-lede-truth.test.mjs` 6 / 6, `scripts/test/config-doc-truth.test.mjs` 19 / 19, measured on the branch.

