### PR TITLE
docs(soak-report): the re-run is not blocked on a key — NOW.md says NOT BLOCKED; name what is outstanding

### DIFF
--- a/docs/SOAK-REPORT.md
+++ b/docs/SOAK-REPORT.md
@@ -9,7 +9,11 @@
 > meaning on a single-feed oracle, and its "testnet compromise" paragraph describes three
 > `ChainlinkSourceAdapter`s that are no longer deployed. The instrument was rewritten for the live
 > oracle on 2026-08-30; **launch gates 3 and 6 are re-earned by a re-run, not by this document.**
-> The re-run is blocked on a testnet key — see `docs/NOW.md` "Blocked on a human".
+> The re-run is **not blocked on a key**: `docs/NOW.md`'s soak entry records **NOT BLOCKED** — both
+> password files exist (`.soak.pw`, `.soak-agent.pw`), and `scripts/soak/run-soak.ps1`'s own header
+> says *"Nothing needs a human once the password files are in place."* What is outstanding is the
+> run itself — the five drills executing against the current deployment, with the canary observed
+> alongside; see the gate 3 and gate 6 rows of `docs/LAUNCH-READINESS.md`.
 
 **Date:** 2026-08-24 → 2026-08-25 · **Chain:** Base Sepolia (84532) · **Issue:** [#21](https://github.com/SlumperSan/agent-governed-vaults/issues/21)
 


### PR DESCRIPTION
Closes #192.

## What changed

One clause, `docs/SOAK-REPORT.md:12`. It read:

> The re-run is blocked on a testnet key — see `docs/NOW.md` "Blocked on a human".

That is an **absence claim**, and the entry it pointed at falsifies it. `docs/NOW.md:75` strikes
the same phrase through and records **NOT BLOCKED**. Replaced with a sentence whose every clause
has a source:

| Clause | Source, verified by reading |
| --- | --- |
| "`docs/NOW.md`'s soak entry records **NOT BLOCKED**" | `docs/NOW.md:75` — `~~**Soak + canary re-run** (needs a funded testnet key)~~ — **NOT BLOCKED.**` |
| "both password files exist (`.soak.pw`, `.soak-agent.pw`)" | `docs/NOW.md:76` |
| the `run-soak.ps1` header quote | `scripts/soak/run-soak.ps1:13` — *"Nothing needs a human once the password files are in place."* |
| "the five drills executing against the current deployment" | `docs/LAUNCH-READINESS.md:109` — "what closes this row is five drills executing against the current deployment and producing evidence" |
| "with the canary observed alongside" | `docs/LAUNCH-READINESS.md:112` — "it closes when the canary actually runs against the current deployment alongside the gate-3 soak" |

The launcher quote is conditional, so it is stated **with its antecedent** — the password-file
existence clause — rather than as a bare consequent. "Current deployment" is left unqualified
because lines 3–11 of the same blockquote already establish the retired-vs-current distinction.
No claim is made about who holds anything, or about where any runbook lives.

The `docs/NOW.md` pointer is dropped because the new sentence names its sources inline.

## Correction to the issue's premise

#192 says the "Blocked on a human" section name has since changed. **It has not** — at the base
commit `f2ee7ed2`, `docs/NOW.md:48` is still `## Blocked on a human`. What was false at `:12` was
the *blocked* clause, not the pointer. Stated so the deviation from the issue reads as deliberate.

## Sweep

Two passes over every `.md`, `.html` and `.txt` **in this worktree at base `f2ee7ed2`** (not the
shared checkout, whose HEAD `422f1d23` predates #189 and still carries hits that base does not).
`node_modules`, build output and `.claude/` excluded. Both `./llms.txt` and `./apps/site/llms.txt`
exist and are inside the walk (`--include=*.txt`); neither matches.

- Pass 1: `blocked on a testnet key|needs a testnet key|needs testnet key|testnet key|funded key|funded testnet key`
- Pass 2, because pass 1 misses the bare-noun form: `blocked on (a|the) key|needs? (only )?(a|the) key|need (a|the) key`

Every hit below was re-read with `grep -noE` context, so the matching phrase itself was seen — no
classification rests on truncated output. **One hit is an absence claim and it is the one fixed.**

| Hit | Matched phrase | Classification |
| --- | --- | --- |
| `docs/SOAK-REPORT.md:12` | *(was)* "blocked on a testnet key" | **ABSENCE claim, falsified by `docs/NOW.md:75` — FIXED here** |
| `README.md:37` | "Both need a funded testnet key and a…" | Requirement statement. Classified true by #189; not re-litigated |
| `docs/DEPLOYMENT.md:245` | "soak + canary, which need a funded testnet key" | Requirement statement. #189; not re-litigated |
| `docs/INCIDENTS.md:41` | "gates 3/6, which need a funded testnet key" | Requirement statement. #189; not re-litigated |
| `docs/LAUNCH-READINESS.md:13` | "The re-runs are unblocked and need only a funded key" | Requirement statement, and already says **unblocked**. #189; not re-litigated |
| `docs/LAUNCH-READINESS.md:109` | "(needs testnet key)" and "It is unblocked and needs only the owner's funded key" | Requirement statement. #189; not re-litigated |
| `docs/LAUNCH-READINESS.md:112` | "(needs testnet key)" | Requirement statement, **same cell shape and wording as `:109`**, which #189 kept. Extended by analogy; listed, not touched |
| `docs/LAUNCH-READINESS.md:337` | "Unblocked — needs only the key." | Requirement statement, already says **unblocked**. Same shape as `:109`; listed, not touched |
| `docs/audit/walkthroughs/AggregationRouterAdapter.md:80` | "still STALE and needs the owner's funded key" | Requirement statement, same shape as `:109`. Listed, not touched |
| `docs/TESTNET-CHECKLIST.md:184` | "require a second funded key against the same" | **Out of family** — a *second* key for two-party drills, a different requirement from gate 3/6's |
| `docs/TESTNET-REPORT.md:727` | "both need a second funded key" | **Out of family**, same second-key requirement |
| `docs/X402-LIVE-REPORT.md:281` | "requires a funded keystore; spends testnet USDC + gas" | **Out of family** — a keystore note on an x402 code snippet, unrelated to the soak gates |
| `docs/NOW.md:51` | *"needs a key"* had become a habit rather than a fact | **Not a claim** — the meta-lesson sentence that records this very defect |

**`docs/vault/*` carries no hit at base.** The shared checkout has six (`HOME.md:10`,
`current-state.md:34`, `launch-readiness-gates.md:19`/`:51`, `open-items.md:7`,
`security-index.md:20`), which is why an earlier draft of this table listed them; they are absent
from `f2ee7ed2` because #189 rewrote those pages. Recorded so a reviewer grepping an older tree
knows why the lists differ.

**In-file sweep of `docs/SOAK-REPORT.md`** for siblings of the fixed shape (`blocked|human|key`):
`:46`, `:47`, `:48`, `:181`, `:182`, `:269` are key-*handling* prose (keystore, `--password-file`,
"no script in this soak reads, stores, or prompts for a key"); `:288` is Mode-F "blocked-settle";
`:200` is neither — it contrasts a scripted human operator with an unaided agent. None is an
availability claim. Zero remaining.

## Measured

Both guards walk `docs/`, and both resolve their repo root from their own file location
(`scripts/test/../..` — `claims-lede-truth.test.mjs:131`, `config-doc-truth.test.mjs:37`), so they
walked this worktree and not the shared checkout.

- `node --test --test-reporter=tap scripts/test/claims-lede-truth.test.mjs` → **# tests 6, # pass 6, # fail 0**
- `node --test --test-reporter=tap scripts/test/config-doc-truth.test.mjs` → **# tests 19, # pass 19, # fail 0**

**No new test, stated rather than left as a mutation-proof-shaped hole.** This is a one-clause docs
change; the two guards are pre-existing and were run as regression. I did prove the guard's walk is
not inert on this file: appending `The operator has no on-chain authority over a deployed vault.` to
`docs/SOAK-REPORT.md` turned exactly test 5 red — `not ok 5 - the operator's lack of power is
enumerated, never claimed as a universal`, naming `docs/SOAK-REPORT.md: "no on-chain authority"`,
`# pass 5 / # fail 1` — and restoring by file copy returned it to `# pass 6 / # fail 0` with
`git diff` showing only the intended five-line hunk.

No guard matches the "blocked on a key" absence shape — grepping `claims-lede-truth.test.mjs` for
`blocked|key|human` returns two unrelated hits (comments at `:19` and `:385`). That is why review
caught this and CI did not. I did **not** add a guard: #192 asks for one clause in its own PR so
#189 stays reviewable, and a shape-matcher for this family is a larger design question.

## What I could not verify

- **Nothing on-chain.** I ran no RPC and signed nothing, so I cannot independently confirm the
  deployer balance `docs/NOW.md:75` states. The new sentence deliberately does not repeat that
  figure or any possession claim; it cites the NOT BLOCKED verdict and the file-existence clause.
- **That the soak would in fact run unattended.** `scripts/soak/run-soak.ps1:13` is quoted as the
  launcher's own header, which is what it is — not as a tested outcome.
- **`npm run gate` and `forge` were not run** (the shared `~/.foundry` deadlocks across concurrent
  sessions); only the two named node suites were run.
