### PR TITLE
fix(canary): a zero sequencer feed is not-applicable, not a check that cannot run

### DIFF
--- a/docs/CANARY.md
+++ b/docs/CANARY.md
@@ -1,7 +1,8 @@
 # Canary — post-launch monitoring
 
 The canary watches a deployed vault set and **stays silent while healthy**. It prints one line per
-signal *transition* (OK→ALERT, ALERT→OK, OK→DEGRADED), so anything it says is worth reading. It is
+signal *transition* (OK→ALERT, ALERT→OK, OK→DEGRADED), plus a one-off NOTICE for a check
+that does not apply to this deployment (§2), so anything it says is worth reading. It is
 the runnable form of the signal table in [DEPLOYMENT.md §6](DEPLOYMENT.md).
 
 "Silent while healthy" is a claim about transition lines specifically. By default the canary also
@@ -62,7 +63,7 @@ Every line carries the **vault**, the **signal**, and **measured vs threshold**.
 degradations go to stderr, recoveries to stdout, so `2>` gives a pure problem feed. The webhook body
 carries the same fields plus the structured `detail` for routing.
 
-Three statuses, rendered as four marks:
+Three statuses, rendered as five marks:
 
 - **ALERT** — measured, out of threshold. Page.
 - **RECOVERED** — back within threshold.
@@ -73,6 +74,13 @@ Three statuses, rendered as four marks:
 - **DETECTOR BROKEN** — the check could not run because the **monitor itself is blind**: it cannot
   reach its target, does not understand the contract it is pointed at, or threw. Nothing was
   measured and nobody knows what is being missed.
+- **NOTICE** — the check does not APPLY to this deployment: the contract path it watches is inert,
+  so the condition it reports on cannot arise here at all. Carried on an `ok` result (see
+  `notApplicable()` in `src/signal.mjs`), stated **once** per tracked signal id
+  (`signal|vault|key`, so once per vault) on the first sighting and never again, and it never counts
+  toward the not-OK tally. This is the opposite of DEGRADED, and the distinction is
+  the point: DEGRADED means something might be wrong and the check cannot see it, NOTICE means there
+  is nothing there to see.
 
 A standing problem is reported **once**, not every poll, and the state survives a restart.
 **DETECTOR BROKEN is the single exception**: it is re-asserted on a doubling backoff — sweeps 1, 2,
@@ -128,6 +136,24 @@ event-driven: it only writes on an up↔down transition, so a months-old `update
 steady state. Staleness-checking it would report a permanent outage on a perfectly healthy chain —
 and `_requireSequencerUp` ignores it for exactly that reason. It gets its own transition key
 (`sequencer`), because when it trips it freezes every vault on the oracle at once.
+
+**On an oracle deployed with no uptime feed, the leg is NOT-APPLICABLE, not degraded.**
+`sequencerUptimeFeed` is immutable (`ChainlinkOracle.sol:75`) and `_requireSequencerUp` returns
+without reading a feed when it is `address(0)` (`ChainlinkOracle.sol:314`), so no sequencer state
+can ever freeze such a vault. The canary says so once per vault, as a NOTICE, and is silent
+thereafter — it does not repeat a "cannot run" line on every vault on every sweep for the life of
+the deployment,
+and the leg does not sit in the not-OK tally forever. Every other guard in `priceWad` is unaffected
+and still measured per asset: unlisted feed, dead or non-positive answer, unset or future timestamp,
+the heartbeat, and the sane-price band (`ChainlinkOracle.sol:285-304`).
+
+**Which chains may ship without an uptime feed is not the canary's call.** It is settled before the
+oracle exists, by `DeployChainlinkOracle.requiresSequencerUptimeFeed`
+(`contracts/script/DeployChainlinkOracle.s.sol:59`), which blocks the broadcast, and re-checked
+read-only by `scripts/verify-chainlink-oracle.mjs`. A monitor pointed at an already-immutable
+contract cannot revisit that decision, and the line it used to print tried to: it named Base
+mainnet and a local/testnet chain as the only two possibilities, which are both wrong at once on a
+sequencer L2 whose vendor publishes no uptime feed.
 
 **Threshold.** `priceWad` returns. There is also a pre-trip early-warning bar that alerts while the
 vault is still priceable, once the answer has aged past it — and unlike the first cut of this
@@ -551,11 +577,16 @@ vault. The cases:
 | `exit-liveness sentinel CANNOT RUN … no member holding shares` | the projection lists no holder to probe with | wait for the first deposit, or check the indexer is caught up |
 | `… not in the indexer projection` | the vault is in `VAULTS` but not in the snapshot | point `STATE_PATH` at a caught-up indexer, or set `START_BLOCK` to the factory deploy block so the vault is discovered |
 | `… reverts StaleOracle` (NAV, exit liveness) | the oracle breaker is tripped | signal (a) is paging for the real cause; coverage resumes when the breaker clears |
-| `sequencer gate not configured … sequencerUptimeFeed is address(0)` | the oracle has no uptime feed | correct off a sequencer L2 (Base Sepolia leaves it `address(0)` by design, so expect exactly one line per vault on testnet). **On Base mainnet it means the deployment shipped with no sequencer guard at all** |
 | `no vaults to watch` | empty watch set | set `VAULTS`, or point `STATE_PATH` at a snapshot that has seen a `VaultCreated` |
 | `feed identity cannot be checked … feedOf() lists no feed for it` | the asset is unlisted, or it is the oracle's pinned USDC leg | if unlisted, signal (a) is already paging (`priceWad` reverts permanently); if it is the pin, there is no aggregator behind it and nothing to drift |
 
 An empty watch set is reported loudly rather than read as a clean bill of health.
+
+**A deployment with no sequencer uptime feed is no longer in this table.** It used to be, as
+`sequencer gate not configured … sequencerUptimeFeed is address(0)`, and that was the wrong class:
+it is not a check that cannot run today and might run tomorrow, it is a check with no subject in
+this deployment for as long as the oracle exists. It now emits one NOTICE line per vault and is
+`ok` thereafter — see §3(a) and the NOTICE mark in §2.
 
 **DETECTOR BROKEN lines are a different class** — the monitor is blind, not the vault. They
 re-assert on a backoff until fixed:
@@ -675,8 +706,8 @@ citation of Operations' spec, not an escalation inferred here, and unconditional
 `CONDITIONAL_PAGE` because no on-chain predicate separates a routine proposal from a hostile one
 (see §3(h)). **The waking-hours half is the receiver's**: nothing in this process knows the time of
 day, and no string it emits promises a response time. `LOG_WEBHOOK_URL` receives every
-other transition: recoveries, every DEGRADED / DETECTOR BROKEN line, and the harmless half of
-`feed-identity`. `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback used for whichever of
+other transition: recoveries, every DEGRADED / DETECTOR BROKEN / NOTICE line, and the harmless
+half of `feed-identity`. `ALERT_WEBHOOK_URL` remains the backwards-compatible fallback used for whichever of
 the two is unset — set only that one and every transition reaches the one configured URL exactly
 once per transition, same as before tiering existed. The webhook body also carries a `tier: 'page'|
 'log'` field, so a receiver on a single shared URL can still route without re-deriving the map.

--- a/packages/canary/src/canary-runner.mjs
+++ b/packages/canary/src/canary-runner.mjs
@@ -2,7 +2,9 @@
 /**
  * Runnable canary entrypoint. Point it at a deployed testnet and it stays SILENT until something
  * is genuinely wrong: one line per signal TRANSITION (OK→ALERT, ALERT→OK, OK→DEGRADED), nothing
- * at all while every signal is healthy.
+ * at all while every signal is healthy. The one exception is a NOTICE: a check with no subject in
+ * this deployment states that once, on its first sighting, and is silent for good after it (see
+ * `notApplicable()` in signal.mjs).
  *
  * STRICTLY READ-ONLY. It builds a viem *public* client (see reader.mjs) and issues only
  * eth_blockNumber / eth_getBlockByNumber / eth_call / eth_getLogs. It never sends a transaction,
@@ -29,7 +31,8 @@
  *                              waking-hours half is the receiver's to implement; nothing in this
  *                              process knows the time of day or promises a response.
  *   LOG_WEBHOOK_URL            POST one JSON body per LOG-tier transition — everything else,
- *                              including every DEGRADED/DETECTOR BROKEN line and feed-identity.
+ *                              including every DEGRADED/DETECTOR BROKEN/NOTICE line and
+ *                              feed-identity.
  *   ALERT_WEBHOOK_URL          back-compat fallback: used for whichever of PAGE_WEBHOOK_URL /
  *                              LOG_WEBHOOK_URL is unset. Set only this and behaviour is unchanged
  *                              from before tiering existed — every transition to one URL.
@@ -86,8 +89,8 @@
  *                              §5.2: with it off, a dead canary and a healthy protocol are the same
  *                              observation. This does NOT touch "silence means healthy" for
  *                              transition lines — that claim is about the per-signal ALERT/
- *                              RECOVERED/DEGRADED lines, which still say nothing while every
- *                              signal stays OK. The heartbeat is a separate, deliberately-noisy
+ *                              RECOVERED/DEGRADED/NOTICE lines, which still say nothing while
+ *                              every signal stays OK (a NOTICE is emitted once, then never again). The heartbeat is a separate, deliberately-noisy
  *                              liveness beat.
  *
  * Run: `RPC_URL=… STATE_PATH=… node packages/canary/src/canary-runner.mjs`

--- a/packages/canary/src/signal.mjs
+++ b/packages/canary/src/signal.mjs
@@ -11,6 +11,10 @@
  *             so it never collapses into `ok`. The runner reports OK→SKIPPED as its own
  *             transition line, which is how a dead sentinel becomes visible instead of silent.
  *
+ * `notApplicable()` below is a REFINEMENT of `ok`, not a fourth status: the check's subject is
+ * inert in this deployment, so the condition it reports on cannot arise. That is a different fact
+ * from `skipped`, and conflating the two is what this vocabulary exists to prevent.
+ *
  * @typedef {'ok'|'alert'|'skipped'} SignalStatus
  * @typedef {Object} SignalResult
  * @property {string} id            stable identity for transition tracking: signal|vault|key
@@ -62,6 +66,32 @@ export const skipped = build('skipped');
  */
 export function detectorBroken(fields) {
   return skipped({ ...fields, detail: { ...(fields.detail ?? {}), detectorBroken: true } });
+}
+
+/**
+ * An `ok` whose check DOES NOT APPLY to this deployment: the contract path it watches is inert, so
+ * the condition it reports on cannot arise here at all.
+ *
+ * This is deliberately not `skipped`. `skipped` means "could not be measured" — a check that might
+ * have found something and did not get to look — so the tracker holds it as a not-OK state and
+ * `unhealthy()` carries it for as long as it lasts. That is the right shape for a transient
+ * blocker and the wrong shape for a permanent one: a check whose subject does not exist in this
+ * deployment would report "cannot run" on every vault on every sweep for the life of the
+ * deployment, which reads as a fault someone should chase rather than a fact about the wiring.
+ *
+ * So it is `ok` carrying a flag. `observe()` in transitions.mjs makes the FIRST sighting emit — a
+ * first-sighting `ok` is otherwise silent — and `markFor()` renders it `NOTICE` rather than
+ * `RECOVERED`, because nothing recovered. Every sweep after that matches the tracked status and
+ * emits nothing, and the tracker snapshot is persisted (see state-file.mjs), so a restart does not
+ * repeat the notice either. `unhealthy()` and `summariseTransitions().notOk` both filter on
+ * `status !== 'ok'` and so do not carry it.
+ *
+ * @param {{signal:string, vault:string, key?:string, message:string,
+ *          measured?:string, threshold?:string, detail?:Record<string,any>}} fields
+ * @returns {SignalResult}
+ */
+export function notApplicable(fields) {
+  return ok({ ...fields, detail: { ...(fields.detail ?? {}), notApplicable: true } });
 }
 
 /** Short vault label for alert lines: 0x1234…cdef. Full address always rides in `detail`. */

--- a/packages/canary/src/signals/oracle-health.mjs
+++ b/packages/canary/src/signals/oracle-health.mjs
@@ -31,7 +31,7 @@
  */
 
 import { CHAINLINK_ORACLE_VIEWS, AGGREGATOR_V3_VIEWS, ORACLE_VIEWS, EXIT_FROZEN_SELECTORS } from '../abis.mjs';
-import { ok, alert, skipped, detectorBroken, shortAddr } from '../signal.mjs';
+import { ok, alert, notApplicable, detectorBroken, shortAddr } from '../signal.mjs';
 import { checkOracleFreshness } from './oracle-freshness.mjs';
 
 /**
@@ -216,7 +216,8 @@ export async function checkChainlinkOracle({ reader, vault, oracle, assets, nowS
   for (const asset of assets) {
     out.push(await assetLeg({
       reader, vault, oracle, asset, nowSec, pinned,
-      sequencerCause: seq.cause, stalenessWarnPct, cadenceByAsset,
+      sequencerCause: seq.cause, sequencerGateActive: !isZero(sequencerFeed),
+      stalenessWarnPct, cadenceByAsset,
     }));
   }
 
@@ -242,15 +243,30 @@ async function sequencerLeg({ reader, vault, oracle, sequencerFeed, nowSec, grac
   const base = { signal: SIGNAL, vault, key: 'sequencer' };
 
   if (isZero(sequencerFeed)) {
-    // Not a detector fault and not health: the contract's own guard is inert here, so there is
-    // nothing to watch. Off a sequencer L2 that is correct; on Base mainnet it means the deployment
-    // shipped with NO sequencer guard at all, which is worth exactly one loud line either way.
+    // NOT APPLICABLE, not skipped. `sequencerUptimeFeed` is immutable (ChainlinkOracle.sol:75), so
+    // a zero here is a permanent fact about this deployment, and `_requireSequencerUp` returns
+    // without reading a feed (ChainlinkOracle.sol:314) on every call for the rest of its life.
+    // There is no sequencer state that could ever freeze this vault, so there is nothing for this
+    // leg to measure — ever, on any sweep, on any vault on this oracle.
+    //
+    // It used to report `skipped` with a two-clause reason ("correct off a sequencer L2; on Base
+    // mainnet it means no guard"), which cost twice over. A `skipped` leg is not-OK forever: it
+    // rides in every heartbeat's notOk tally and in `unhealthy()`, so the standing count never
+    // reaches zero and a real degradation has to be spotted inside a permanent one. And on a
+    // sequencer L2 that HAS no vendor uptime feed both clauses are false at once — the deployment
+    // is not off a sequencer L2, and it is not on Base.
+    //
+    // Which chains may ship without an uptime feed is not this file's judgement to make and never
+    // was: it is decided before the oracle exists, by `DeployChainlinkOracle.requiresSequencerUptimeFeed`
+    // (contracts/script/DeployChainlinkOracle.s.sol:59), which blocks the broadcast, and re-checked
+    // read-only by scripts/verify-chainlink-oracle.mjs. A monitor watching an already-immutable
+    // contract cannot revisit that decision, so it states what is wired and stops.
     return {
       cause: null,
-      result: skipped({
+      result: notApplicable({
         ...base,
-        message: `sequencer gate not configured on the oracle at ${shortAddr(oracle)} for vault ${shortAddr(vault)}: sequencerUptimeFeed is address(0), so ChainlinkOracle._requireSequencerUp is a no-op and this sub-check cannot run. Correct off a sequencer L2 (local/testnet); on Base mainnet it means the deployment has no sequencer guard`,
-        detail: { vault, oracle, sequencerUptimeFeed: ZERO, configured: false },
+        message: `sequencer check inactive on this deployment (vault ${shortAddr(vault)}, oracle ${shortAddr(oracle)}): the oracle was constructed with no uptime feed, so ChainlinkOracle._requireSequencerUp returns without reading a feed (ChainlinkOracle.sol:314) and no sequencer state can freeze this vault. The rest of priceWad is unaffected — an unlisted feed, a dead or non-positive answer, an unset or future timestamp, the heartbeat and the sane-price band still freeze the asset they apply to (ChainlinkOracle.sol:285-304), and this signal still measures each of them per asset. Whether a chain may ship without an uptime feed is settled at deploy time by DeployChainlinkOracle.requiresSequencerUptimeFeed, not here`,
+        detail: { vault, oracle, sequencerUptimeFeed: ZERO, configured: false, sequencerGate: 'inert' },
       }),
     };
   }
@@ -343,7 +359,7 @@ async function sequencerLeg({ reader, vault, oracle, sequencerFeed, nowSec, grac
 // ── one basket asset ─────────────────────────────────────────────────────────
 
 /** @returns {Promise<import('../signal.mjs').SignalResult>} */
-async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequencerCause, stalenessWarnPct, cadenceByAsset }) {
+async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequencerCause, sequencerGateActive, stalenessWarnPct, cadenceByAsset }) {
   const base = { signal: SIGNAL, vault, key: asset };
 
   const cfgRead = await reader.tryRead(oracle, CHAINLINK_ORACLE_VIEWS, 'feedOf', [asset]);
@@ -367,7 +383,7 @@ async function assetLeg({ reader, vault, oracle, asset, nowSec, pinned, sequence
   if (pinned && eqAddr(asset, pinned)) {
     return ok({
       ...base,
-      message: `asset ${shortAddr(asset)} on vault ${shortAddr(vault)} is the oracle's pinned USDC leg — priceWad returns $1.00 and can never go stale (it can still be frozen by the sequencer gate, which has its own key)`,
+      message: `asset ${shortAddr(asset)} on vault ${shortAddr(vault)} is the oracle's pinned USDC leg — priceWad returns $1.00 and can never go stale${sequencerGateActive ? ' (it can still be frozen by the sequencer gate, which has its own key)' : ' (and this oracle has no uptime feed, so the sequencer gate cannot freeze it either — see the sequencer key)'}`,
       measured: 'pinned 1e18', threshold: 'pinned',
       detail: { vault, oracle, asset, pinned: true },
     });

--- a/packages/canary/src/transitions.mjs
+++ b/packages/canary/src/transitions.mjs
@@ -13,6 +13,10 @@
  *    starting up against a healthy chain must not announce every signal it is watching.
  *  - `skipped` is its own state, not a silent `ok`. OK→SKIPPED emits, because a sentinel that has
  *    stopped being able to run is exactly the thing you would otherwise never notice.
+ *  - `notApplicable` (carried on a result's `detail`) is the mirror image of that rule. It rides on an `ok`
+ *    result whose check has no subject in this deployment, and it is the ONE case where a
+ *    first-sighting `ok` emits: exactly one NOTICE line, so the fact is stated once instead of
+ *    never. Every later sweep matches the tracked status and emits nothing.
  *  - `minConsecutive` (carried on a result's `detail`) requires N consecutive same-status
  *    observations before a transition is emitted. Used by share-conservation when it cannot pin
  *    its chain read to the indexer's height, where a one-poll mismatch is ordinary lag.
@@ -62,6 +66,10 @@ function markFor(to, r, repeat) {
   if (r?.detail?.detectorBroken) {
     return repeat > 0 ? `DETECTOR BROKEN (still blind after ${repeat} consecutive sweeps)` : 'DETECTOR BROKEN';
   }
+  // A not-applicable check is `ok`, but `MARK.ok` is "RECOVERED" and nothing recovered: there was
+  // never a fault to come back from. NOTICE says what the line actually is — a statement of fact
+  // about how this deployment is wired, made once.
+  if (to === 'ok' && r?.detail?.notApplicable) return 'NOTICE';
   return MARK[to] ?? to.toUpperCase();
 }
 
@@ -117,7 +125,10 @@ export function createTransitionTracker({ initial = {} } = {}) {
           status: r.status, since: poll, pendingStatus: null, pendingCount: 0,
           brokenPolls: blind ? 1 : 0, brokenNext: blind ? 2 : 0,
         });
-        if (r.status !== 'ok') out.push(emit(r, 'ok'));
+        // A healthy first sighting stays silent; a not-applicable one does not. Left silent it
+        // would never be said at all, and "this check has no subject here" is precisely the fact an
+        // operator cannot infer from silence — silence is what a passing check looks like.
+        if (r.status !== 'ok' || r.detail?.notApplicable === true) out.push(emit(r, 'ok'));
         continue;
       }
 

--- a/packages/canary/test/oracle-health.test.mjs
+++ b/packages/canary/test/oracle-health.test.mjs
@@ -286,14 +286,100 @@ test('feedOf reverting on an oracle that claimed to be a ChainlinkOracle is a BR
 
 // ── the L2 sequencer gate ────────────────────────────────────────────────────
 
-test('the sequencer gate is DEGRADED, not OK, when no uptime feed is configured', async () => {
-  // Correct off a sequencer L2 (Base Sepolia leaves it address(0) by design) — but it is a check
-  // that cannot run, and on mainnet it would mean the deployment shipped with no guard at all.
+test('with no uptime feed the sequencer leg is NOT-APPLICABLE, not a check that failed to run', async () => {
+  // `sequencerUptimeFeed` is immutable (ChainlinkOracle.sol:75) and `_requireSequencerUp` returns
+  // without reading a feed when it is zero (ChainlinkOracle.sol:314). Nothing about this can change
+  // while the oracle exists, so `skipped` — "could not be measured" — was the wrong word: it made
+  // the leg not-OK on every sweep of every vault for the life of the deployment.
   const s = forSequencer(await run(readerFor()));
-  assert.equal(s.status, 'skipped');
+  assert.equal(s.status, 'ok');
+  assert.equal(s.detail.notApplicable, true);
   assert.equal(s.detail.configured, false);
-  assert.equal(s.detail.detectorBroken, undefined, 'a known-state skip must not escalate as a broken detector');
-  assert.match(s.message, /no sequencer guard/);
+  assert.equal(s.detail.sequencerGate, 'inert');
+  assert.equal(s.detail.detectorBroken, undefined, 'a deployment fact must not escalate as a broken detector');
+});
+
+test('the not-applicable line states the contract behaviour, and claims no chain it cannot know', async () => {
+  const s = forSequencer(await run(readerFor()));
+  assert.match(s.message, /sequencer check inactive on this deployment/);
+  assert.match(s.message, /ChainlinkOracle\.sol:314/, 'cite the line where the gate returns');
+  assert.match(s.message, /DeployChainlinkOracle\.requiresSequencerUptimeFeed/,
+    'the deploy-time guard owns the may-this-chain-ship-without-one decision, not the canary');
+  // The replaced line asserted two things a canary cannot read off an oracle: that the deployment
+  // is off a sequencer L2, and that it is on Base. Both are false at once on a sequencer L2 whose
+  // vendor publishes no uptime feed — the case that motivated this change.
+  assert.ok(!/Base mainnet/.test(s.message), 'the canary does not know which chain it is on');
+  assert.ok(!/local\/testnet/.test(s.message), 'nor that a chain without a feed is a testnet');
+  assert.equal(s.measured, undefined, 'nothing was measured, so nothing is reported as measured');
+  assert.equal(s.threshold, undefined);
+});
+
+test('a zero uptime feed produces ONE notice and then silence, however long the canary runs', async () => {
+  // The whole point. A `skipped` leg re-states itself as a standing not-OK forever; this states the
+  // fact once, marked NOTICE rather than RECOVERED (nothing recovered) or DEGRADED (nothing is).
+  const reader = readerFor();
+  const tracker = createTransitionTracker();
+  const lines = [];
+  for (let poll = 1; poll <= 30; poll += 1) {
+    for (const t of tracker.observe(await run(reader), { poll })) lines.push({ poll, line: t.line });
+  }
+  assert.equal(lines.length, 1, 'exactly one line, at the first sighting');
+  assert.equal(lines[0].poll, 1);
+  assert.match(lines[0].line, /^NOTICE \[oracle-freshness\] sequencer check inactive on this deployment/);
+  assert.ok(!/DEGRADED|RECOVERED|ALERT/.test(lines[0].line));
+});
+
+test('the not-applicable leg never counts as unhealthy, so the standing notOk tally can reach zero', async () => {
+  // `unhealthy()` feeds the heartbeat line and the off-host summary. Under `skipped` this leg sat
+  // in that tally permanently, so a real degradation had to be spotted inside a standing one.
+  const tracker = createTransitionTracker();
+  tracker.observe(await run(readerFor()), { poll: 1 });
+  assert.deepEqual(tracker.unhealthy(), []);
+});
+
+test('upgrading over a state file that recorded the old `skipped` emits one NOTICE, not a RECOVERED', async () => {
+  // The first sweep after this change reads a snapshot written by the previous build, where the
+  // leg is `skipped`. That is a real status change, so it emits — and it must not read as a
+  // recovery from a fault that never existed.
+  const tracker = createTransitionTracker({
+    initial: { [`oracle-freshness|${VAULT}|sequencer`]: { status: 'skipped', since: 0, pendingStatus: null, pendingCount: 0 } },
+  });
+  const emitted = tracker.observe(await run(readerFor()), { poll: 1 }).filter((t) => t.key === 'sequencer');
+  assert.equal(emitted.length, 1);
+  assert.equal(emitted[0].from, 'skipped');
+  assert.equal(emitted[0].to, 'ok');
+  assert.match(emitted[0].line, /^NOTICE \[oracle-freshness\]/);
+  assert.ok(!/RECOVERED/.test(emitted[0].line));
+});
+
+test('a CONFIGURED uptime feed is untouched: the leg measures, and says nothing while healthy', async () => {
+  // The guard on the other half of the change. Everything above is about the zero-feed deployment;
+  // a deployment that has a feed must still be measured, and must still emit nothing when up.
+  const reader = readerFor({ sequencerUptimeFeed: SEQ_FEED });
+  const s = forSequencer(await run(reader));
+  assert.equal(s.status, 'ok');
+  assert.equal(s.detail.notApplicable, undefined, 'a measured leg is not a not-applicable one');
+  assert.equal(s.detail.sequencerUptimeFeed, SEQ_FEED);
+  assert.match(s.message, /sequencer up for/);
+  const tracker = createTransitionTracker();
+  for (let poll = 1; poll <= 5; poll += 1) {
+    assert.deepEqual(tracker.observe(await run(reader), { poll }), [], `poll ${poll} broke the silence`);
+  }
+});
+
+test('the pinned USDC leg does not promise a sequencer freeze on an oracle that has no uptime feed', async () => {
+  // The parenthetical named the ONE thing that can still freeze a pinned leg. With no uptime feed
+  // that thing does not exist, so on a zero-feed deployment the sentence was simply untrue.
+  const withGate = forAsset(await run(
+    readerFor({ usdcPin: USDC, sequencerUptimeFeed: SEQ_FEED }),
+    { assets: [USDC] },
+  ), USDC);
+  assert.equal(withGate.detail.pinned, true);
+  assert.match(withGate.message, /can still be frozen by the sequencer gate/);
+
+  const withoutGate = forAsset(await run(readerFor({ usdcPin: USDC }), { assets: [USDC] }), USDC);
+  assert.equal(withoutGate.detail.pinned, true);
+  assert.match(withoutGate.message, /the sequencer gate cannot freeze it either/);
 });
 
 test('a DOWN sequencer alerts vault-wide, and says pricing resumes AFTER the restart, not at it', async () => {

--- a/packages/canary/test/sinks.test.mjs
+++ b/packages/canary/test/sinks.test.mjs
@@ -135,6 +135,25 @@ test('tierOf: a feed-identity ALERT that carries HARM pages; the self-clearing s
   assert.equal(tierOf(degraded), 'log', 'a DEGRADED feed-identity is a broken detector, not a proven drift');
 });
 
+test('tierOf: a NOTICE is INFO-class -- LOG tier, on a PAGE signal, and stdout not stderr', () => {
+  // A not-applicable check rides on an `ok` transition carrying `detail.notApplicable`. It must
+  // reach the LOG webhook and stdout, never the pager, even on `oracle-freshness` -- which is in
+  // PAGE_SIGNALS, so the assertion is not vacuous. `tierOf` gates on `to === 'alert'` before it
+  // consults the signal map; this pins that the ordering keeps holding.
+  const notice = tr('ok', 'oracle-freshness');
+  notice.result.detail = { ...notice.result.detail, notApplicable: true };
+  notice.line = 'NOTICE [oracle-freshness] sequencer check inactive on this deployment';
+  assert.ok(PAGE_SIGNALS.has('oracle-freshness'), 'the signal under test must be one that CAN page');
+  assert.equal(tierOf(notice), 'log', 'a NOTICE must never wake anyone');
+
+  const out = []; const err = [];
+  const sink = createConsoleSink({ log: (m) => out.push(m), error: (m) => err.push(m) });
+  return sink.emit(notice).then(() => {
+    assert.deepEqual(out, [notice.line], 'a NOTICE belongs on the clean feed');
+    assert.deepEqual(err, [], '`2>` is the problem feed; a statement of fact is not a problem');
+  });
+});
+
 test('tierOf: an unknown/renamed signal defaults to LOG, never silently PAGE', () => {
   assert.equal(tierOf(tr('alert', 'some-future-signal')), 'log');
 });

--- a/scripts/soak/drill4-oraclefreeze.mjs
+++ b/scripts/soak/drill4-oraclefreeze.mjs
@@ -134,7 +134,7 @@ if (result.verdict === 'INSUFFICIENT_EVIDENCE') {
   log('VERDICT: STALENESS EVENT OBSERVED');
   for (const a of result.breached) log(`  ${a.symbol}: ${a.breachSamples}/${a.readableSamples} readable samples frozen (priceWad reverted)`);
   assert(result.canaryTracked,
-    `a staleness breach was observed on-chain but no canary oracle-freshness row keyed by a BASKET ASSET left ok (${result.canaryAssetRows} such row(s) exist) — the canary did NOT track the freeze. Per-vault meta rows (sequencer, flavor) are excluded on purpose: on Base Sepolia the sequencer row is permanently skipped and would satisfy this check by itself`);
+    `a staleness breach was observed on-chain but no canary oracle-freshness row keyed by a BASKET ASSET left ok (${result.canaryAssetRows} such row(s) exist) — the canary did NOT track the freeze. Per-vault meta rows (sequencer, flavor) are excluded on purpose: neither evidences anything about an asset. The sequencer row used to be permanently skipped where sequencerUptimeFeed is address(0) and would have satisfied this check by itself; it now reports ok (not-applicable), and the exclusion is kept on status-blind grounds because the flavor row is skipped today`);
   log('  canary tracked the event (at least one ASSET row left ok)');
 } else {
   log('VERDICT: NO STALENESS EVENT IN THE WINDOW — documenting worst-case age instead (per #21)');

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -213,9 +213,12 @@ export function sequencerState({ feed, round, chainNow, grace }) {
     unreadable: false, answer: null, startedAtSec: null, upForSec: null, resumesAtSec: null,
     gracePeriodSec: grace,
   };
-  // Not a fault and not health: off a sequencer L2 (Base Sepolia leaves this at address(0) by
-  // design) `_requireSequencerUp` is a no-op, so there is nothing to observe. On Base MAINNET the
-  // same reading means the deployment shipped with no sequencer guard at all.
+  // Not a fault and not health: `_requireSequencerUp` returns without reading a feed when this is
+  // address(0) (ChainlinkOracle.sol:314), so there is nothing to observe. This sampler cannot tell
+  // WHY a deployment has no feed and does not guess — the two guesses it used to print (off a
+  // sequencer L2; on Base mainnet) are both wrong at once on a sequencer L2 whose vendor publishes
+  // no uptime feed. Which chains may ship without one is settled at deploy time by
+  // DeployChainlinkOracle.requiresSequencerUptimeFeed.
   if (!base.configured || round == null) return base;
 
   if (!round.ok) {

--- a/scripts/soak/series-analysis.mjs
+++ b/scripts/soak/series-analysis.mjs
@@ -335,9 +335,13 @@ export function summarizeFreezeSafety(samples) {
  * (`oracle-freshness|<vault>|<asset>`). The live flavor also emits two per-vault rows under the
  * same signal name — `sequencer` and `flavor` — and NEITHER may stand in for asset coverage:
  *
- *  - `sequencer` is permanently `skipped` on Base Sepolia, where the oracle leaves
- *    `sequencerUptimeFeed` at `address(0)` by design. A `status !== 'ok'` test that counted it
- *    would be satisfied on every run whether or not any asset row ever left OK.
+ *  - `sequencer` reports on the L2 uptime gate, which is a fact about the vault's oracle and not
+ *    about any asset. Where the oracle leaves `sequencerUptimeFeed` at `address(0)` that row used
+ *    to be permanently `skipped`, and a `status !== 'ok'` test that counted it was satisfied on
+ *    every such run whether or not any asset row ever left OK. It now reports `ok` (not-applicable
+ *    — `notApplicable()` in packages/canary/src/signal.mjs), which retires that particular false
+ *    green without retiring the reason for the allowlist below: the row still evidences nothing
+ *    about an asset either way.
  *  - `flavor` is the `DETECTOR BROKEN` row emitted when the oracle answers neither known ABI. It is
  *    `skipped` too, and counting it would be strictly worse: a BLIND detector would certify that
  *    the canary tracked the freeze.

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -666,6 +666,27 @@ test('an asset row that left ok DOES count, so the fix does not simply disable t
   assert.equal(verdictOf(byAsset, rows).canaryTracked, true);
 });
 
+test('drill 4 does not claim the sequencer row is permanently skipped on a zero-feed oracle', () => {
+  // WHY A TEXT PIN. The two comments above describe an allowlist whose only runtime consumer is
+  // drill4-oraclefreeze.mjs, which executes at import and prints this rationale in the assertion
+  // message it fails with — so no fixture in this file reaches that prose. Nor does a guard:
+  // scripts/test/config-doc-truth.test.mjs and scripts/test/claims-lede-truth.test.mjs walk
+  // `.md`/`.html`/`.txt`/`.json`, and `.mjs` is in neither set. This is a text pin over the
+  // source, the same instrument the run-soak.ps1 tests below use, and it catches the defect that
+  // did happen: the claim was rewritten here and in series-analysis.mjs and left standing in the
+  // drill. On a zero `sequencerUptimeFeed` the leg returns `notApplicable`
+  // (packages/canary/src/signals/oracle-health.mjs:266), which is an `ok`, so a present-tense
+  // "permanently skipped" is false about the deployment the drill actually runs against.
+  const drill4 = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'soak', 'drill4-oraclefreeze.mjs'),
+    'utf8',
+  );
+  assert.doesNotMatch(drill4, /sequencer row is permanently skipped/,
+    'the sequencer row on a zero-feed oracle now reports ok (not-applicable), never skipped');
+  assert.match(drill4, /neither evidences anything about an asset/,
+    'the exclusion rests on status-blind grounds, so the rationale must survive the status change — without this the pin above would also pass on a deleted message');
+});
+
 // ───────────────── insufficient evidence is not "no event" ─────────────────
 
 test('a series with no readable asset observation is INSUFFICIENT_EVIDENCE, never NO_EVENT', () => {

--- a/scripts/test/soak-drills.test.mjs
+++ b/scripts/test/soak-drills.test.mjs
@@ -623,11 +623,14 @@ test('isAssetSubject accepts an address and rejects every per-vault meta key', (
   assert.equal(isAssetSubject(undefined), false);
 });
 
-test('a permanently-skipped `sequencer` row does NOT count as the canary tracking a freeze', () => {
-  // PR #89 added a per-vault `sequencer` row under the `oracle-freshness` signal name. On Base
-  // Sepolia sequencerUptimeFeed is address(0), so that row is permanently `skipped` — under the old
+test('a not-OK `sequencer` row does NOT count as the canary tracking a freeze', () => {
+  // PR #89 added a per-vault `sequencer` row under the `oracle-freshness` signal name. Where
+  // sequencerUptimeFeed is address(0) that row was permanently `skipped` — under the old
   // `rows.some(r => r.status !== 'ok')` it satisfied the assertion by itself, whether or not any
-  // asset row ever left OK. That is a drill certifying nothing while exiting 0.
+  // asset row ever left OK. That is a drill certifying nothing while exiting 0. The canary now
+  // reports that case as not-applicable `ok`, so this exact fixture is a state file written by an
+  // older build; the guard is kept because the exclusion must hold on STATUS-blind grounds — the
+  // `flavor` row below is `skipped` today and would otherwise walk straight back through.
   const byAsset = summarize([liveSample('t1', 1, { asset: { priceReverts: true, frozenCauseKey: 'heartbeat-exceeded' } })]);
   const rows = oracleCanaryRows({
     transitions: {


### PR DESCRIPTION
**Robinhood Mainnet Deploy runbook blocker 6.**

## What was wrong

`ChainlinkOracle._requireSequencerUp` returns without reading a feed when `sequencerUptimeFeed` is `address(0)` (`contracts/src/oracle/ChainlinkOracle.sol:314`), and that field is `immutable` (`:75`). The canary's sequencer leg reported that as `skipped` — the vocabulary's word for "could NOT be measured" (`packages/canary/src/signal.mjs:9-12`) — which is the wrong fact, and it cost twice.

**It is not-OK forever.** `unhealthy()` (`transitions.mjs:168`) and `summariseTransitions().notOk` (`state-file.mjs:52`) both filter on `status !== 'ok'`. On a deployment with no uptime feed the leg sat in every heartbeat's notOk tally for the life of the oracle, one row per vault, so the standing count never reached zero and a real degradation had to be spotted inside a permanent one.

**And the reason text was wrong in both halves** on a sequencer L2 whose vendor publishes no uptime feed:

> Correct off a sequencer L2 (local/testnet); on Base mainnet it means the deployment has no sequencer guard

Such a chain is not off a sequencer L2, and it is not Base. Worse, the sentence claimed a judgement a monitor cannot make: which chains may ship without a feed is settled *before the oracle exists*, by `DeployChainlinkOracle.requiresSequencerUptimeFeed` (`contracts/script/DeployChainlinkOracle.s.sol:59`), which blocks the broadcast, and re-checked read-only by `scripts/verify-chainlink-oracle.mjs`. A monitor pointed at an already-immutable contract cannot revisit it.

## What it does now

One **NOTICE** per vault — once, on first sighting, not once per sweep — then `ok` / not-applicable forever after.

- **`signal.mjs`** — `notApplicable()`: an `ok` carrying `detail.notApplicable`. Deliberately **not** a fourth status, so nothing downstream (sinks, state file, ops-check, the soak's row readers) has to learn one.
- **`transitions.mjs`** — a first-sighting `ok` is silent, and this is the one exception, so the fact gets stated once instead of never. Rendered `NOTICE`, because `MARK.ok` is `RECOVERED` and nothing recovered. A state file written by the previous build (`skipped`) upgrades through one NOTICE rather than a false RECOVERED — covered by a test.
- **`oracle-health.mjs`** — the leg, plus the pinned-USDC line, which promised "it can still be frozen by the sequencer gate" on an oracle that has no gate.

### Two shapes worth naming rather than leaving a reviewer to find

1. **The notice is a `from: 'ok'` → `to: 'ok'` self-transition.** Deliberate — no other transition has that shape. It falls out of reusing `emit(r, 'ok')` for a first sighting, and it is what keeps the notice on the LOG tier (`tierOf` gates on `to === 'alert'`) and on stdout (`createConsoleSink` gates on `to === 'ok'`). Both are now pinned by a test in `sinks.test.mjs`, asserted on `oracle-freshness` specifically because that signal *is* in `PAGE_SIGNALS`, so the assertion is not vacuous.
2. **The dictated replacement sentence was changed on purpose.** The task specified "the staleness guard alone protects pricing here". That is false: the sane-price band (`ChainlinkOracle.sol:299`) guards too, as do the unlisted-feed, non-positive-answer and timestamp checks (`:285`, `:288-290`). The shipped line says "the rest of `priceWad` is unaffected" and enumerates what still freezes an asset, citing `:285-304`.

## Sweep — `grep -rni sequencer packages/canary/src`, plus every enumeration of the mark vocabulary

Fixed here:

| Site | What it assumed |
|---|---|
| `signals/oracle-health.mjs:245` | the leg itself |
| `signals/oracle-health.mjs:386` | pinned-USDC line promised a sequencer freeze on an oracle with no gate |
| `scripts/soak/oracle-sampler.mjs:219` | the identical two-clause guess, in its `not-configured` branch |
| `scripts/soak/series-analysis.mjs:335` | "`sequencer` is permanently `skipped`" — this change makes it false |
| `scripts/test/soak-drills.test.mjs:624` | same claim, in a test **name** |
| `docs/CANARY.md:4`, `:707` | lede and §5.3 listed the marks the canary emits and where they route; NOTICE was missing from both |
| `canary-runner.mjs:4`, `:33`, `:91` | three more incomplete enumerations of the same vocabulary |
| `docs/CANARY.md` §2, §3(a), §4 | the mark table, the signal description, and the "signals that cannot run" table — the zero-feed row leaves §4 entirely, because it is not a check that might run tomorrow |

Checked and correct as-is, listed so the sweep is auditable:

- `oracle-health.mjs:163` and `feed-identity.mjs:160` use `sequencerUptimeFeed()` as the **flavor probe** and gate on whether the call *answered*, never on whether the address is non-zero. Both correct.
- `abis.mjs:82`, `:94`, `:99-104` — the ABI entry and its field-discipline note; neither assumes a feed is configured.
- `oracle-health.mjs:432` — `sequencerCause ?? facts.cause`. With the gate inert the cause is `null`, so nothing is misattributed.
- The soak's `isAssetSubject` allowlist excludes the `sequencer` row on its **key**, not its status, so the status change cannot re-open the false green PR #89 introduced.

## Verification

`node --test --test-reporter=tap` over the full `test:backend` file set: **1074 tests, 1050 pass, 0 unrelated fail, 20 skipped.** The 4 remaining failures are `contracts/out exists — this guard must never skip its way to green` and its three siblings: `forge` was not run in this worktree (shared `~/.foundry` deadlocks across concurrent sessions), so the build artifacts those guards read are absent. Pre-existing and unrelated; CI builds contracts first.

Eight new tests (one existing test replaced, since the behaviour it pinned is the behaviour being changed), **each mutation-proven** — seven mutations of the source, restored by file copy and confirmed clean by `git diff`:

| Mutation | Kills |
|---|---|
| `notApplicable(` → `skipped(` + old message | 5 tests |
| drop `\|\| r.detail?.notApplicable` from the first-sighting branch | the one-notice test |
| drop the `NOTICE` mark | the notice line + upgrade-path tests |
| revert the pinned-leg conditional | the pinned-leg test |
| make the zero-check unconditional | the CONFIGURED-feed guard (+11 existing) |
| reorder `tierOf`'s alert gate after `PAGE_SIGNALS` | the INFO-class test (+3 existing) |
| send `notApplicable` to `error` in the console sink | the INFO-class test |

`config-doc-truth` and `claims-lede-truth` both green against the new prose — including `SEQUENCER_FAILS_CLOSED`, whose banned shape this text deliberately does not take.

## Not in scope, found while sweeping

- `docs/CANARY.md` §6 says the canary suite is "284 tests"; it was 307 before this change and is 314 after. Stale independently of this PR.
- `docs/LAUNCH-READINESS.md:228` still says the `oracle-freshness` signal "has NOT been ported and emits `skipped` on a launch vault". False since the C-6 pivot shipped `signals/oracle-health.mjs`, and unrelated to the sequencer leg.

No merge, no `merge-preflight` dispatch from here.



---

## Round 2 — the blocker from the independent verdict at `43d3af0b`

**REJECT, one blocker: drill 4's own assertion message still said the sequencer row "is permanently skipped".** It was `scripts/soak/drill4-oraclefreeze.mjs:140` at `43d3af0b`; after rebasing over #206 the same line is `scripts/soak/drill4-oraclefreeze.mjs:137`. Round 1 rewrote that exact claim in `scripts/soak/series-analysis.mjs:340` and `scripts/test/soak-drills.test.mjs:628` and left the runtime consumer of the allowlist those two describe untouched. After this PR a zero-`sequencerUptimeFeed` leg returns `notApplicable` (`packages/canary/src/signals/oracle-health.mjs:266`), which is an `ok`, and `contracts/config/base-sepolia.json:16` leaves that feed empty by design — so the clause was false about the one chain it named.

The message now reads: *"Per-vault meta rows (sequencer, flavor) are excluded on purpose: neither evidences anything about an asset. The sequencer row used to be permanently skipped where sequencerUptimeFeed is address(0) and would have satisfied this check by itself; it now reports ok (not-applicable), and the exclusion is kept on status-blind grounds because the flavor row is skipped today."* Each clause is sourced rather than paraphrased from the siblings: `flavor` is emitted by `detectorBroken` (`packages/canary/src/signals/oracle-health.mjs:173`), which is a `skipped` (`packages/canary/src/signal.mjs:68`).

**Behaviour is unchanged.** `isAssetSubject` (`scripts/soak/series-analysis.mjs:353`) excludes meta rows by KEY, not by status, so the exclusion holds either way and no false green is opened or closed. Only the assertion message moved.

### The pin, and why it is a text pin

`.mjs` prose has no guard — `config-doc-truth.test.mjs` and `claims-lede-truth.test.mjs` walk `.md`/`.html`/`.txt`/`.json` only — and `drill4-oraclefreeze.mjs` executes at import, so no fixture reaches its assertion messages. `scripts/test/soak-drills.test.mjs:669-686` adds one text pin over the source, the instrument that file already uses at `:1259` and for the `run-soak.ps1` ordering tests. It asserts both halves: the present-tense claim is gone, and the status-blind rationale that replaced it is present — so deleting the whole message reds it too.

**Mutation-proved at this head.** Reverting that one line in `drill4-oraclefreeze.mjs` yields `not ok 50 - drill 4 does not claim the sequencer row is permanently skipped on a zero-feed oracle` — **1 fail, 98 pass, and no other test moves.** Restored by file copy; `git status` clean and `git hash-object` equal to `git rev-parse HEAD:scripts/soak/drill4-oraclefreeze.mjs` (`2f024a7d`) afterwards.

### Sweep — full repository scope, re-run at `70c20014`

Terms swept with `git grep` over the whole tree: `permanently skipped`; `sequencer row`; `sequencer` within 160 characters of `skip`; `cannot run` / `can't run` / `never runs` / `does not run`; `skipped(`; `gate not configured`; `oracle-freshness` near `skip`; `(row|leg) (is|was|stays|remains) skipped`. Every hit, classified:

| file:line | classification |
|---|---|
| `scripts/soak/drill4-oraclefreeze.mjs:137` | **updated** — the blocker |
| `scripts/test/soak-drills.test.mjs:669-686` | **added** — the new pin (the only remaining occurrences of the banned present-tense string are its own regex and title) |
| `scripts/soak/series-analysis.mjs:340` | already-true — rewritten to past tense in round 1 |
| `scripts/test/soak-drills.test.mjs:628` | already-true — rewritten to past tense in round 1 |
| `docs/CANARY.md:585-589` | already-true — round 1; the zero-feed deployment is out of the "cannot run" table |
| `docs/CANARY.md:570-577` | already-true — §4's table is exit-liveness / projection / `StaleOracle` / empty watch set / feed identity; no sequencer row |
| `packages/canary/src/signals/oracle-health.mjs:246,252` | already-true — "NOT APPLICABLE, not skipped" / "It used to report `skipped`" |
| `packages/canary/README.md:50` | already-true — `skipped` does still exist, and other signals still emit it |
| `packages/canary/src/signal.mjs:10,79` | already-true — the `skipped` / `notApplicable` doc comments |
| `packages/canary/src/signals/exit-liveness.mjs:17,88,143` | not-the-shape — a different signal's skips |
| `packages/canary/src/signals/feed-identity.mjs:68` | not-the-shape — a different signal |
| `packages/canary/src/canary-runner.mjs:313,315` | not-the-shape — the projection skip |
| `docs/SOAK-REPORT.md:236-237` | not-the-shape — recorded `exit-liveness` transitions |
| `docs/TESTNET-REPORT.md:586` | not-the-shape — an `exit-liveness` transcript line |
| `docs/RESTORE-DRILL.md:247-248` | not-the-shape — a recorded transcript of ASSET-keyed rows, not the meta row |
| `docs/DEPLOYMENT.md:310` | already-true — `DETECTOR BROKEN` re-assertion |
| `scripts/soak/drill4-oraclefreeze.mjs:111-112`, `scripts/test/soak-drills.test.mjs:723` | already-true — about the on-chain gate never EXECUTING, a different claim from the canary row's status |
| `apps/site/how-it-works.html:194`, `apps/site/risks.html:128`, `contracts/config/base-sepolia.json:17`, `contracts/config/deployments/base-sepolia.json:53`, `contracts/script/DeployTestnet.s.sol:236`, `docs/TESTNET-CHECKLIST.md:88`, `docs/evidence/testnet-lifecycle-run.json:56` | not-the-shape — `ChainlinkOracle` skipping the ON-CHAIN gate, pinned true by `scripts/test/config-doc-truth.test.mjs:466-469` |
| `packages/canary/test/oracle-health.test.mjs:345`, `scripts/test/soak-drills.test.mjs:638,663` | not-the-shape — fixture DATA, not prose: state files written by the previous build, explained at `oracle-health.test.mjs:341-343` and `soak-drills.test.mjs:628-633` |
| `docs/LAUNCH-READINESS.md:228` | pre-existing false, out of scope — a different claim (the whole signal's port status), disclosed in round 1 and unchanged by this PR |

### Counts, this head

- `node --test --test-reporter=tap scripts/test/soak-drills.test.mjs` — **99 tests, 99 pass, 0 fail, 0 skipped.** The base file at `origin/protocol/main` runs 98 tests, and the diff adds exactly one `test(`.
- `node --test --test-reporter=tap "packages/canary/test/*.test.mjs"` — **314 tests, 303 pass, 0 fail, 11 skipped** — unchanged by round 2, and matching the independent verdict's own measurement at `43d3af0b`.
- `node --test --test-reporter=tap scripts/test/config-doc-truth.test.mjs scripts/test/claims-lede-truth.test.mjs` — **25 tests, 25 pass, 0 fail**.

Rebased onto `origin/protocol/main` (`5812961d`, which is #206 — it also edits `drill4-oraclefreeze.mjs`, in the header, with no conflict) as one new commit on top of `1877e451`; nothing was amended. `behind_by 0` at `70c20014`.

### Verdict nits knowingly deferred

Left as the verdict classified them, to keep this round's diff to the blocker: the "284 tests" figure in `docs/CANARY.md` and `packages/canary/README.md:105` (pre-existing and stale independently of this PR); the LOG-tier enumeration in `packages/canary/README.md:77` and the repo-root `.env.example:89-91` (incomplete, not false); the over-long comment line at `packages/canary/src/canary-runner.mjs:92` and the un-rewrapped `docs/CANARY.md` lines; and `docs/LAUNCH-READINESS.md:228`, which is out of scope.

No merge, no `merge-preflight` dispatch from here.
