### PR TITLE
docs(reference-agent): five source comments still said the protocol was not deployed

### DIFF
--- a/docs/REFERENCE-AGENT.md
+++ b/docs/REFERENCE-AGENT.md
@@ -344,6 +344,14 @@ mode — join, a freeze-safety `cancelPending` detour, activate, commit, reveal,
 priced on its own, and settle, every phase with a transaction hash. See
 [SOAK-REPORT.md](SOAK-REPORT.md) §5.
 
+The same claim outlived this section in the source comments, which the claims guard cannot reach —
+it walks `.md`, `.html`, `.txt` and `.json`, not `.mjs`. Five sites across
+`fixtures/demo-chain.mjs`, `fixtures/seed-snapshot.mjs`, `src/chain.mjs` and `src/run.mjs` still
+said the protocol was not deployed; all five were corrected on 2026-09-04
+([#197](https://github.com/SlumperSan/agent-governed-vaults/issues/197)). The absence is now scoped
+to mainnet, where it is true: `contracts/config/deployments/` holds one record,
+[`base-sepolia.json`](../contracts/config/deployments/base-sepolia.json), and no mainnet one.
+
 **The live run is what makes the warning above stronger, not weaker.** It surfaced two launch-class
 bugs that no amount of mock testing had found: `requireProvenOperator: false` was inert, so no
 configuration could ever admit a zero-track-record operator; and execute-mode deposits set no ERC-20

--- a/packages/reference-agent/fixtures/demo-chain.mjs
+++ b/packages/reference-agent/fixtures/demo-chain.mjs
@@ -2,10 +2,13 @@
 /**
  * Demo scenario — three vaults chosen to exercise every branch of the policy in one pass.
  *
- * This is FIXTURE DATA, not live protocol state. The contracts are not deployed yet (issue #10,
- * `VaultFactory` over the EIP-170 cap), so there is no chain to read and no indexer with real
- * history. Rather than run the demo against an empty snapshot — which produces "0 vaults known"
- * and an incoherent narrative — the same events are folded through the REAL projection code
+ * This is FIXTURE DATA, not live protocol state. (Nothing is deployed to mainnet: the only record
+ * in `contracts/config/deployments/` is `base-sepolia.json`, a testnet trial.) But no deployment
+ * would retire this file. The scenario below needs three vaults holding a specific joint state at
+ * the same moment — an unattested `operatorId 0`, an operator whose realized net has gone
+ * negative, and a Rebalance proposal in its reveal phase against a commit THIS agent already made
+ * — and no live chain can be relied on to be holding that when a demo happens to run. So the same
+ * events are folded through the REAL projection code
  * (`seed-snapshot.mjs` → `packages/indexer/src/projections.mjs`) so the API serves them exactly as
  * it would serve real ones, and the chain half comes from the stub reader, which marks every value
  * it produces `[stub-chain]`.

--- a/packages/reference-agent/fixtures/seed-snapshot.mjs
+++ b/packages/reference-agent/fixtures/seed-snapshot.mjs
@@ -5,9 +5,12 @@
  *
  * `node packages/reference-agent/fixtures/seed-snapshot.mjs [path]`
  *
- * The protocol has no deployment (issue #10), so there is no chain for the indexer to read and no
- * real history for the API to serve. Rather than demo against an empty snapshot — which yields
- * "0 vaults" and a narrative about nothing — this folds synthetic events through the REAL
+ * Nothing is deployed to mainnet: the only record in `contracts/config/deployments/` is
+ * `base-sepolia.json`, a testnet trial. The events here are synthetic for a reason no deployment
+ * changes, though. The demo needs a specific joint state across three vaults at once — see
+ * `fixtures/demo-chain.mjs`, down to a reveal-phase proposal against a commit the demo agent
+ * itself made — and no live chain can be relied on to be holding that at demo time. So rather than
+ * serve whatever a real snapshot happened to contain, this folds synthetic events through the REAL
  * projection code (`packages/indexer/src/projections.mjs`) and writes them with the REAL store
  * (`store.mjs`, whose round-trip is already covered by the existing suite).
  *

--- a/packages/reference-agent/src/chain.mjs
+++ b/packages/reference-agent/src/chain.mjs
@@ -372,7 +372,8 @@ export function createChainReader({ client, rpcUrl, chainId = 84532, chainName =
 /**
  * A chain reader with no chain behind it. Used by the demo run and the tests: it answers from a
  * fixture and marks every value it produces so the narrative cannot be mistaken for live data.
- * The protocol has no deployment yet (issue #10, EIP-170), so the demo run uses this by default.
+ * The demo run uses this whenever no RPC is configured: `config.mjs` defaults `chain.rpcUrl` to
+ * null, and `run.mjs` builds the real reader only when that value is set.
  *
  * @param {Record<string, any>} fixture  vault ⇒ partial readVault result
  * @param {Record<string, any>} [govFixture]  vault ⇒ partial readGovernance result

--- a/packages/reference-agent/src/run.mjs
+++ b/packages/reference-agent/src/run.mjs
@@ -17,8 +17,9 @@
  * Flags:
  *   --api=<url>        metered API base URL          (default http://127.0.0.1:8402)
  *   --rpc=<url>        JSON-RPC endpoint for chain reads. Omitted ⇒ the STUB reader, whose values
- *                      are marked [stub-chain] in the narrative. The protocol has no deployment
- *                      yet (issue #10), so the stub is the default for the demo run.
+ *                      are marked [stub-chain] in the narrative. `config.mjs` defaults
+ *                      `chain.rpcUrl` to null, so the stub is what a demo run gets unless you
+ *                      pass one.
  *   --governance=<addr> --subvault-registry=<addr> --usdc=<addr> --chain-id=<n>
  *   --ticks=<n>        how many loop passes to run (default 1)
  *   --demo-wallet      generate a throwaway in-memory key, used as the x402 payer AND as the
@@ -119,8 +120,9 @@ async function main() {
   }
 
   // ── chain reader ───────────────────────────────────────────────────────────
-  // No RPC ⇒ the stub, loudly marked. The protocol is not deployed yet (docs/RUNTIME.md, #10), so
-  // the demo run cannot read a real chain and does not pretend to.
+  // No RPC ⇒ the stub, loudly marked. Nothing is deployed to mainnet; the one record in
+  // contracts/config/deployments/ is base-sepolia.json, a testnet trial. Without an --rpc there is
+  // no node to read at all, so the demo run answers from the fixture and does not pretend to.
   let chainReader;
   let entryMarks = {};
   if (config.chain.rpcUrl) {


### PR DESCRIPTION
Closes #197.

## What changed

Five source comments in `packages/reference-agent` asserted, as an unscoped absolute, that the
protocol is not deployed. All five cited [issue #10](https://github.com/SlumperSan/agent-governed-vaults/issues/10),
which is closed; one also cited `docs/RUNTIME.md`, which carries no such claim (a
`grep -niE "not deployed|no deployment|deployed yet" docs/RUNTIME.md` returns nothing).

| Site | Was | Now |
| --- | --- | --- |
| `packages/reference-agent/fixtures/demo-chain.mjs:5` | "The contracts are not deployed yet (issue #10, `VaultFactory` over the EIP-170 cap), so there is no chain to read and no indexer with real history" | mainnet scoping in parentheses; the reason the fixture exists is the joint state the scenario needs |
| `packages/reference-agent/fixtures/seed-snapshot.mjs:8` | "The protocol has no deployment (issue #10), so there is no chain for the indexer to read" | same |
| `packages/reference-agent/src/chain.mjs:375` | "The protocol has no deployment yet (issue #10, EIP-170), so the demo run uses this by default" | the real reason: `config.mjs:57` defaults `chain.rpcUrl` to null |
| `packages/reference-agent/src/run.mjs:20` | "The protocol has no deployment yet (issue #10), so the stub is the default" | same |
| `packages/reference-agent/src/run.mjs:122` | "The protocol is not deployed yet (docs/RUNTIME.md, #10)" | scoped to mainnet, plus the no-`--rpc` code path |

The issue names two of these. The other three are the same claim, in the same package, found by the
sweep the issue itself asks for. They are fixed together because leaving three false absolutes
standing is the defect this repository keeps re-learning.

## Why the consequents were rewritten too, not just the premises

Every one of these comments has the shape "absolute, so consequence". Mechanically inserting
"on mainnet" would have shipped a *new* false claim, because there **is** a chain to read now. So
each consequence was re-sourced, and deliberately re-sourced on something no deployment can change:

- **Why the fixtures exist.** Not vault scarcity - `contracts/config/deployments/base-sepolia.json`
  is a deployment record, not a census of Base Sepolia, and `VaultFactory` is permissionless
  (`scripts/soak/oracle-sampler.mjs:84` notes that drills 1 and 2 create their own vaults). The
  sourced reason is the scenario `fixtures/demo-chain.mjs` enumerates in its own docblock: three
  vaults holding a joint state at the same moment - an unattested `operatorId 0`, an operator whose
  realized net has gone negative, and a Rebalance proposal in its reveal phase **against a commit
  this agent already made**. No live chain can be relied on to be holding that when a demo happens
  to run.
- **Why the stub is the default.** `packages/reference-agent/src/config.mjs:57` sets
  `chain.rpcUrl: null`, and `packages/reference-agent/src/run.mjs:128` reads
  `if (config.chain.rpcUrl) { ... } else { stub }`. That is a code path, not a deployment fact, and
  it was true before the deployment and stays true after it.

## Source for "nothing is deployed to mainnet"

Not taken from `apps/site` (the CLAIMS rule forbids establishing a claim by paraphrasing another
document that says it). `contracts/config/deployments/` contains a single file, `base-sepolia.json`.
There is no mainnet deployment record. `contracts/config/base-mainnet.json` is a pre-deploy
*config*, not a deployment record - its own `status` field calls the deferred multi-source path
"NOT-DEPLOYABLE". `docs/NOW.md:21` states "Launch is NO-GO".

## Doc update

`docs/REFERENCE-AGENT.md` section 7 already recorded the doc's own prior version of this claim as
false. One paragraph is added after it: the source comments carried the same claim, five of them,
corrected 2026-09-04, and why the claims guard could not have caught them.

## Sweep and classification

`grep -rniE "not deployed|deployed yet|no deployment|not live|before launch|pre-launch|prelaunch|not been deployed|undeployed|awaiting deployment|yet to be deployed|once deployed|when deployed|not launched|before mainnet|has no deployment|not yet live" packages/ scripts/`
over `.mjs .js .ts .json .html .txt`, node_modules excluded. Every hit, counted by site:

**false-unscoped - FIXED (5 sites)**

- `packages/reference-agent/fixtures/demo-chain.mjs:5`
- `packages/reference-agent/fixtures/seed-snapshot.mjs:8`
- `packages/reference-agent/src/chain.mjs:375`
- `packages/reference-agent/src/run.mjs:20`
- `packages/reference-agent/src/run.mjs:122`

**scoped-true - LEFT (4 sites)**

- `scripts/gate.mjs:150` - "This gate **used to be** RED on purpose (issue #10, VaultFactory over
  the EIP-170 cap)". Past tense, a historical record, and the only remaining home for the #10
  history the comments above dropped.
- `scripts/verify-chainlink-oracle.mjs:105` - "a **pre-deploy run** must not be blocked". About the
  script's own two calling modes, not about protocol deployment state.
- `scripts/verify-chainlink-oracle.mjs:359-360` - "silent forever **once deployed**". Same: the
  lifetime of an oracle misconfiguration, not the protocol's deployment status.
- `scripts/soak/oracle-sampler.mjs:84` - "cannot be fixed by setting `SOAK_VAULTS` **at launch**".
  "Launch" there is the launch of the soak process, not the protocol launch.

**not-about-deployment - LEFT (7 sites)**

- `packages/canary/src/signals/feed-identity.mjs:21` - "LIVE-vs-CACHED, **not live**-vs-config".
  A comparison, not a deployment claim. This file belongs to PR #191's in-flight set and was read
  only, never edited.
- `scripts/lib/verdicts.mjs:25` - "Divergence is **not liveness**". About verdict semantics.
- `scripts/verify-chainlink-oracle.mjs:7` and `scripts/verify-mainnet-config.mjs:10` - "No key, no
  signature, no transaction, **no deployment**". A statement that the script itself deploys nothing.
- `scripts/test/config-doc-truth.test.mjs:340` - "records, **not live** claims".
- `scripts/test/config-doc-truth.test.mjs:566` - "a claim **no deployment** satisfies".
- `scripts/test/config-doc-truth.test.mjs:609-640` and `:765` - the banned-shape list and its
  "at launch" discussion. Quotes false claims in order to prohibit them; guard text, not a claim.

No pre-existing sibling of the fixed shape is left standing in `packages/` or `scripts/`. The
`apps/site` pages already scope the same claim correctly ("Not deployed to mainnet. No mainnet
deployment of the current code exists...") and were not touched.

## Measured

```
node --test --test-reporter=tap scripts/test/claims-lede-truth.test.mjs
# tests 6    # pass 6    # fail 0

node --test --test-reporter=tap "packages/reference-agent/test/*.test.mjs"
# tests 136  # pass 132  # fail 0  # skipped 4

node --test --test-reporter=tap scripts/test/config-doc-truth.test.mjs
# tests 19   # pass 19   # fail 0

node --check on all four changed .mjs files: clean
```

All three suites were re-run after the final revision of the two fixture comments.
`config-doc-truth` was run because the doc paragraph sits inside the tree it walks.

## Not verified

- **No mutation proof, because this change adds no test.** It is comment and prose only; there is no
  new assertion to invert. Nothing is claimed about mutation coverage.
- **`claims-lede-truth.test.mjs` does not reach any of the five fixed sites.** Its `PUBLIC_EXT` at
  `scripts/test/claims-lede-truth.test.mjs:152` is `['.md', '.html', '.txt', '.json']`, so `.mjs` is
  unreachable from it. Its green run covers the `docs/REFERENCE-AGENT.md` edit only. The comment
  fixes are guarded by review, not by CI.
- **No chain reads were performed**, which is why no replacement clause rests on one. The mainnet
  claim rests on the contents of `contracts/config/deployments/`; the fixture-rationale claims rest
  on the scenario `fixtures/demo-chain.mjs` describes.
- `npm run gate` and `forge` were not run - the shared `~/.foundry` deadlocks across concurrent
  sessions here. CI covers them.
