### PR TITLE
test(governance): pin the proposal-status decodes in smoke-test and the reference agent

### DIFF
--- a/packages/reference-agent/test/chain.test.mjs
+++ b/packages/reference-agent/test/chain.test.mjs
@@ -134,6 +134,32 @@ test('decodeProposal also accepts a NAMED object, in case viem starts returning 
   assert.equal(p.statusName, 'Active');
 });
 
+test('an out-of-range enum byte decodes to Unknown rather than undefined (issue #196)', () => {
+  // THE ONE BRANCH THE TWO TESTS ABOVE DO NOT REACH. Between them they already pin the enum
+  // arrays (`the enums match Governance.sol declaration order`) and every tuple position with
+  // pairwise-distinct values, so a respelt entry or a shifted index is caught. What nothing
+  // executed was the `?? 'Unknown'` fallback at chain.mjs:128 and :136 — deleting both left this
+  // whole suite green, verified by mutation. The fallback has one reader, `policy.mjs:341-343`,
+  // and it is the reader's message that degrades: an out-of-range byte would make the agent
+  // decline with "proposal status is undefined, not Active", or name the mandate check's subject
+  // "undefined", instead of saying Unknown. That is a behaviour, not a formality, so it is pinned.
+  //
+  // Reachable through decode drift, not through Governance: a `status` beyond 5 or a `ptype`
+  // beyond 2 cannot be written by the contract's own enums, but an ABI change that shifted the
+  // tuple would put an unrelated field's value into either position.
+  const raw = new Array(16).fill(0n);
+  raw[0] = '0x' + 'a'.repeat(40);
+  raw[1] = 9n; // ptype, past ChildAllocation (2)
+  raw[8] = 7n; // status, past Expired (5)
+  const p = decodeProposal(raw);
+  assert.equal(p.ptype, 9, 'the numeric field still carries the raw byte');
+  assert.equal(p.ptypeName, 'Unknown');
+  assert.equal(p.status, 7);
+  assert.equal(p.statusName, 'Unknown');
+  assert.equal(PROPOSAL_TYPE.length, 3, '9 is out of range only while ProposalType has three members');
+  assert.equal(PROPOSAL_STATUS.length, 6, '7 is out of range only while Status has six members');
+});
+
 // ── the reader's fault tolerance ────────────────────────────────────────────
 
 /** A viem-shaped client that answers from a table and can be told to fail. */

--- a/scripts/lib/proposal-decode.mjs
+++ b/scripts/lib/proposal-decode.mjs
@@ -1,0 +1,65 @@
+// @ts-check
+/**
+ * Decode one `proposals(uint256)` result into a named object. Pure — no chain, no `cast`.
+ *
+ * WHY THIS IS A SEPARATE MODULE. scripts/smoke-test.mjs reads a proposal in three places, and it
+ * cannot be imported by a test: it resolves a deployment file, builds `cast` argument lists and
+ * runs the whole lifecycle at import. So the decode that lived inside it — `STATUS[Number(p[8])]`
+ * and four bare index constants — was arithmetic no test in this repository could reach. Respell
+ * an entry in `STATUS` and `stepFinalize`'s `status === 'Passed'` assertion rejects a proposal
+ * that did pass; shift one index and `recoverStrandedProposal` hands `classifyProposal` a
+ * timestamp belonging to a different field. Either way every suite stays green. Issue #196.
+ *
+ * The field names and the Number/BigInt split are deliberately identical to `readProposal` in
+ * scripts/soak/lib.mjs:419-433, so that if the two decodes are later served by one module the
+ * change is an import swap rather than a rewrite at every call site. They are separate today
+ * because lib.mjs's decode is still fused to its own `call()` — the soak runner's `cast` wrapper —
+ * and unfusing it is PR #193's change, not this one.
+ */
+
+/**
+ * The `cast call` signature. `cast` prints one line per return value, so this signature's arity
+ * is also the length of the array `decodeProposal` expects.
+ *
+ * Sixteen values, matching `Governance.proposals(uint256)`.
+ */
+export const PROPOSAL_SIG =
+  'proposals(uint256)(address,uint8,address,uint64,uint64,uint64,uint64,uint64,uint8,bytes32,uint256,uint256,uint256,uint256,uint256,uint256)';
+
+/** Tuple position of each field, in the order `PROPOSAL_SIG` returns them. */
+export const P = {
+  VAULT: 0, PTYPE: 1, PROPOSER: 2, CREATED_AT: 3, COMMIT_DEADLINE: 4, REVEAL_DEADLINE: 5,
+  EXECUTABLE_AT: 6, EXPIRES_AT: 7, STATUS: 8, ACTION_HASH: 9, SNAPSHOT_TOTAL: 10,
+  MEMBER_COUNT: 11, FOR_WEIGHT: 12, AGAINST_WEIGHT: 13, REVEALED_WEIGHT: 14,
+  REVEALED_VOTER_COUNT: 15,
+};
+
+/**
+ * `Governance.Status`, in declaration order (contracts/src/Governance.sol:95-102).
+ *
+ * There is NO out-of-range fallback here, and that is the pre-existing behaviour preserved
+ * unchanged: a status byte outside 0..5 decodes to `undefined`, exactly as the inline lookup in
+ * smoke-test.mjs did before this extraction. packages/reference-agent/src/chain.mjs:136 appends
+ * `?? 'Unknown'` instead; that is a deliberate choice in that module, not a divergence introduced
+ * here, and changing this one would alter the text of smoke-test's finalize assertion.
+ */
+export const STATUS = ['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expired'];
+
+/**
+ * @param {string[]} p one decoded `cast call` output line per tuple member, in `P` order
+ * @returns {object} the named proposal, with `raw` carrying the input lines unchanged
+ */
+export function decodeProposal(p) {
+  return {
+    raw: p,
+    vault: p[P.VAULT], ptype: Number(p[P.PTYPE]), proposer: p[P.PROPOSER],
+    createdAt: Number(p[P.CREATED_AT]),
+    commitDeadline: Number(p[P.COMMIT_DEADLINE]), revealDeadline: Number(p[P.REVEAL_DEADLINE]),
+    executableAt: Number(p[P.EXECUTABLE_AT]), expiresAt: Number(p[P.EXPIRES_AT]),
+    status: STATUS[Number(p[P.STATUS])], actionHash: p[P.ACTION_HASH],
+    snapshotTotal: BigInt(p[P.SNAPSHOT_TOTAL]), memberCount: Number(p[P.MEMBER_COUNT]),
+    forWeight: BigInt(p[P.FOR_WEIGHT]), againstWeight: BigInt(p[P.AGAINST_WEIGHT]),
+    revealedWeight: BigInt(p[P.REVEALED_WEIGHT]),
+    revealedVoterCount: Number(p[P.REVEALED_VOTER_COUNT]),
+  };
+}

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -34,6 +34,7 @@ import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PROPOSAL_SIG, decodeProposal } from './lib/proposal-decode.mjs';
 import { classifyProposal } from './proposal-recovery.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -197,10 +198,10 @@ const T_VAULT_CREATED = keccakOf('VaultCreated(address,address,address,uint256)'
 const T_REBALANCE_EXECUTED = keccakOf('RebalanceExecuted(address,uint256)');
 const T_EXIT_SETTLED = keccakOf('ExitSettled(address,uint256,uint256,uint256,uint256)');
 
-const PROPOSAL_SIG = 'proposals(uint256)(address,uint8,address,uint64,uint64,uint64,uint64,uint64,uint8,bytes32,uint256,uint256,uint256,uint256,uint256,uint256)';
-const P_COMMIT_DEADLINE = 4, P_REVEAL_DEADLINE = 5, P_EXPIRES_AT = 7, P_STATUS = 8;
-const P_REVEALED_VOTER_COUNT = 15;
-const STATUS = ['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expired'];
+// PROPOSAL_SIG, the tuple index map and the Status enum now live in ./lib/proposal-decode.mjs,
+// which is pure and therefore reachable by scripts/test/proposal-decode.test.mjs. This file
+// executes its whole lifecycle at import, so while the decode lived here no test could run it
+// (issue #196).
 
 // ────────────────────────────────── phases ──────────────────────────────────
 
@@ -324,9 +325,9 @@ function stepPropose() {
   const pid = callU(dep.governance, 'activeProposalOf(address)(uint256)', state.vault);
   assert(pid > 0n, 'no active proposal after propose');
   state.pid = pid.toString();
-  const p = call(dep.governance, PROPOSAL_SIG, state.pid);
-  state.commitDeadline = Number(p[P_COMMIT_DEADLINE]);
-  state.revealDeadline = Number(p[P_REVEAL_DEADLINE]);
+  const p = decodeProposal(call(dep.governance, PROPOSAL_SIG, state.pid));
+  state.commitDeadline = p.commitDeadline;
+  state.revealDeadline = p.revealDeadline;
   log(`proposal ${state.pid}: commit until ${state.commitDeadline}, reveal until ${state.revealDeadline}`);
   state.steps.propose = { done: true, tx: r.transactionHash };
   save();
@@ -356,10 +357,10 @@ async function stepReveal() {
 async function stepFinalize() {
   await waitUntilChainTime(state.revealDeadline, 'reveal phase end (1h)');
   const r = send('governance.finalize', dep.governance, 'finalize(uint256)', state.pid);
-  const p = call(dep.governance, PROPOSAL_SIG, state.pid);
-  const status = STATUS[Number(p[P_STATUS])];
+  const p = decodeProposal(call(dep.governance, PROPOSAL_SIG, state.pid));
+  const status = p.status;
   assert(status === 'Passed', `proposal finalized as ${status}, expected Passed (signer-regime quorum: 1 of 1 members revealed FOR)`);
-  state.expiresAt = Number(p[P_EXPIRES_AT]);
+  state.expiresAt = p.expiresAt;
   log(`proposal Passed; executable now (timelock 0), window closes at ${state.expiresAt}`);
   state.steps.finalize = { done: true, tx: r.transactionHash };
   save();
@@ -413,16 +414,16 @@ function stepExit() {
  */
 function recoverStrandedProposal() {
   if (!state.pid || state.steps.execute?.done) return;
-  const p = call(dep.governance, PROPOSAL_SIG, state.pid);
-  const status = STATUS[Number(p[P_STATUS])];
+  const p = decodeProposal(call(dep.governance, PROPOSAL_SIG, state.pid));
+  const status = p.status;
   const now = chainNow();
 
   const { stranded, action, reason } = classifyProposal({
     status,
     now,
-    expiresAt: Number(p[P_EXPIRES_AT]),
-    revealDeadline: Number(p[P_REVEAL_DEADLINE]),
-    revealedVoterCount: Number(p[P_REVEALED_VOTER_COUNT]),
+    expiresAt: p.expiresAt,
+    revealDeadline: p.revealDeadline,
+    revealedVoterCount: p.revealedVoterCount,
   });
   if (!stranded) return;
 

--- a/scripts/test/proposal-decode.test.mjs
+++ b/scripts/test/proposal-decode.test.mjs
@@ -1,0 +1,189 @@
+// @ts-check
+/**
+ * Fixture pins for the `proposals(uint256)` decode that scripts/smoke-test.mjs runs (issue #196).
+ *
+ * WHAT WAS UNREACHABLE. Before the extraction, smoke-test.mjs decoded a proposal status inline as
+ * `STATUS[Number(p[P_STATUS])]` in two places and read four fields by bare index constant. That
+ * file resolves a deployment file, builds `cast` argument lists and runs the whole testnet
+ * lifecycle at import, so no test could execute any of it. A respelt `STATUS` entry makes
+ * `stepFinalize` reject a proposal that did pass; a shifted index hands `classifyProposal` a
+ * timestamp from a different field. Neither shows up in any suite.
+ *
+ * PROVENANCE, stated precisely because a fixture that claims to be captured and is not is worse
+ * than no fixture. NEITHER TUPLE BELOW WAS CAPTURED FROM A CHAIN OR A LOG — both are CONSTRUCTED.
+ * Four values in `PROPOSAL_3_EXECUTED` are carried from the only place in this repository that
+ * already pins them: the `votableNow` regression at scripts/test/soak-drills.test.mjs:980-983,
+ * whose literal at :981 uses createdAt 1788479808, commitDeadline 1788483408 and status Executed
+ * for the proposal 3 that drill 5 met on 2026-09-04, and whose comment at :975 names it ptype 2,
+ * ChildAllocation. Those are values that file asserts, not a chain read taken here. The `vault`
+ * field is scripts/soak/soak-vaults.json's `smokeVault.address`, which that file's `smokeVault`
+ * note names as drill 5's host vault. The remaining eleven fields are
+ * synthetic, chosen only so that all sixteen decoded values are pairwise distinct — which is what
+ * makes an index shift change an ASSERTED value rather than swap two equal ones.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { P, PROPOSAL_SIG, STATUS, decodeProposal } from '../lib/proposal-decode.mjs';
+import { classifyProposal } from '../proposal-recovery.mjs';
+
+/** One cleaned `cast call` output line per tuple member, in `P` order — what `call()` returns. */
+const PROPOSAL_3_EXECUTED = [
+  '0xb940d71b0d695e2ba2b5853bf565c69daa3e3c98',                         // 0  vault
+  '2',                                                                  // 1  ptype (ChildAllocation)
+  '0x00000000000000000000000000000000000000b2',                         // 2  proposer (synthetic)
+  '1788479808',                                                         // 3  createdAt
+  '1788483408',                                                         // 4  commitDeadline
+  '1788487008',                                                         // 5  revealDeadline (synthetic)
+  '1788487009',                                                         // 6  executableAt (synthetic)
+  '1788573408',                                                         // 7  expiresAt (synthetic)
+  '4',                                                                  // 8  status (Executed)
+  `0x${'ab'.repeat(32)}`,                                               // 9  actionHash (synthetic)
+  '7000000000000000000',                                                // 10 snapshotTotal (synthetic)
+  '5',                                                                  // 11 memberCount (synthetic)
+  '6000000000000000000',                                                // 12 forWeight (synthetic)
+  '1000000000000000000',                                                // 13 againstWeight (synthetic)
+  '8000000000000000000',                                                // 14 revealedWeight (synthetic)
+  '3',                                                                  // 15 revealedVoterCount (synthetic)
+];
+
+/** Wholly synthetic, status byte 1 — the tuple that exercises `STATUS[1] === 'Active'`. */
+const PROPOSAL_ACTIVE = [
+  '0x00000000000000000000000000000000000000a1', '0',
+  '0x00000000000000000000000000000000000000b2',
+  '1000', '4600', '8200', '8201', '94600',
+  '1',
+  `0x${'11'.repeat(32)}`,
+  '9000', '4', '0', '0', '0', '0',
+];
+
+/** The same tuple with one status byte changed — the enum index is the only thing that moves. */
+const withStatus = (tuple, byte) => tuple.map((v, i) => (i === P.STATUS ? String(byte) : v));
+
+test('decodeProposal maps every tuple index to its named field, and no two land on the same one', () => {
+  const p = decodeProposal(PROPOSAL_3_EXECUTED);
+  assert.deepEqual(
+    {
+      vault: p.vault, ptype: p.ptype, proposer: p.proposer, createdAt: p.createdAt,
+      commitDeadline: p.commitDeadline, revealDeadline: p.revealDeadline,
+      executableAt: p.executableAt, expiresAt: p.expiresAt, status: p.status,
+      actionHash: p.actionHash, snapshotTotal: p.snapshotTotal, memberCount: p.memberCount,
+      forWeight: p.forWeight, againstWeight: p.againstWeight, revealedWeight: p.revealedWeight,
+      revealedVoterCount: p.revealedVoterCount,
+    },
+    {
+      vault: '0xb940d71b0d695e2ba2b5853bf565c69daa3e3c98',
+      ptype: 2,
+      proposer: '0x00000000000000000000000000000000000000b2',
+      createdAt: 1788479808,
+      commitDeadline: 1788483408,
+      revealDeadline: 1788487008,
+      executableAt: 1788487009,
+      expiresAt: 1788573408,
+      status: 'Executed',
+      actionHash: `0x${'ab'.repeat(32)}`,
+      snapshotTotal: 7000000000000000000n,
+      memberCount: 5,
+      forWeight: 6000000000000000000n,
+      againstWeight: 1000000000000000000n,
+      revealedWeight: 8000000000000000000n,
+      revealedVoterCount: 3,
+    },
+  );
+  // The timestamps and counts are Numbers and the weight fields BigInts; `deepEqual` from
+  // node:assert/strict is exact about that, so a Number/BigInt swap is caught rather than coerced
+  // away. It matters at the call sites: `classifyProposal` tests `revealedVoterCount === 0`, which
+  // a BigInt `0n` would fail.
+  assert.equal(p.raw, PROPOSAL_3_EXECUTED, 'raw must carry the input lines through unchanged');
+});
+
+test('decodeProposal produces the exact status strings smoke-test.mjs compares against', () => {
+  // THE MUTATION ISSUE #196 DESCRIBES. `stepFinalize` asserts `status === 'Passed'` and
+  // `classifyProposal` branches on the literals 'Passed', 'Active', 'Expired' and 'Defeated'
+  // (scripts/proposal-recovery.mjs:26-38). Every one of those strings is produced only by this
+  // array, so respell an entry — 'Active' -> 'Activ' — and the smoke run rejects a healthy
+  // proposal, or fails to recognise a stranded one, with no test anywhere going red.
+  const decoded = STATUS.map((_, i) => decodeProposal(withStatus(PROPOSAL_ACTIVE, i)).status);
+  assert.deepEqual(decoded, ['None', 'Active', 'Passed', 'Defeated', 'Executed', 'Expired'],
+    'the six Governance.Status names, in declaration order (contracts/src/Governance.sol:95-102)');
+  assert.equal(decodeProposal(PROPOSAL_ACTIVE).status, 'Active');
+});
+
+test('a status byte outside the enum still decodes to undefined, as it did before the extraction', () => {
+  // FAITHFULNESS, NOT A PREFERENCE. The inline lookup this module replaced had no `?? 'Unknown'`
+  // fallback, so an out-of-range byte produced `undefined` and `stepFinalize` printed "proposal
+  // finalized as undefined". Adding a fallback here would change that message, so the behaviour is
+  // preserved and pinned. packages/reference-agent/src/chain.mjs:136 makes the opposite choice for
+  // its own decode; that divergence is deliberate and is pinned separately in
+  // packages/reference-agent/test/chain.test.mjs.
+  assert.equal(decodeProposal(withStatus(PROPOSAL_ACTIVE, 6)).status, undefined);
+  assert.equal(STATUS.length, 6, 'six is the first out-of-range byte only while the enum has six members');
+});
+
+test('the P index map still matches the arity and order of PROPOSAL_SIG', () => {
+  // A fixture is only evidence if it has the shape the signature returns. `cast call` prints one
+  // line per return value, so the tuple length and the highest index in `P` must agree with the
+  // signature smoke-test.mjs actually sends.
+  const returns = /\)\(([^)]*)\)$/.exec(PROPOSAL_SIG);
+  assert.ok(returns, 'PROPOSAL_SIG must still declare a return tuple');
+  const arity = returns[1].split(',').length;
+  assert.equal(arity, 16, 'proposals(uint256) returns sixteen values');
+  assert.equal(PROPOSAL_3_EXECUTED.length, arity, 'the fixture must be one line per return value');
+  assert.equal(PROPOSAL_ACTIVE.length, arity);
+  assert.equal(Math.max(...Object.values(P)), arity - 1, 'P must not index past the tuple');
+  assert.equal(new Set(Object.values(P)).size, arity, 'every index used exactly once');
+  assert.equal(new Set(PROPOSAL_3_EXECUTED).size, arity,
+    'the fixture values must be pairwise distinct, or an index swap decodes identically');
+});
+
+test('a decoded Passed proposal past its execution window routes recovery to markExpired', () => {
+  // ACROSS THE SEAM. `recoverStrandedProposal` feeds the decode straight into `classifyProposal`,
+  // so this pins `STATUS[2]` and `P.EXPIRES_AT` to the branch that consumes them rather than each
+  // to a literal of its own. `now` is derived from the decoded value, so the literal assert below
+  // is what makes an index shift visible here: without it, EXPIRES_AT landing on EXECUTABLE_AT
+  // would still be one second behind a derived `now` and this test would pass on the wrong field.
+  const p = decodeProposal(withStatus(PROPOSAL_3_EXECUTED, 2));
+  assert.equal(p.status, 'Passed');
+  assert.equal(p.expiresAt, 1788573408, 'index 7, not its neighbour executableAt at index 6');
+  const r = classifyProposal({
+    status: p.status,
+    now: p.expiresAt + 1,
+    expiresAt: p.expiresAt,
+    revealDeadline: p.revealDeadline,
+    revealedVoterCount: p.revealedVoterCount,
+  });
+  assert.equal(r.stranded, true);
+  assert.equal(r.action, 'markExpired');
+});
+
+test('a decoded Active proposal with the reveal window shut and nothing revealed routes to finalize', () => {
+  // The 2026-08-21 restart case (scripts/test/proposal-recovery.test.mjs). It needs THREE decoded
+  // fields to agree — status, revealDeadline and revealedVoterCount — and the last of those must
+  // be a Number, because `classifyProposal` tests `revealedVoterCount === 0` and a BigInt `0n`
+  // fails that comparison silently, leaving the proposal unrecovered and every later propose()
+  // reverting ProposalActive().
+  const p = decodeProposal(PROPOSAL_ACTIVE);
+  assert.equal(p.revealedVoterCount, 0);
+  const r = classifyProposal({
+    status: p.status,
+    now: p.revealDeadline,
+    expiresAt: p.expiresAt,
+    revealDeadline: p.revealDeadline,
+    revealedVoterCount: p.revealedVoterCount,
+  });
+  assert.equal(r.stranded, true);
+  assert.equal(r.action, 'finalize');
+});
+
+test('smoke-test.mjs reads every proposal through decodeProposal, so the fixtures pin a decoder it uses', () => {
+  // WHAT A FIXTURE CANNOT REACH. smoke-test.mjs runs `cast` and the whole lifecycle at import, so
+  // no test can drive it in-process, and a fixture could therefore pin a decoder no caller
+  // reaches. This is a text-and-count pin over the source instead, and it catches the edit that
+  // actually happens here — one site re-inlined while the other two keep the helper.
+  const src = readFileSync(new URL('../smoke-test.mjs', import.meta.url), 'utf8');
+  const uses = src.match(/decodeProposal\(call\(dep\.governance, PROPOSAL_SIG, state\.pid\)\)/g) ?? [];
+  assert.equal(uses.length, 3, 'stepPropose, stepFinalize and recoverStrandedProposal each read one proposal');
+  assert.match(src, /import \{ PROPOSAL_SIG, decodeProposal \} from '\.\/lib\/proposal-decode\.mjs';/);
+  assert.doesNotMatch(src, /STATUS\[/, 'no inline enum-index decode may remain in smoke-test.mjs');
+  assert.doesNotMatch(src, /const PROPOSAL_SIG =/, 'the signature must have one definition, in the pure module');
+});


### PR DESCRIPTION
Closes #196.

## What changed

**`scripts/smoke-test.mjs` — the decode was unreachable.** It read a proposal in three
places and decoded the status inline as `STATUS[Number(p[P_STATUS])]` (formerly :359 and
:416), plus four bare index constants. The file resolves a deployment file, builds `cast`
argument lists and runs the whole testnet lifecycle at import, so nothing in the suite could
execute any of it. Respell a `STATUS` entry and `stepFinalize` rejects a proposal that did
pass; shift one index and `recoverStrandedProposal` hands `classifyProposal` a timestamp
belonging to a different field. Every suite stays green through both.

- **New `scripts/lib/proposal-decode.mjs`** — pure, no chain, no `cast`. Holds `PROPOSAL_SIG`,
  the `P` index map, `STATUS` and `decodeProposal(lines)`. Field names and the Number/BigInt
  split are deliberately identical to `readProposal` in `scripts/soak/lib.mjs:419-433`.
- The three call sites (`stepPropose`, `stepFinalize`, `recoverStrandedProposal`) now read
  named fields. **Nothing observable changes:** the same values land in the state file
  (`state.commitDeadline`, `state.revealDeadline`, `state.expiresAt`, all `Number` as before),
  every log line and assertion string is byte-identical, and an out-of-range status still
  decodes to `undefined` rather than gaining a fallback — a fallback would have changed the
  text of the finalize assertion.
- **New `scripts/test/proposal-decode.test.mjs`**, 7 cases.

**`packages/reference-agent/src/chain.mjs` — no source change was needed.** The issue's premise
is already partly satisfied here, which is worth stating plainly rather than claiming novel
coverage: `chain.test.mjs:80-82` `deepEqual`s both enum arrays, so a respelt entry already goes
red there, and `chain.test.mjs:90-128` pins all sixteen tuple positions with pairwise-distinct
values, so an index swap already goes red there too. The one branch nothing executed was the
`?? 'Unknown'` fallback at `chain.mjs:128` (`ptypeName`) and `:136` (`statusName`). That is the
fixture this PR adds — a raw tuple with `ptype: 9n` and `status: 7n`, asserting both names
decode to `Unknown` and both numeric fields still carry the raw byte. Its one reader is
`policy.mjs:341-343`, where losing the fallback degrades the agent's decline message to
"proposal status is undefined, not Active".

## The one behavioural difference, stated

`decodeProposal` coerces all sixteen fields eagerly, where the inline code touched only five.
The four `BigInt(...)` coercions are new work on the same `cast call` output. This is the exact
decode `scripts/soak/lib.mjs:419-433` already runs against the same signature on the same
chain, so the shape is proven, but it is a difference and not a pure extraction.

## Measured

Both suites, `node --test --test-reporter=tap` (the spec reporter prints no per-test lines).

| suite | before | after |
| --- | --- | --- |
| `scripts/test/*.test.mjs` | 215 tests, 210 pass, **4 fail**, 1 skipped | 222 tests, 217 pass, **4 fail**, 1 skipped |
| `packages/reference-agent/test/*.test.mjs` | 136 tests, 132 pass, 0 fail, 4 skipped | 137 tests, 133 pass, 0 fail, 4 skipped |

The 4 failures are `contracts-size-truth.test.mjs` with `contracts/out` absent (`contracts/out
exists — this guard must never skip its way to green` and three siblings). **They are identical
before and after this change** — the "before" column was measured on this branch's merge base at
`f2ee7ed2` immediately after `npm ci`, before any file was touched. `forge` was not run: the
shared `~/.foundry` deadlocks across concurrent sessions here.

## Mutation proof

Each defect was applied, the suite run, then the file restored by copy and `git diff` confirmed
empty.

| mutation | expected red | actual |
| --- | --- | --- |
| `chain.mjs`: delete `?? 'Unknown'` at both :128 and :136 | only the new out-of-range test | reference-agent suite 137 tests, **exactly 1 fail** — `an out-of-range enum byte decodes to Unknown…`. `the enums match Governance.sol declaration order` and `decodeProposal maps all sixteen tuple positions correctly` both stayed **green**, which is what makes the "already pinned" claim above measured rather than asserted. |
| `proposal-decode.mjs`: `STATUS[1]` `'Active'` → `'Activ'` | the status-string test | `scripts/test` 222 tests, 6 fail = the 4 pre-existing + `decodeProposal produces the exact status strings smoke-test.mjs compares against` and `a decoded Active proposal with the reveal window shut…` |
| `proposal-decode.mjs`: swap `P.EXECUTABLE_AT` and `P.EXPIRES_AT` (6 ↔ 7) | the index-map test | `decodeProposal maps every tuple index…` and `a decoded Passed proposal past its execution window…` red; other 5 green |
| `smoke-test.mjs`: re-inline the `recoverStrandedProposal` site | the source-text pin | only `smoke-test.mjs reads every proposal through decodeProposal…` red |

The index-swap run is worth one note, because the first version of that test did **not** catch
it: the seam test derives `now` from the decoded `expiresAt`, so a shift onto `executableAt`
left it one second behind either way and the test passed on the wrong field. The literal
`assert.equal(p.expiresAt, 1788573408, …)` was added for exactly that, and the table above is
the re-run after it.

## Fixture provenance

**CONSTRUCTED, NOT CAPTURED — neither tuple came from a chain or a log.** Four values in
`PROPOSAL_3_EXECUTED` are carried from the only place in the repository that already pins them:
the `votableNow` regression at `scripts/test/soak-drills.test.mjs:980-983`, whose literal at
:981 uses `createdAt 1788479808`, `commitDeadline 1788483408` and status `Executed`, and whose
comment at :975 names it ptype 2, `ChildAllocation`. The `vault` field is
`scripts/soak/soak-vaults.json`'s `smokeVault.address`. The remaining eleven fields are
synthetic, chosen so all sixteen decoded values are pairwise distinct — which is what makes an
index shift change an *asserted* value instead of swapping two equal ones. The values were also
chosen to agree with the fixture PR #193 constructs, as read from its diff on 2026-09-04, so a
later merge of the two decodes needs no fixture reconciliation.

## Concurrency

- **PR #193 is in flight on `scripts/soak/lib.mjs`.** This PR touches none of the four files
  #193 touches, imports nothing from it, and does not depend on its unmerged `decodeProposal`.
  The two are independent in either merge order.
- **Another session is editing `scripts/smoke-test.mjs` around :220-240** (a bare `catch` in
  `preflight`). My hunks land at :37 (the import), :201-204 (the constant block, now a
  comment), :328, :360-363 and :417-426. No overlap.
- **PR #191 is in flight on `packages/canary/src/signals/*.mjs`.** Not touched — see the sweep
  below for why that matters.

## Sweep for siblings of this shape

Greps run: `STATUS\[|_STATUS\[|\[Number\(` and `\['None', 'Active'|'Rebalance', 'RuleChange'`
across `packages/`, `apps/` and `scripts/`, excluding tests and `node_modules`. Three hits
outside this change, all **pre-existing and left untouched** per docs/SWARM.md §4:

1. `scripts/soak/lib.mjs:427` — `status: STATUS[Number(p[P.STATUS])]` inside `readProposal`,
   unreachable because the decode is fused to `call()`. **Classification: the same defect, and
   it is exactly what PR #193 fixes.** Left alone deliberately.
2. `packages/canary/src/signals/governance-watch.mjs:109, :116, :200, :203` — four enum-index
   decodes over its own copies of both tables at :91-92, with `?? \`type#${n}\`` fallbacks. No
   file under `packages/canary/test/` references `STATUSES` or `PROPOSAL_TYPES` by name.
   **Classification: an unpinned sibling of the same shape, softened by its fallback (it
   degrades to `status#7`, not `undefined`).** Untouched because PR #191 is in flight on that
   exact path; it wants its own issue.
3. `apps/web/src/governance.mjs:27` — `PROPOSAL_TYPES` is exported and, per a repo-wide grep,
   never imported or indexed anywhere. **Classification: not a decode site at all — an unused
   export.** No action.

## Not verified

- No chain, RPC or `cast` was run. The fixtures assert what the decode does with a given tuple;
  that a live `proposals(uint256)` returns exactly sixteen lines in this order is asserted
  against `PROPOSAL_SIG` and `contracts/src/Governance.sol:95-102`, not observed here.
- `npm run gate` and `forge` were not run (shared `~/.foundry` deadlock). CI is the check.
- Pre-existing stale citations noticed and **not** fixed, since they sit in untouched lines:
  `chain.mjs:109` cites the `Status` enum as `Governance.sol:68` and `:111` cites
  `ProposalType` as `:62`; both are wrong — the actual declarations are at `Governance.sol:95`
  and `:89`. The new module and test cite the correct lines.
