### PR TITLE
feat(soak): the address book decides the chain — eight drills stop pinning 84532

### DIFF
--- a/scripts/soak/agent-policy.mjs
+++ b/scripts/soak/agent-policy.mjs
@@ -41,7 +41,9 @@ export function resolveAgentRunConfig(env, { defaultRpc = 'https://base-sepolia-
     keystore: String(env.SOAK_AGENT_KEYSTORE),
     password: String(env.SOAK_AGENT_KEYSTORE_PASSWORD),
     apiBaseUrl: env.SOAK_API || 'http://127.0.0.1:8402',
-    rpcUrl: env.BASE_SEPOLIA_RPC || defaultRpc,
+    // SOAK_RPC first, BASE_SEPOLIA_RPC second: the same order lib.mjs resolves `RPC` in, so the
+    // drill's cast reads and its viem writes cannot end up on two different endpoints.
+    rpcUrl: env.SOAK_RPC || env.BASE_SEPOLIA_RPC || defaultRpc,
   };
 }
 

--- a/scripts/soak/deployment.mjs
+++ b/scripts/soak/deployment.mjs
@@ -16,8 +16,15 @@
  *
  * Pure: parsing and validation do no I/O, so they are unit-testable. The one I/O entry point
  * (`loadDeployment`) is a thin fs wrapper over `parseDeployment`.
+ *
+ * WHICH CHAIN A SOAK RUN TARGETS IS DECIDED HERE, ONCE. Every soak entrypoint used to name the
+ * address book and repeat `{ expectChainId: 84532 }` at its own `loadDeployment` call, so eight
+ * files had to agree before a run could point anywhere else. `deploymentPath` picks the record and
+ * `assertLiveChainId` proves the RPC is the chain that record describes; the expected chain id is
+ * the record's own `chainId` field and is not written down a second time.
  */
 import fs from 'node:fs';
+import path from 'node:path';
 
 const ADDR = /^0x[0-9a-fA-F]{40}$/;
 
@@ -133,4 +140,45 @@ export function wiringExpectations(dep) {
 export function loadDeployment(pathname, opts = {}) {
   if (!fs.existsSync(pathname)) throw new Error(`deployment: address book not found at ${pathname}`);
   return parseDeployment(JSON.parse(fs.readFileSync(pathname, 'utf8')), opts);
+}
+
+/** Repo-relative location of the address book a soak run loads when nothing overrides it. */
+export const DEFAULT_DEPLOYMENT = ['contracts', 'config', 'deployments', 'base-sepolia.json'];
+
+/**
+ * The address book a soak entrypoint should load.
+ *
+ * `SOAK_DEPLOYMENT` overrides it — absolute, or relative to the repo root. The documented default
+ * is `contracts/config/deployments/base-sepolia.json`, which is the only address book committed
+ * under that directory. Callers pass no `expectChainId`: the record carries `chainId`, so handing
+ * that same number back to the parser is a comparison that cannot fail.
+ *
+ * @param {string} root repo root
+ * @param {Record<string, string|undefined>} [env]
+ */
+export function deploymentPath(root, env = process.env) {
+  const override = env.SOAK_DEPLOYMENT;
+  if (override) return path.isAbsolute(override) ? override : path.join(root, override);
+  return path.join(root, ...DEFAULT_DEPLOYMENT);
+}
+
+/**
+ * Refuse a run whose RPC is not the chain the address book describes.
+ *
+ * The message names BOTH numbers on purpose. Which half is wrong — the record or the endpoint — is
+ * the only thing the operator has to decide, and a bare "chain id mismatch" makes them guess.
+ *
+ * @param {{chainId: number, chainName: string}} dep
+ * @param {number} liveChainId chain id read from the RPC
+ * @returns {number} the record's chain id, once the live one has matched it
+ */
+export function assertLiveChainId(dep, liveChainId) {
+  const live = Number(liveChainId);
+  if (live !== dep.chainId) {
+    throw new Error(
+      `deployment: address book ${dep.chainName || '(unnamed)'} is chain ${dep.chainId}, `
+      + `but the RPC answers chain ${live} — point SOAK_DEPLOYMENT and SOAK_RPC at the same chain`,
+    );
+  }
+  return dep.chainId;
 }

--- a/scripts/soak/drill1-multivault.mjs
+++ b/scripts/soak/drill1-multivault.mjs
@@ -20,8 +20,8 @@
  *
  * Vault B is also drill 3's Mode-F host, so this drill leaves it activated with live shares.
  *
- * Env: SOAK_SIGNER_ARGS (required for the write steps), BASE_SEPOLIA_RPC, SOAK_API,
- *      SOAK_STATE_DIR, SOAK_INDEXER_STATE, SOAK_RESET=1 to start over.
+ * Env: SOAK_SIGNER_ARGS (required for the write steps), SOAK_RPC (or BASE_SEPOLIA_RPC),
+ *      SOAK_DEPLOYMENT, SOAK_API, SOAK_STATE_DIR, SOAK_INDEXER_STATE, SOAK_RESET=1 to start over.
  * Run:  node scripts/soak/drill1-multivault.mjs
  */
 import fs from 'node:fs';
@@ -30,14 +30,11 @@ import {
   ROOT, RPC, log, assert, eq, call, callU, send, tryCall, chainNow, waitUntilChainTime, pollUntil,
   openState, runSteps, topicToAddress, TOPIC, SIGNER_ARGS, cast,
 } from './lib.mjs';
-import { loadDeployment, wiringExpectations } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment, wiringExpectations } from './deployment.mjs';
 import { apiGet } from './api-client.mjs';
 import { vaultsIn, headBlockOf } from './snapshot.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 const soak = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'soak', 'soak-vaults.json'), 'utf8'));
 const B = soak.vaultB;
 
@@ -61,8 +58,7 @@ const TOKENS_B = tokensFor(B.basket);
 
 function preflight() {
   log(`rpc=${RPC}  factory=${dep.factory}`);
-  const chainId = Number(cast(['chain-id', '--rpc-url', RPC]));
-  assert(chainId === dep.chainId, `RPC chain id ${chainId} != address-book chainId ${dep.chainId}`);
+  assertLiveChainId(dep, Number(cast(['chain-id', '--rpc-url', RPC])));
 
   // Re-prove the address book against the chain. A committed JSON file can drift from a
   // redeploy; spending a signature against a stale book is the expensive way to find out.

--- a/scripts/soak/drill2-subvault.mjs
+++ b/scripts/soak/drill2-subvault.mjs
@@ -37,7 +37,8 @@
  * Wall clock: parent deposit + 4h observation window, then 2 governance rounds of
  * (1h commit + 1h reveal) each. Budget ~8h, nearly all of it waiting. Resumable throughout.
  *
- * Env: SOAK_SIGNER_ARGS (required), BASE_SEPOLIA_RPC, SOAK_API, SOAK_STATE_DIR, SOAK_RESET=1.
+ * Env: SOAK_SIGNER_ARGS (required), SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT, SOAK_API,
+ *      SOAK_STATE_DIR, SOAK_RESET=1.
  * Run:  node scripts/soak/drill2-subvault.mjs
  */
 import fs from 'node:fs';
@@ -47,13 +48,10 @@ import {
   ROOT, RPC, log, assert, eq, call, callU, send, chainNow, waitUntilChainTime, pollUntil,
   openState, runSteps, topicToAddress, TOPIC, SIGNER_ARGS, cast, abiEncode, keccakOf, readProposal,
 } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 import { apiGet } from './api-client.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 const soak = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'soak', 'soak-vaults.json'), 'utf8'));
 const C = soak.childVault;
 const PARENT = soak.smokeVault.address;
@@ -80,8 +78,7 @@ const ALLOCATE_USDC = String(C.allocateUsdc ?? 2_000_000n);
 
 function preflight() {
   log(`rpc=${RPC}  parent=${PARENT}`);
-  const chainId = Number(cast(['chain-id', '--rpc-url', RPC]));
-  assert(chainId === dep.chainId, `RPC chain id ${chainId} != address-book chainId ${dep.chainId}`);
+  assertLiveChainId(dep, Number(cast(['chain-id', '--rpc-url', RPC])));
 
   if (!state.signer) {
     assert(SIGNER_ARGS.length > 0, 'SOAK_SIGNER_ARGS is required; this script never handles the key itself');

--- a/scripts/soak/drill3-modef.mjs
+++ b/scripts/soak/drill3-modef.mjs
@@ -43,7 +43,8 @@
  *
  * Host is vault B, created by drill 1 — run that first.
  *
- * Env: SOAK_SIGNER_ARGS (required), BASE_SEPOLIA_RPC, SOAK_STATE_DIR, SOAK_RESET=1.
+ * Env: SOAK_SIGNER_ARGS (required), SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT,
+ *      SOAK_STATE_DIR, SOAK_RESET=1.
  * Run:  node scripts/soak/drill3-modef.mjs
  */
 import fs from 'node:fs';
@@ -53,12 +54,9 @@ import {
   ROOT, RPC, log, assert, eq, call, callU, send, tryCall, chainNow, waitUntilChainTime,
   openState, runSteps, TOPIC, SIGNER_ARGS, cast, abiEncode, keccakOf, readProposal,
 } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 
 const STATE_DIR = process.env.SOAK_STATE_DIR ?? path.join(ROOT, 'scripts', 'soak');
 const STATE_PATH = path.join(STATE_DIR, '.state-drill3.json');
@@ -82,8 +80,7 @@ function resolveHost() {
 
 function preflight() {
   log(`rpc=${RPC}  governance=${dep.governance}`);
-  const chainId = Number(cast(['chain-id', '--rpc-url', RPC]));
-  assert(chainId === dep.chainId, `RPC chain id ${chainId} != address-book chainId ${dep.chainId}`);
+  assertLiveChainId(dep, Number(cast(['chain-id', '--rpc-url', RPC])));
 
   const vault = resolveHost();
   log(`Mode-F host: vault B ${vault}`);

--- a/scripts/soak/drill4-oraclefreeze.mjs
+++ b/scripts/soak/drill4-oraclefreeze.mjs
@@ -49,16 +49,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { ROOT, log, assert, openState } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { deploymentPath, loadDeployment } from './deployment.mjs';
 import {
   readSeries, summarize, findGaps, summarizeFreezeSafety, summarizeSequencer, oracleCanaryRows, verdictOf,
   freezeSafetyReport,
 } from './series-analysis.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 
 const SERIES = process.env.SOAK_SERIES ?? path.join(ROOT, 'data', 'oracle-series.jsonl');
 const CANARY_STATE = process.env.SOAK_CANARY_STATE ?? path.join(ROOT, 'data', 'canary-state.json');

--- a/scripts/soak/drill5-agent-execute.mjs
+++ b/scripts/soak/drill5-agent-execute.mjs
@@ -56,7 +56,8 @@
  *
  * Env (required): SOAK_AGENT_KEYSTORE, SOAK_AGENT_KEYSTORE_PASSWORD,
  *                 AGENT_I_UNDERSTAND_THIS_SPENDS_FUNDS=yes
- * Env (optional): BASE_SEPOLIA_RPC, SOAK_API, SOAK_STATE_DIR, SOAK_TICK_MS, SOAK_MAX_TICKS,
+ * Env (optional): SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT, SOAK_API, SOAK_STATE_DIR,
+ *                 SOAK_TICK_MS, SOAK_MAX_TICKS,
  *                 SOAK_AGENT_CAP_USDC (x402 session spend cap per phase poll window, default
  *                 5.00 — see the cap note in buildAgent), SOAK_PHASE (run a single phase),
  *                 SOAK_RESET=1
@@ -69,14 +70,11 @@ import {
   budgetExhaustedFailure,
   readProposal, votableNow,
 } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 import { loadAccountFromKeystore, redact } from '../lib/keystore.mjs';
 import { resolveAgentRunConfig, policyFor, TESTNET_CHAIN_IDS, EXECUTE_ENV_VAR } from './agent-policy.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 const soak = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'soak', 'soak-vaults.json'), 'utf8'));
 const VAULT = soak.smokeVault.address;
 
@@ -112,7 +110,7 @@ async function buildAgent(phase, cfgIn, account, walletClient, entryMarks = {}) 
       },
     },
     chain: {
-      rpcUrl: cfgIn.rpcUrl, chainId: dep.chainId, chainName: 'base-sepolia',
+      rpcUrl: cfgIn.rpcUrl, chainId: dep.chainId, chainName: dep.chainName,
       governance: dep.governance.toLowerCase(),
       subvaultRegistry: dep.subRegistry.toLowerCase(), // omit and the fee gate always blocks
       usdc: dep.usdc.toLowerCase(), usdcName: 'USDC', usdcVersion: '2',
@@ -190,7 +188,7 @@ const cfgIn = resolveAgentRunConfig(process.env);
 
 const chainId = Number(cast(['chain-id', '--rpc-url', cfgIn.rpcUrl]));
 assert(TESTNET_CHAIN_IDS.has(chainId), `refusing to run against chain ${chainId} — testnet only`);
-assert(chainId === dep.chainId, `RPC chain ${chainId} != address book ${dep.chainId}`);
+assertLiveChainId(dep, chainId);
 
 const account = await loadAccountFromKeystore(cfgIn.keystore, cfgIn.password);
 saveFirst('agent', account.address);

--- a/scripts/soak/drill5-fasttrack.mjs
+++ b/scripts/soak/drill5-fasttrack.mjs
@@ -24,20 +24,17 @@
  * fast track adds coverage rather than removing it. The report states this ordering plainly.
  *
  * Env: SOAK_AGENT_KEYSTORE, SOAK_AGENT_KEYSTORE_PASSWORD, AGENT_I_UNDERSTAND_THIS_SPENDS_FUNDS=yes,
- *      BASE_SEPOLIA_RPC. Testnet chain ids only.
+ *      SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT. Testnet chain ids only.
  * Run:  node scripts/soak/drill5-fasttrack.mjs
  */
 import fs from 'node:fs';
 import path from 'node:path';
 import { ROOT, RPC, log, assert, call, callU, cast, pollUntil } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 import { loadAccountFromKeystore } from '../lib/keystore.mjs';
 import { resolveAgentRunConfig, TESTNET_CHAIN_IDS } from './agent-policy.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 const soak = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'soak', 'soak-vaults.json'), 'utf8'));
 const VAULT = soak.smokeVault.address;
 const AMOUNT = 1_000_000n; // 1.00 USDC — the smoke vault minimum
@@ -54,6 +51,7 @@ const ERC20_ABI = [
 const cfg = resolveAgentRunConfig(process.env);
 const chainId = Number(cast(['chain-id', '--rpc-url', cfg.rpcUrl]));
 assert(TESTNET_CHAIN_IDS.has(chainId), `refusing chain ${chainId} — testnet only`);
+assertLiveChainId(dep, chainId);
 
 const account = await loadAccountFromKeystore(cfg.keystore, cfg.password);
 log(`fast-track for agent ${account.address} on ${VAULT}`);

--- a/scripts/soak/drill5-gov-companion.mjs
+++ b/scripts/soak/drill5-gov-companion.mjs
@@ -20,9 +20,10 @@
  * to logs/soak-pids.txt, so `run-soak.ps1 -Stop` reaches it; that matters because SOAK_SIGNER_ARGS
  * names a `--password-file` the operator deletes once the run is over.
  *
- * Env: SOAK_SIGNER_ARGS (deployer), BASE_SEPOLIA_RPC, SOAK_STATE_DIR, SOAK_RESET=1. run-soak.ps1
- *      sets the first two for the whole run; it never sets SOAK_STATE_DIR, and only reads it to
- *      find the state file this script writes.
+ * Env: SOAK_SIGNER_ARGS (deployer), SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT,
+ *      SOAK_STATE_DIR, SOAK_RESET=1. run-soak.ps1 sets SOAK_SIGNER_ARGS and SOAK_RPC for the whole
+ *      run; it never sets SOAK_STATE_DIR, and only reads it to find the state file this script
+ *      writes.
  * Run:  node scripts/soak/drill5-gov-companion.mjs   (standalone: the agent must already hold
  *       shares — drill5-fasttrack.mjs is one way to get there)
  */
@@ -33,12 +34,9 @@ import {
   ROOT, RPC, log, assert, call, callU, send, tryCall, waitUntilChainTime,
   openState, SIGNER_ARGS, cast, abiEncode, keccakOf, readProposal, pollUntil, TOPIC,
 } from './lib.mjs';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 const soak = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'soak', 'soak-vaults.json'), 'utf8'));
 const VAULT = soak.smokeVault.address;
 const AGENT = '0x290caf006794a73bB1ba928a38c2A7f099015a6d';
@@ -48,6 +46,7 @@ const STATE_PATH = path.join(STATE_DIR, '.state-drill5gov.json');
 const { state, save, saveFirst } = openState(STATE_PATH, dep.factory);
 
 log('DRILL 5 COMPANION — deployer half of the agent governance round (smoke vault)');
+assertLiveChainId(dep, Number(cast(['chain-id', '--rpc-url', RPC])));
 assert(SIGNER_ARGS.length > 0, 'SOAK_SIGNER_ARGS is required');
 if (!state.signer) saveFirst('signer', cast(['wallet', 'address', ...SIGNER_ARGS], { interactive: true }).split('\n').pop().trim());
 

--- a/scripts/soak/lib.mjs
+++ b/scripts/soak/lib.mjs
@@ -16,7 +16,8 @@
  *      from it: every assertion re-reads state with `cast call`. The runner's own output is
  *      not evidence about the chain.
  *
- * Env: BASE_SEPOLIA_RPC, SOAK_SIGNER_ARGS, CAST, and per-drill state paths.
+ * Env: SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT, SOAK_SIGNER_ARGS, CAST, and per-drill
+ *      state paths.
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -28,7 +29,16 @@ import { classifyCallError } from '../../packages/canary/src/call-error.mjs';
 // percent-encoded, so the raw pathname yields a directory that does not exist and every drill
 // dies at load resolving the address book under it.
 export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-export const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
+// SOAK_RPC is the chain-neutral name; BASE_SEPOLIA_RPC is read after it so an operator's existing
+// environment keeps working unchanged. The documented default is a Base Sepolia public node, which
+// is the chain `deploymentPath`'s default address book describes. A run elsewhere sets SOAK_RPC and
+// SOAK_DEPLOYMENT together, and `assertLiveChainId` refuses the pair when they disagree.
+//
+// `||`, not `??`, because agent-policy.mjs resolves the same two names with `||`. A shell that
+// exports SOAK_RPC empty would otherwise leave this at '' while drill 5's viem client fell through
+// to the default — the drill's cast reads and its writes on two endpoints, which no chain-id check
+// can see, since drill 5 reads the id through the viem side's url.
+export const RPC = process.env.SOAK_RPC || process.env.BASE_SEPOLIA_RPC || 'https://base-sepolia-rpc.publicnode.com';
 const CAST = process.env.CAST ?? 'cast';
 
 /**

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -53,17 +53,17 @@
  * Output: one JSON line per sample to the series file, so a gap in the series is visible as a
  * timestamp jump rather than being silently interpolated.
  *
- * Env: BASE_SEPOLIA_RPC, SOAK_SERIES (default data/oracle-series.jsonl),
+ * Env: SOAK_RPC (or BASE_SEPOLIA_RPC), SOAK_DEPLOYMENT, SOAK_SERIES (default data/oracle-series.jsonl),
  *      SOAK_SAMPLE_MS (default 120000), SOAK_PROBE_MEMBER (address to probe cancelPending as)
  */
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadDeployment } from './deployment.mjs';
+import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
+const RPC = process.env.SOAK_RPC || process.env.BASE_SEPOLIA_RPC || 'https://base-sepolia-rpc.publicnode.com';
 const CAST = process.env.CAST ?? 'cast';
 const SERIES = process.env.SOAK_SERIES ?? path.join(ROOT, 'data', 'oracle-series.jsonl');
 const SAMPLE_MS = Number(process.env.SOAK_SAMPLE_MS ?? 120_000);
@@ -99,10 +99,7 @@ function resolveProbeVaults() {
   }
 }
 
-const dep = loadDeployment(
-  path.join(ROOT, 'contracts', 'config', 'deployments', 'base-sepolia.json'),
-  { expectChainId: 84532 },
-);
+const dep = loadDeployment(deploymentPath(ROOT));
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const clean = (s) => s.replace(/\s+\[[^\]]*\]$/, '').trim();
@@ -382,11 +379,11 @@ function readFeedConfig(asset) {
 /**
  * Prove the deployed oracle is the one this sampler models, ONCE, before any series line exists.
  *
- * There is deliberately no fall-back to the retired quorum sampler: nothing points this script at a
- * pre-pivot address book (`loadDeployment` is pinned to `base-sepolia.json` / chain 84532), so a
- * legacy path here would be untested dead code. If the probe fails the sampler REFUSES rather than
- * writing a series nobody can trust — a soak that produces no evidence is recoverable, one that
- * produces wrong evidence is what this rewrite is fixing.
+ * There is deliberately no fall-back to the retired quorum sampler. `SOAK_DEPLOYMENT` now chooses
+ * the address book, so this probe — not a pin on the filename — is what establishes that the oracle
+ * answering is a ChainlinkOracle. If it fails the sampler REFUSES rather than writing a series
+ * nobody can trust: a soak that produces no evidence is recoverable, one that produces wrong
+ * evidence is what this rewrite is fixing.
  */
 function probeOracle() {
   const seq = callRaw(dep.aggregator, 'sequencerUptimeFeed()(address)');
@@ -503,6 +500,13 @@ const invokedDirectly = process.argv[1]
   && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
 if (invokedDirectly) {
+  // Before the first series line exists, prove the endpoint is the chain the address book
+  // describes. Everything downstream — the oracle probe, every price age, drill 4's whole verdict —
+  // is attributed to `dep`, so sampling the wrong chain writes a series that reads as evidence.
+  const idRead = tryCast(['chain-id', '--rpc-url', RPC]);
+  if (!idRead.ok) throw new Error(`oracle-sampler: could not read the chain id from ${RPC}: ${idRead.err}`);
+  assertLiveChainId(dep, Number(clean(idRead.out)));
+
   const { sequencerFeed } = probeOracle();
   const graceRead = callRaw(dep.aggregator, 'GRACE_PERIOD()(uint256)');
   const pinRead = callRaw(dep.aggregator, 'usdc()(address)');

--- a/scripts/soak/run-soak.ps1
+++ b/scripts/soak/run-soak.ps1
@@ -17,7 +17,14 @@
 #         powershell -ExecutionPolicy Bypass -File scripts\soak\run-soak.ps1 -Status
 #         powershell -ExecutionPolicy Bypass -File scripts\soak\run-soak.ps1 -Stop
 #
-# Env READ if you set it:  BASE_SEPOLIA_RPC (default https://sepolia.base.org)
+# Env READ if you set it:  SOAK_RPC         (default https://sepolia.base.org; BASE_SEPOLIA_RPC is
+#                                            read as a fallback so an existing environment still
+#                                            works. Set it together with SOAK_DEPLOYMENT when the
+#                                            run targets a chain other than Base Sepolia - every
+#                                            drill refuses a pair that disagrees, in
+#                                            deployment.mjs assertLiveChainId)
+#                          SOAK_DEPLOYMENT  (default contracts\config\deployments\base-sepolia.json,
+#                                            the address book that decides which chain is expected)
 #                          SOAK_API         (default http://127.0.0.1:8402)
 #                          SOAK_STATE_DIR   (default <repo>\scripts\soak - where the drills keep
 #                                            their resumable state; this script only reads it to
@@ -40,7 +47,6 @@ $ErrorActionPreference = 'Stop'
 $Root    = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $LogDir  = Join-Path $Root 'logs'
 $PidFile = Join-Path $LogDir 'soak-pids.txt'
-$Deployer = '0x0f80606a2283fD9C67cE2eEC79B90E95907F9f35'
 
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 Set-Location $Root
@@ -86,6 +92,20 @@ if (-not (Test-Path $SignerPasswordFile)) {
   throw "signer password file not found: $SignerPasswordFile`nCreate it with:`n  `"your-deployer-password`" | Out-File -NoNewline -Encoding ascii `"$SignerPasswordFile`""
 }
 
+# The address book, resolved exactly as deployment.mjs deploymentPath does, so the launcher and the
+# drills cannot disagree about which chain this run targets. Resolved HERE and not beside $PidFile:
+# $ErrorActionPreference is 'Stop', so a typo'd SOAK_DEPLOYMENT read above the -Status/-Stop blocks
+# would throw before -Stop could kill the pids - and -Stop is what reaches the detached companion
+# holding a --password-file.
+$Book = if ($env:SOAK_DEPLOYMENT) {
+          if ([System.IO.Path]::IsPathRooted($env:SOAK_DEPLOYMENT)) { $env:SOAK_DEPLOYMENT }
+          else { Join-Path $Root $env:SOAK_DEPLOYMENT }
+        } else { Join-Path $Root 'contracts\config\deployments\base-sepolia.json' }
+# Read the signer from that book rather than repeating it here. The preflight below unlocks a
+# keystore and compares the derived address against this value, so a second copy that drifted would
+# reject the correct key or accept the wrong one.
+$Deployer = (Get-Content -Raw $Book | ConvertFrom-Json).deployer
+
 $env:SOAK_SIGNER_ARGS = "--account deployer --password-file $SignerPasswordFile"
 
 # Prove the signer args work BEFORE launching anything long. This derives an address and
@@ -112,7 +132,13 @@ if ($runAgent -and -not (Test-Path $AgentPasswordFile)) {
   $runAgent = $false
 }
 
-$env:BASE_SEPOLIA_RPC = if ($env:BASE_SEPOLIA_RPC) { $env:BASE_SEPOLIA_RPC } else { 'https://sepolia.base.org' }
+# Resolve the endpoint once, in the order lib.mjs and agent-policy.mjs resolve it, and export it
+# under BOTH names: SOAK_RPC is what every soak script reads first, and BASE_SEPOLIA_RPC is left set
+# so a tool that only knows the old name still sees the same endpoint.
+$env:SOAK_RPC = if ($env:SOAK_RPC) { $env:SOAK_RPC }
+                elseif ($env:BASE_SEPOLIA_RPC) { $env:BASE_SEPOLIA_RPC }
+                else { 'https://sepolia.base.org' }
+$env:BASE_SEPOLIA_RPC = $env:SOAK_RPC
 $env:SOAK_API         = if ($env:SOAK_API) { $env:SOAK_API } else { 'http://127.0.0.1:8402' }
 # Drill 4's freeze-safety probe needs a member who actually HAS a pending deposit. The deployer
 # gets one during drill 1's and drill 2's 4h observation windows - that is the only window in
@@ -210,7 +236,7 @@ while ($true) {
   if (-not (Test-Path $statePath)) { Write-Host '  (no indexer state yet)'; continue }
   try {
     $last = (Get-Content $statePath -Raw | ConvertFrom-Json).lastBlock
-    $head = [int](cast block-number --rpc-url $env:BASE_SEPOLIA_RPC)
+    $head = [int](cast block-number --rpc-url $env:SOAK_RPC)
     $lag = $head - $last
     Write-Host ("  indexer at {0}, head {1} (lag {2} blocks)" -f $last, $head, $lag)
     if ($lag -le 20) { Write-Host '  caught up.' -ForegroundColor Green; break }

--- a/scripts/test/soak-deployment.test.mjs
+++ b/scripts/test/soak-deployment.test.mjs
@@ -12,7 +12,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { parseDeployment, wiringExpectations, loadDeployment } from '../soak/deployment.mjs';
+import {
+  parseDeployment, wiringExpectations, loadDeployment, deploymentPath, assertLiveChainId,
+} from '../soak/deployment.mjs';
 import { classifyCancelPending, SEL_NO_PENDING } from '../soak/oracle-sampler.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '..', '..');
@@ -138,6 +140,51 @@ test('the committed base-sepolia address book parses and is chain-84532', () => 
   }
   // The oracle resolves to the deployed ChainlinkOracle in the factory allowlist.
   assert.equal(d.aggregator, '0x3a8bd8a6599c3fdd0b3a269e0142e6b468ddd935');
+});
+
+// ── which chain a soak run targets ────────────────────────────────────────────
+//
+// The expected chain id used to be written down nine times: once per soak entrypoint as
+// `{ expectChainId: 84532 }`, and again in each record's own `chainId`. These pin the one that
+// survived — the record's — and the check that the endpoint agrees with it.
+
+test('a 4663 address book against a live chain 84532 refuses, naming both numbers', () => {
+  // The failure this exists to make legible: a Robinhood Chain 4663 record loaded while SOAK_RPC
+  // still points at Base Sepolia. Both halves are plausible on their own, so the message has to say
+  // which is which or the operator cannot tell whether to change the record or the endpoint.
+  const raw = { ...good(), chainId: 4663, chainName: 'robinhood-mainnet' };
+  const dep = parseDeployment(raw);
+  assert.throws(() => assertLiveChainId(dep, 84532), (e) => {
+    assert.match(e.message, /4663/, 'the record chain id must appear');
+    assert.match(e.message, /84532/, 'the live chain id must appear');
+    assert.match(e.message, /robinhood-mainnet/, 'name the book, so the operator knows which file');
+    return true;
+  });
+});
+
+test('the mismatch is symmetric — a Base Sepolia book against live 4663 refuses too', () => {
+  // Not a formality: a guard that only fires in one direction lets the exact reverse mistake — the
+  // committed base-sepolia.json left in place while SOAK_RPC is repointed — run to completion and
+  // write a series attributed to the wrong chain.
+  const dep = parseDeployment(good());
+  assert.throws(() => assertLiveChainId(dep, 4663), /is chain 84532, but the RPC answers chain 4663/);
+});
+
+test('a matching pair passes and hands back the record chain id', () => {
+  const dep = parseDeployment(good());
+  assert.equal(assertLiveChainId(dep, 84532), 84532);
+  // cast prints the id as text; a string that matches numerically must not be refused.
+  assert.equal(assertLiveChainId(dep, '84532'), 84532);
+});
+
+test('deploymentPath defaults to the committed book and SOAK_DEPLOYMENT overrides it', () => {
+  assert.equal(deploymentPath(ROOT, {}), BOOK);
+  const abs = path.join(ROOT, 'contracts', 'config', 'deployments', 'elsewhere.json');
+  assert.equal(deploymentPath(ROOT, { SOAK_DEPLOYMENT: abs }), abs);
+  // A relative override resolves against the repo root, not the process cwd: the drills are run
+  // from wherever the operator happens to be standing.
+  assert.equal(deploymentPath(ROOT, { SOAK_DEPLOYMENT: 'contracts/config/deployments/rh.json' }),
+    path.join(ROOT, 'contracts/config/deployments/rh.json'));
 });
 
 // ── freeze-safety classifier (drill 4) ────────────────────────────────────────

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -728,6 +728,17 @@ test('resolveAgentRunConfig accepts a complete environment and defaults the API 
   assert.match(c.rpcUrl, /^https:\/\//);
 });
 
+test('SOAK_RPC outranks BASE_SEPOLIA_RPC, which still works on its own', () => {
+  // Drill 5's viem writes go to whatever this returns while its cast reads go to lib.mjs's `RPC`.
+  // The two resolve in the same order, so an operator who sets only the new name, or only the old
+  // one, gets one endpoint rather than two.
+  assert.equal(resolveAgentRunConfig({ ...okEnv, SOAK_RPC: 'https://a.example' }).rpcUrl, 'https://a.example');
+  assert.equal(resolveAgentRunConfig({ ...okEnv, BASE_SEPOLIA_RPC: 'https://b.example' }).rpcUrl, 'https://b.example');
+  assert.equal(
+    resolveAgentRunConfig({ ...okEnv, SOAK_RPC: 'https://a.example', BASE_SEPOLIA_RPC: 'https://b.example' }).rpcUrl,
+    'https://a.example', 'SOAK_RPC wins when both are set');
+});
+
 test('resolveAgentRunConfig names EVERY problem at once, not just the first', () => {
   // An operator fixing a three-item misconfiguration one error at a time is an operator who
   // eventually pastes a private key into a shell to make it stop.
@@ -1240,6 +1251,75 @@ test('the two seams the fixture cannot execute are pinned as source text instead
     'the local min is still what the diagnostic line prints as boundedWeight');
 });
 
+// ───────── no soak entrypoint may pin a chain id in its own source ─────────
+//
+// Eight entrypoints each carried `{ expectChainId: 84532 }` beside their `loadDeployment` call, so
+// the expected chain was written down eight times and the address book's own `chainId` a ninth.
+// Pointing a run at another chain meant editing all eight, and until someone did, drill coverage
+// was reachable on Base Sepolia and nowhere else. The chain id now comes from the record, and
+// `assertLiveChainId` proves the endpoint matches it.
+//
+// A source-text pin, like the run-soak.ps1 tests below, because these files execute at import and
+// no node test can run them. What it catches is the defect that actually happens: a new drill, or
+// an edit to an old one, quietly re-pinning a literal in a file nothing else checks.
+
+const SOAK_ENTRYPOINTS = [
+  'drill1-multivault.mjs', 'drill2-subvault.mjs', 'drill3-modef.mjs', 'drill4-oraclefreeze.mjs',
+  'drill5-agent-execute.mjs', 'drill5-fasttrack.mjs', 'drill5-gov-companion.mjs',
+  'oracle-sampler.mjs',
+];
+
+test('the eight soak entrypoints contain no chain-id literal at all', () => {
+  for (const name of SOAK_ENTRYPOINTS) {
+    const src = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', name), 'utf8');
+    assert.doesNotMatch(src, /\b84532\b/, `${name} still names Base Sepolia's chain id`);
+    // Every chain id, not just this one: re-pinning 4663 in a drill would recreate the same
+    // defect pointing the other way.
+    assert.doesNotMatch(src, /expectChainId/,
+      `${name} passes expectChainId — the record's own chainId is the expected value`);
+  }
+});
+
+test('every soak entrypoint loads the address book through deploymentPath', () => {
+  // The other half of the same property. Dropping the literal but keeping a hardcoded
+  // `path.join(ROOT, ..., 'base-sepolia.json')` would leave the file un-repointable and this
+  // file's 84532 assertion above would still pass.
+  for (const name of SOAK_ENTRYPOINTS) {
+    const src = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', name), 'utf8');
+    assert.match(src, /loadDeployment\(deploymentPath\(ROOT\)\)/,
+      `${name} must resolve its address book through deploymentPath`);
+    assert.doesNotMatch(src, /'base-sepolia\.json'/,
+      `${name} names the Base Sepolia book directly, so SOAK_DEPLOYMENT cannot repoint it`);
+  }
+});
+
+test('the one surviving 84532 is the drill-5 testnet allowlist, and it is still a Set of chain ids', () => {
+  // NOT swept, deliberately. `TESTNET_CHAIN_IDS` is the gate that stops a throwaway keystore
+  // signing on a chain where the funds are real; widening it is a launch-parameter decision, not a
+  // portability fix. Pinned here so the exemption stays exactly this one declaration — a second
+  // 84532 appearing elsewhere in agent-policy.mjs would go unnoticed if the file were skipped.
+  const src = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'agent-policy.mjs'), 'utf8');
+  const hits = src.match(/\b84532\b/g) ?? [];
+  assert.equal(hits.length, 1, 'agent-policy.mjs must name 84532 exactly once');
+  assert.match(src, /export const TESTNET_CHAIN_IDS = new Set\(\[84532, /,
+    'the single occurrence must be the testnet allowlist');
+});
+
+test('the soak scripts resolve their RPC from SOAK_RPC first, then BASE_SEPOLIA_RPC', () => {
+  // Two resolvers, two files: lib.mjs drives every `cast` read and write, agent-policy.mjs drives
+  // drill 5's viem client. Letting them disagree would put the reads and the writes of one drill on
+  // two different endpoints, which is exactly the kind of split a chain-id check cannot see.
+  // Same names AND the same operator. `??` in one and `||` in the other agree on every set value
+  // and disagree on an exported-but-empty one, which is precisely the split this pins shut — and
+  // one `assertLiveChainId` cannot catch, because drill 5 reads the chain id through the viem url.
+  const lib = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'lib.mjs'), 'utf8');
+  assert.match(lib, /process\.env\.SOAK_RPC \|\| process\.env\.BASE_SEPOLIA_RPC \|\|/);
+  const sampler = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'oracle-sampler.mjs'), 'utf8');
+  assert.match(sampler, /process\.env\.SOAK_RPC \|\| process\.env\.BASE_SEPOLIA_RPC \|\|/);
+  const policy = fs.readFileSync(path.join(LIB_ROOT, 'scripts', 'soak', 'agent-policy.mjs'), 'utf8');
+  assert.match(policy, /rpcUrl: env\.SOAK_RPC \|\| env\.BASE_SEPOLIA_RPC \|\| defaultRpc/);
+});
+
 // ───────── the launcher wiring: run-soak.ps1 must actually start the companion ─────────
 //
 // The votability gate taught drill 5 to say "no votable round" instead of stalling for 40 ticks,
@@ -1267,6 +1347,38 @@ const PS_ACTIVATE = /New-NodeStep 'scripts\/soak\/drill5-agent-execute\.mjs' 'ac
 const PS_COMPANION = /Start-Process[^\n]*drill5-gov-companion\.mjs/;
 const PS_VOTE = /New-NodeStep 'scripts\/soak\/drill5-agent-execute\.mjs'\s*$/m;
 const PS_WAIT = /\$comp\.WaitForExit\(\)/;
+
+test('the launcher takes the signer and the endpoint from the same places the drills do', () => {
+  // run-soak.ps1 hardcoded the deployer address and defaulted only BASE_SEPOLIA_RPC. Both were
+  // copies of something the drills resolve differently, so a run repointed at another chain would
+  // have had its preflight compare the unlocked key against Base Sepolia's deployer and reject it.
+  // No node test can execute PowerShell in CI (ubuntu-latest), so these are text pins.
+  assert.match(RUN_SOAK, /\$Deployer = \(Get-Content -Raw \$Book \| ConvertFrom-Json\)\.deployer/,
+    'the signer must come from the address book, not a second copy in the launcher');
+  assert.doesNotMatch(RUN_SOAK, /\$Deployer = '0x/, 'no hardcoded deployer address may return');
+  assert.match(RUN_SOAK, /\$env:SOAK_DEPLOYMENT/, '$Book must honour the same override the drills read');
+  assert.match(RUN_SOAK, /base-sepolia\.json/, 'and fall back to the same committed default');
+
+  // SOAK_RPC first, BASE_SEPOLIA_RPC second — lib.mjs's order. Then BOTH are exported, so a child
+  // reading either name sees one endpoint.
+  const rpc = /\$env:SOAK_RPC = if \(\$env:SOAK_RPC\) \{ \$env:SOAK_RPC \}[\s\S]*?elseif \(\$env:BASE_SEPOLIA_RPC\)[\s\S]*?else \{ 'https:\/\/sepolia\.base\.org' \}/;
+  assert.match(RUN_SOAK, rpc);
+  assert.match(RUN_SOAK, /\$env:BASE_SEPOLIA_RPC = \$env:SOAK_RPC/);
+});
+
+test('reading the address book cannot break -Stop, because it happens after that block', () => {
+  // $ErrorActionPreference is 'Stop'. Resolving $Book above the -Status/-Stop early exits would let
+  // a typo'd SOAK_DEPLOYMENT throw before -Stop killed the pids — and -Stop is the only thing that
+  // reaches the detached companion, which runs with a --password-file the operator deletes after
+  // the run. The read belongs below those exits, where it is first needed.
+  const iStop = anchorAt(/^if \(\$Stop\) \{/m, 'the -Stop block');
+  const iExit = RUN_SOAK.indexOf('exit 0', iStop);
+  assert.ok(iExit > iStop, 'the -Stop block must still end in an early exit');
+  const iBook = anchorAt(/\$Book = if \(\$env:SOAK_DEPLOYMENT\)/, 'the address-book resolution');
+  const iDeployer = anchorAt(/\$Deployer = \(Get-Content -Raw \$Book/, 'the signer read');
+  assert.ok(iBook > iExit, '$Book must resolve only after -Stop has already exited');
+  assert.ok(iDeployer > iBook, 'the signer is read from $Book, so it comes after it');
+});
 
 test('run-soak.ps1 starts the governance companion, between drill 5 activating and voting', () => {
   // The ordering is FORCED, not a preference: drill5-gov-companion.mjs refuses to propose until


### PR DESCRIPTION
Clears the gate-3 blocker in the vault runbook `Runbooks/Robinhood Mainnet Deploy.md` — the one
the brief for this change calls **blocker 5**. The runbook states it twice: at preflight item **P7**,
which lists all eight pins by file and line and concludes "**gate 3 cannot be earned on 4663 as the
code stands**", and again at **§3 item 4**, "No soak, and none is reachable." Nothing in this PR
touches 4663 itself; it removes the reason a soak could not be pointed at any chain but Base Sepolia.

## The defect

Eight soak entrypoints each carried `{ expectChainId: 84532 }` beside their own `loadDeployment`
call, and `deployment.mjs` threw on mismatch. So the expected chain id was written down eight times,
and the address book's own `chainId` a ninth. Repointing a run meant editing eight files that had no
reason to disagree.

## The fix — one place, and a check a literal could not make

- **`deploymentPath(ROOT)`** picks the record. `SOAK_DEPLOYMENT` overrides it (absolute, or relative
  to the repo root); the documented default is the committed
  `contracts/config/deployments/base-sepolia.json`, the only address book under that directory.
- **No caller passes `expectChainId`.** `loadDeployment`'s signature is unchanged and the option
  still works, but a drill passing the record's own `chainId` back to the parser would be a
  comparison that cannot fail. The record's `chainId` *is* the expected value.
- **`assertLiveChainId(dep, live)`** is what replaces the pin: it compares the record against the id
  the RPC answers and names both numbers plus the book. Drills 1, 2, 3 and 5 already made that
  comparison inline with four different messages and now share one. **drill5-fasttrack,
  drill5-gov-companion and oracle-sampler never made it at all** — dropping their filename pin
  without adding the live check would have been a net loss of safety, so they gained it here.
  drill4-oraclefreeze reads a recorded series and opens no RPC, so it has nothing to compare.

A Robinhood record therefore drives the same drills with no drill edit: `SOAK_DEPLOYMENT` selects it,
`SOAK_RPC` selects the endpoint, and the pair is refused if they disagree.

## Every other Base-Sepolia literal in `scripts/soak`, and what happened to it

Parameterised (chain-shaped):

| Where (line numbers as they stand on `protocol/main`) | Was | Now |
|---|---|---|
| `lib.mjs:31` | `BASE_SEPOLIA_RPC ?? <publicnode>` | `SOAK_RPC \|\| BASE_SEPOLIA_RPC \|\| <publicnode>`, default documented in place |
| `oracle-sampler.mjs:66` | same | same |
| `agent-policy.mjs:44` | `env.BASE_SEPOLIA_RPC \|\| defaultRpc` | `env.SOAK_RPC \|\| env.BASE_SEPOLIA_RPC \|\| defaultRpc` |
| `run-soak.ps1:115` | set `BASE_SEPOLIA_RPC` only | resolves once in that order, exports **both** names |
| `run-soak.ps1:213` | read `$env:BASE_SEPOLIA_RPC` | reads `$env:SOAK_RPC` |
| `run-soak.ps1:43` `$Deployer` | hardcoded `0x0f80…9f35` | `(Get-Content -Raw $Book \| ConvertFrom-Json).deployer` — the launcher unlocks a keystore and compares the derived address against this, so a stale second copy would reject the correct key |
| `drill5-agent-execute.mjs:115` | `chainName: 'base-sepolia'` | `chainName: dep.chainName` |
| nine `Env:` header sentences | named `BASE_SEPOLIA_RPC` alone | name `SOAK_RPC (or BASE_SEPOLIA_RPC)` and `SOAK_DEPLOYMENT` (`lib.mjs`, drills 1/2/3, drill5-agent-execute, drill5-fasttrack, drill5-gov-companion, oracle-sampler, `run-soak.ps1`) |
| `oracle-sampler.mjs:386` | a comment claiming `loadDeployment` "is pinned to `base-sepolia.json` / chain 84532" | rewritten — that sentence became false with this change |

`explorer` needed no work: `parseDeployment` exposes it and nothing in `scripts/soak` consumes it or
hardcodes an explorer URL.

Two details in that table that are load-bearing rather than cosmetic:

- **All three RPC resolvers use `||`, not `??`.** `??` and `||` agree on every set value and
  disagree on an exported-but-empty one. `lib.mjs` was `??` in the first draft of this PR, which
  would have left `RPC` as `''` under `SOAK_RPC=""` while drill 5's viem client fell through to the
  default — the same drill's `cast` reads and its writes on two endpoints. `assertLiveChainId`
  cannot see that split, because drill 5 reads the chain id through the viem side's url. Pinned by
  a test that matches the operator, not just the names.
- **`run-soak.ps1` resolves `$Book` *below* the `-Status`/`-Stop` early exits.** `$ErrorActionPreference`
  is `'Stop'`, so reading the address book above them would let a typo'd `SOAK_DEPLOYMENT` throw
  before `-Stop` killed the pids — and `-Stop` is what reaches the detached governance companion,
  which runs with a `--password-file` the operator deletes after the run. Pinned by an index-order
  test.

**Left alone, deliberately, and why** (line numbers on this branch):

- **`agent-policy.mjs:22` `TESTNET_CHAIN_IDS = new Set([84532, …])`** — the gate that stops a
  throwaway keystore signing where funds are real. Widening it is a launch decision (SWARM §10), not
  a portability fix. It is now pinned by a test as the *single* surviving `84532` in that file, so a
  second occurrence cannot hide behind the exemption. **Drill 5 consequently still refuses chain
  4663; that is a separate, human decision.**
- **`soak-vaults.json`** — Base Sepolia vault addresses and baskets read on-chain. Genuine record
  data, exactly as the brief specifies.
- **`drill5-agent-execute.mjs:116` `usdcName: 'USDC', usdcVersion: '2'`** — USDC's EIP-712 domain
  differs by deployment; this repo's own `apps/api/src/facilitator.mjs:57` defaults the same field to
  `'USD Coin'`. No address-book field carries it today, so parameterising it needs a record-schema
  change and an on-chain read. **Residual, reported not fixed.**
- **`drill5-agent-execute.mjs:217` / `drill5-fasttrack.mjs:60` `chain: baseSepolia`** (viem) — already
  inconsistent with `TESTNET_CHAIN_IDS`, which admits four chains. I did not verify how the reference
  agent's `writeContract` treats the client's `chain`, so I have not touched a signing path on an
  unverified reading. **Residual, reported not fixed.**
- **`drill5-gov-companion.mjs:42` `AGENT = '0x290caf…'`**, and the `faucet.circle.com, Base Sepolia`
  hints at `drill1:82` / `drill2:101`, and the Base-Sepolia sequencer prose in `drill4-oraclefreeze`
  (`:22`, `:111`, `:137`, `:158`), `oracle-sampler:216`, `series-analysis:119,:338` — none are RPC,
  chain id or explorer, and the sequencer paragraphs overlap the in-flight sequencer-exemption PR.
  Listed rather than edited (SWARM §4).
- **`scripts/smoke-test.mjs:41`** reads `BASE_SEPOLIA_RPC` only. Outside `scripts/soak`, and another
  session is editing that file. **Reported, untouched.**

## Docs

- **`docs/SOAK-REPORT.md` — not edited, and not stale.** Its three "Base Sepolia" sentences (`:5`,
  `:18`, `:43`) and `:261` `base-sepolia-rpc.publicnode.com` all describe the 2026-08-24→25 run,
  which happened on Base Sepolia. They are a historical record, and this change does not make any of
  them false.
- **`run-soak.ps1`'s header — edited**, because its `Env READ if you set it: BASE_SEPOLIA_RPC` line
  did become incomplete. It now documents `SOAK_RPC` (with the fallback and the default) and
  `SOAK_DEPLOYMENT`.

## Tests — eleven new, all mutation-proved

`scripts/test/soak-deployment.test.mjs`
- a 4663 record against a live 84532 refuses, and the message names **both** ids and the book
- the mismatch is symmetric (Base Sepolia book, live 4663)
- a matching pair passes and returns the record id, including `cast`'s string output
- `deploymentPath` defaults, takes an absolute override, and resolves a relative one against the
  repo root rather than the process cwd

`scripts/test/soak-drills.test.mjs` (source-text pins, matching the existing `run-soak.ps1` ones —
these files execute at import, so no node test can run them)
- the eight entrypoints contain no `84532` and no `expectChainId`
- …and each loads through `deploymentPath`, with no direct `'base-sepolia.json'` — dropping the
  literal while keeping a hardcoded path would otherwise pass the test above
- `agent-policy.mjs` names `84532` exactly once, and that once is the allowlist declaration
- all three RPC resolvers keep the same precedence **and the same operator**
- `SOAK_RPC` outranks `BASE_SEPOLIA_RPC`, each works alone (behavioural, via `resolveAgentRunConfig`)
- the launcher's signer comes from the book and its RPC is exported under both names
- the launcher reads the book only after the `-Stop` block has already exited

**Mutation proof: 15 mutations applied one at a time, each restored by file copy and confirmed with
`git diff`. Every one was caught, by the intended test** — message dropping the live id / the book
name; the comparison never firing; `SOAK_DEPLOYMENT` ignored; a relative override resolved against
cwd; a drill re-pinning `expectChainId: 84532`; a drill hardcoding the book path; a second `84532`
in `agent-policy.mjs`; any RPC resolver dropping `SOAK_RPC`; `lib.mjs` or `oracle-sampler.mjs`
switching back to `??`; the launcher re-hardcoding `$Deployer`; the launcher not exporting
`BASE_SEPOLIA_RPC`; the book read moved above the `-Stop` exit.

## Counts

- `soak-drills.test.mjs` + `soak-deployment.test.mjs`: **118 pass, 0 fail** (baseline on this branch
  point before the change: 107 pass, 0 fail).
- All of `scripts/test/*.test.mjs`: **241 tests, 236 pass, 4 fail, 1 skipped.** All four failures are
  in `contracts-size-truth.test.mjs`, which I did not touch — that suite is 0/4 on its own in this
  worktree because there is no `contracts/out`. `forge` was not run (shared `~/.foundry` deadlocks
  across sessions), so those reds are expected here and are not caused by this change.
- `claims-lede-truth` + `config-doc-truth`: 25 pass, 0 fail.

No contract source changed, so there is no gas or EIP-170 delta to report.

