### PR TITLE
fix(reference-agent): decide the seed-snapshot main guard with fileURLToPath

### DIFF
--- a/packages/reference-agent/fixtures/seed-snapshot.mjs
+++ b/packages/reference-agent/fixtures/seed-snapshot.mjs
@@ -21,6 +21,8 @@
  * The scenario matches fixtures/demo-chain.mjs — see that file for what each vault is for.
  */
 
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { applyAll } from '../../indexer/src/projections.mjs';
 import { saveSnapshot } from '../../indexer/src/store.mjs';
 import { DEMO_OPERATORS, DEMO_VAULTS } from './demo-chain.mjs';
@@ -106,7 +108,16 @@ export async function seed(path) {
 }
 
 // Run directly: node fixtures/seed-snapshot.mjs [path]
-if (import.meta.url === `file://${process.argv[1]?.replace(/\\/g, '/')}` || process.argv[1]?.endsWith('seed-snapshot.mjs')) {
+//
+// fileURLToPath, not a `file://` template built out of argv[1]: from a checkout whose path
+// contains a space, import.meta.url carries it percent-encoded (`sp%20ace`) while argv[1] carries
+// it raw, so the two never compare equal and the guard does not fire. The
+// `|| process.argv[1]?.endsWith('seed-snapshot.mjs')` fallback that masked that is dropped —
+// this module has exactly two invocations, and neither needs it: `node
+// packages/reference-agent/fixtures/seed-snapshot.mjs` (docs/REFERENCE-AGENT.md:28), where argv[1]
+// is this file, and `import { seed }` (scripts/live-x402-run.mjs:50), where argv[1] is that
+// script. The form below is the one that importer already uses at scripts/live-x402-run.mjs:361.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   const path = process.argv[2] ?? './data/demo-snapshot.json';
   const state = await seed(path);
   console.log(

--- a/packages/reference-agent/test/seed-snapshot.test.mjs
+++ b/packages/reference-agent/test/seed-snapshot.test.mjs
@@ -1,0 +1,74 @@
+// @ts-check
+/**
+ * The run-directly guard in fixtures/seed-snapshot.mjs.
+ *
+ * The failure this catches is a SILENT one: the guard decides whether `node
+ * packages/reference-agent/fixtures/seed-snapshot.mjs <path>` seeds anything at all. When it does
+ * not fire, the process exits 0 having written no snapshot and printed nothing, so the demo in
+ * docs/REFERENCE-AGENT.md:28 goes on to serve an empty snapshot rather than reporting an error.
+ *
+ * It used to be decided by `import.meta.url === `file://${argv[1].replace(/\\/g, '/')}`` — a
+ * hand-rolled path-to-URL translation. `import.meta.url` percent-encodes, argv[1] does not, so
+ * from a checkout under `.../sp ace/` the two sides read `sp%20ace` and `sp ace` and never match.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * seed-snapshot.mjs and its complete static-import closure. Static imports resolve at load, so a
+ * missing one kills the child before the guard is reached; the `../../indexer/...` specifiers also
+ * mean the copies have to keep their directory layout. Everything else these five reach for is a
+ * node builtin (verified by reading each file's import list).
+ */
+const CLOSURE = [
+  ['packages', 'reference-agent', 'fixtures', 'seed-snapshot.mjs'],
+  ['packages', 'reference-agent', 'fixtures', 'demo-chain.mjs'],
+  ['packages', 'indexer', 'src', 'projections.mjs'],
+  ['packages', 'indexer', 'src', 'store.mjs'],
+  ['packages', 'oplog', 'src', 'durable.mjs'],
+];
+
+test('seed-snapshot.mjs seeds when run as a script from a path containing a space', () => {
+  // Reproduced the way the docs invoke it — as the main module, so the child's argv[1] is the
+  // copied file itself — from a tree whose path contains a space. os.tmpdir() rather than a fixed
+  // directory so this runs on the CI runner as well as here; mkdtemp so concurrent runs cannot
+  // collide.
+  //
+  // realpath because the guard is not symlink-transparent: node realpaths the main module's
+  // import.meta.url but leaves process.argv[1] as given, so a scratch root reached through a
+  // symlink (os.tmpdir() is /var/folders/... → /private/var/... on macOS) would fail this test for
+  // that reason instead of the percent-encoding one it exists to pin.
+  const scratch = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'seed-snapshot-space-')));
+  const root = path.join(scratch, 'sp ace');
+  try {
+    const repo = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+    for (const rel of CLOSURE) {
+      fs.mkdirSync(path.join(root, ...rel.slice(0, -1)), { recursive: true });
+      fs.copyFileSync(path.join(repo, ...rel), path.join(root, ...rel));
+    }
+
+    const script = path.join(root, ...CLOSURE[0]);
+    const out = path.join(root, 'data', 'demo-snapshot.json');
+    assert.ok(script.includes(' '), 'the script path under test must contain a space');
+
+    const stdout = execFileSync(process.execPath, [script, out], { encoding: 'utf8' });
+
+    // The guard firing is observable two ways, and both are asserted: the branch's own console.log
+    // and the snapshot it writes. Asserting only the exit code would pass on a guard that never
+    // fired, because not seeding also exits 0.
+    assert.match(stdout, /^seeded /m,
+      'the run-directly branch must fire — no output means the guard did not match argv[1]');
+    assert.equal(fs.existsSync(out), true, 'the branch must write the snapshot it reports seeding');
+
+    const snapshot = JSON.parse(fs.readFileSync(out, 'utf8'));
+    assert.equal(snapshot.lastBlock, 1010, 'the snapshot must be the one seed() builds');
+    assert.ok(Object.keys(snapshot.vaults ?? {}).length > 0, 'the seeded snapshot must carry vaults');
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #195.

## What changed

`packages/reference-agent/fixtures/seed-snapshot.mjs:106` decided whether it was the main module by
building a `file://` URL out of `process.argv[1]` by string replacement and comparing it to
`import.meta.url` — the inverse of the shape #190 fixed for #184. `import.meta.url` percent-encodes;
`argv[1]` does not, so from a checkout under `sp ace/` the two sides read `sp%20ace` and `sp ace`
and never compare equal.

```js
- if (import.meta.url === `file://${process.argv[1]?.replace(/\\/g, '/')}` || process.argv[1]?.endsWith('seed-snapshot.mjs')) {
+ if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
```

## Why this direction, measured rather than argued

The issue offers two candidates. Both are correct here, so the tie is broken by convention, not by
taste. Measured from a real directory named `sp ace`, running the probe both with an absolute
`argv[1]` and with the relative form `docs/REFERENCE-AGENT.md:28` uses:

| expression | result |
|---|---|
| `pathToFileURL(argv[1]).href === import.meta.url` | `true` |
| `fileURLToPath(import.meta.url) === resolve(argv[1])` | `true` |
| the old `` `file://${argv[1].replace(/\\/g,'/')}` `` | **`false`** |

So the defect reproduces exactly as #195 describes, and either fix closes it. `fileURLToPath` wins
on convention: **all eight** other `argv[1]` main-module guards in `scripts/`, `packages/` and
`apps/` already use that direction and **none** uses `pathToFileURL`. The specific form chosen is
byte-for-byte the one at `scripts/live-x402-run.mjs:361` — the file that imports this module — so
the guard and its only importer now read identically.

Node resolved a relative `argv[1]` to an absolute path in the same measurement, which is why
`resolve()` is sufficient and no `?.` is needed on the left of the comparison. The leading
`process.argv[1] &&` is kept because `resolve(undefined)` throws: `node -e "import(...)"` leaves
`argv[1]` undefined, and that path is exercised below.

## The `endsWith` fallback is dropped, and that is what makes the test load-bearing

`grep -rn "seed-snapshot" . --exclude-dir=node_modules --exclude-dir=.git` on this head returns
**exactly two** invocations, and neither needs the fallback:

- `docs/REFERENCE-AGENT.md:28` — `node packages/reference-agent/fixtures/seed-snapshot.mjs ./data/demo-snapshot.json`, where `argv[1]` **is** this file.
- `scripts/live-x402-run.mjs:50` — `import { seed }`, where `argv[1]` is *that* script, so the guard must **not** fire.

Every other hit is prose or the new test. Both paths were exercised: the documented command prints
`seeded ./data/demo-snapshot.json: 3 vaults, 2 operators, 1 proposal(s), lastBlock 1010`, and
`node -e "import('./packages/reference-agent/fixtures/seed-snapshot.mjs')"` imports cleanly, seeds
nothing, and does not throw on the undefined `argv[1]`.

Dropping the fallback is load-bearing for the proof, and this is the issue's thesis measured:
**with** the fallback restored alongside the old broken comparison, the new test still **passes** —
the fallback masks the defect entirely. Only with the fallback gone does the test pin the URL
comparison.

## Sweep

`scripts/`, `packages/` and `apps/` at `f2ee7ed2` (not the whole tree — that is the scope grepped),
for every hand-rolled path↔URL translation:

| shape | hits | classification |
|---|---|---|
| `` `file://${...}` `` string building | **1** | `seed-snapshot.mjs:106` — the site fixed here. |
| `replace(/^\/([A-Za-z]:)/` drive-letter strip | **0** | Confirms #190's reviewer: none of the #184 shape remains. |
| `argv[1]` guards already on `fileURLToPath` | 8 | Not the hand-rolled shape; untouched lines. See below. |
| `.pathname` | 5 | None is a file path. See below. |
| `new URL(rel, import.meta.url)` → `fs`/`import()` | 3 | URL objects handed to APIs that accept them; no string munging. |

**Pre-existing siblings left alone** (untouched lines, per `docs/SWARM.md` §4) — the eight guards
split into two families, and I describe what they do rather than asserting they are safe:

- With `resolve`: `scripts/live-x402-run.mjs:361`, `scripts/merge-preflight.mjs:172`,
  `scripts/soak/oracle-sampler.mjs:502`, `scripts/verify-chainlink-oracle.mjs:480`.
- Comparing a bare `argv[1]` with no `resolve`: `packages/canary/src/canary-runner.mjs:580`,
  `packages/indexer/src/index-runner.mjs:248`, `packages/oplog/src/ops-check.mjs:126`,
  `apps/api/src/serve.mjs:163`.

**The `.pathname` hits, classified by reading:** `scripts/dashboard.mjs:236,241` operate on an HTTP
request URL built at `:235` (`new URL(req.url ?? '/', 'http://${HOST}:${PORT}')`), not a file path;
`apps/site/functions/_middleware.js:45`, `scripts/soak/lib.mjs:27` and
`scripts/test/soak-drills.test.mjs:1187` are comments. **The `new URL(rel, import.meta.url)` hits:**
`packages/canary/test/sinks.test.mjs:23`, `packages/reference-agent/test/chain.test.mjs:27`,
`scripts/test/soak-drills.test.mjs:959`.

## The test

`packages/reference-agent/test/seed-snapshot.test.mjs` copies `seed-snapshot.mjs` and its complete
static-import closure — `demo-chain.mjs`, `indexer/src/projections.mjs`, `indexer/src/store.mjs`,
`oplog/src/durable.mjs`; everything else those reach is a node builtin — into a scratch tree under
`.../sp ace/`, preserving the directory layout so the `../../indexer/...` specifiers resolve, and
runs the copy **as main** in a child process. It asserts the branch's own `console.log` fired, that
the snapshot file exists, and that it is the one `seed()` builds (`lastBlock` 1010, non-empty
vaults) — asserting only the exit code would pass on a guard that never fired, because not seeding
also exits 0.

Two deliberate choices worth flagging:

- **`os.tmpdir()` + `mkdtemp`, not a fixed directory.** My brief asked for the session scratchpad,
  but a hardcoded `C:\Users\...` path cannot run on `ubuntu-latest`, which is the only runner in
  `.github/workflows/`. `mkdtemp` also keeps concurrent runs from colliding. Same choice #190's
  space-path test made.
- **`fs.realpathSync` around the scratch root.** Node realpaths the main module's `import.meta.url`
  but leaves `process.argv[1]` as given, so this guard is not symlink-transparent. Without the
  realpath the test would fail on macOS (`os.tmpdir()` is `/var/folders/…` → `/private/var/…`) for a
  reason unrelated to percent-encoding. This is the first test here that compares `argv[1]` to
  `import.meta.url`, so #190's green is not evidence on this point.

## What was measured

- `node --test --test-reporter=tap packages/reference-agent/test/*.test.mjs` — **before: 136 tests,
  132 pass, 0 fail, 4 skipped. After: 137 tests, 133 pass, 0 fail, 4 skipped.** Exactly one test
  added. The glob was confirmed to match all six pre-existing files.
- **Mutation proof.** Restoring the string-replacement comparison **without** the fallback in the
  worktree source (not the scratch copy, which the test overwrites on every run) and re-running that
  same set: **137 tests, 132 pass, 1 fail** — the one failure being exactly
  `seed-snapshot.mjs seeds when run as a script from a path containing a space`. Run twice, once
  against the final hardened test file. Restored by file copy from a pristine snapshot; `git diff`
  confirmed clean afterwards.
- **Counter-mutation.** Old comparison **with** the `endsWith` fallback: the new test passes. This
  is the measurement behind the claim that the fallback masked the defect.
- `node --check` passes on both changed files.

## What I could **not** verify

- **The guard is not symlink-transparent, by design and in company.** With the `endsWith` fallback
  gone, `node packages/reference-agent/fixtures/seed-snapshot.mjs` from a checkout reached *through
  a symlink* would not fire the guard, because Node realpaths `import.meta.url` but not `argv[1]`.
  All eight sibling guards share this property, and neither real invocation involves a symlinked
  checkout, but it is a real narrowing versus the fallback and is stated rather than left to be
  found. Not exercised on a symlinked checkout.
- **CI's runner was not used for the measurement.** Everything above was measured on Windows with
  Node v24.18.0. The test asserts nothing platform-shaped — no drive letters, no platform skip — and
  the percent-encoding it pins is not Windows-specific, but the ubuntu-latest run is CI's to do.
- **`npm run gate` and `forge` were not run.** The shared `~/.foundry` deadlocks across concurrent
  sessions in this repository, and this change touches no Solidity, no gas and no ABI, so the
  contracts steps are a regression check only. CI runs them.
- **The demo end-to-end was not run from a space path.** Only `seed-snapshot.mjs` itself was, which
  is where the defect lives; standing up the API in front of the seeded snapshot is a separate
  surface this change does not touch.
