### PR TITLE
fix(verify-chainlink-oracle): the 4663 exemption row names both surviving guards, and the row comment counts its test environments right

### DIFF
--- a/contracts/script/DeployChainlinkOracle.s.sol
+++ b/contracts/script/DeployChainlinkOracle.s.sol
@@ -51,10 +51,11 @@ contract DeployChainlinkOracle is Script {
     /// could supply — the fail-closed default would block the deploy outright rather than cost one
     /// argument. WHAT IT COSTS: with `sequencerUptimeFeed` left at address(0),
     /// `ChainlinkOracle._requireSequencerUp` returns early (ChainlinkOracle.sol:314) and `priceWad`
-    /// serves prices through a sequencer outage instead of reverting. On this chain the per-asset
-    /// heartbeat/staleness bound is therefore the only guard left standing between a stalled chain
-    /// and a priced vault. This is a deliberate weakening of a security gate, approved by the owner
-    /// on 2026-09-04 in those terms; see docs/DEPLOYMENT.md "Robinhood Chain 4663".
+    /// serves prices through a sequencer outage instead of reverting. Two guards are therefore left
+    /// standing between a stalled chain and a priced vault, not one: the per-asset staleness bound
+    /// (the heartbeat, ChainlinkOracle.sol:294) and the sane-price band (ChainlinkOracle.sol:299).
+    /// This is a deliberate weakening of a security gate, approved by the owner on 2026-09-04 in
+    /// those terms; see docs/DEPLOYMENT.md "Robinhood Chain 4663".
     uint256 constant ROBINHOOD_CHAIN_ID = 4663;
 
     /// @notice Does a deploy on `chainId` have to supply ORACLE_SEQUENCER?

--- a/scripts/test/verify-chainlink-oracle.test.mjs
+++ b/scripts/test/verify-chainlink-oracle.test.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   SEQUENCER_EXEMPT_CHAIN_IDS,
+  SEQUENCER_EXEMPT_REASONS,
   bandBoundsTwoDecimalDrift,
   chainBindingVerdict,
   compareAggregatorPin,
@@ -371,6 +372,67 @@ test('the sequencer-exempt set is exactly {31337, 84532, 4663}', () => {
     [4663, 31337, 84532].sort((a, b) => a - b),
     'an id was added to or removed from the exempt set; the deploy-script allowlist must match',
   );
+});
+
+/**
+ * THE 4663 REASON IS PRINTED, so it is a public claim and not a comment.
+ *
+ * `SEQUENCER_EXEMPT_REASONS.get(4663)` is interpolated into the `sequencer uptime feed` row detail
+ * ("guard intentionally skipped on exempt chain 4663: <reason>"), so whatever it says is what an
+ * operator reads off a passing pre-deploy run. It said "leaving the per-asset heartbeat as the only
+ * guard", which undercounts: `priceWad` keeps the staleness bound AND the sane-price band when the
+ * uptime feed is address(0). docs/DEPLOYMENT.md, apps/site/how-it-works.html, apps/site/risks.html
+ * and contracts/config/robinhood-mainnet.json all already said two, so the printed string was the
+ * one place a reader was told one.
+ *
+ * Pinned against the CONTRACT rather than against the other prose, because agreeing with a document
+ * that is itself wrong is the failure this class of test exists to catch. Both cited lines are also
+ * required to fall inside `priceWad` — the band is enforced twice, once in the constructor
+ * (ChainlinkOracle.sol:218-220) and once at read time, and only the read-time one survives an
+ * outage, so a cite that drifted onto the constructor check would be the wrong claim spelled right.
+ */
+test('the 4663 exemption reason names BOTH surviving guards, and both cites land inside priceWad', () => {
+  const reason = SEQUENCER_EXEMPT_REASONS.get(4663);
+  assert.ok(reason, '4663 is no longer in SEQUENCER_EXEMPT_REASONS; the printed row has no reason to state');
+
+  // Both guards named. Two assertions, not one combined regex, so the failure says which vanished.
+  const heartbeat = reason.match(/heartbeat[^()]*\(ChainlinkOracle\.sol:(\d+)\)/);
+  assert.ok(heartbeat, 'the 4663 reason no longer names the per-asset heartbeat/staleness bound with a line cite');
+  const band = reason.match(/sane-price band[^()]*\(ChainlinkOracle\.sol:(\d+)\)/);
+  assert.ok(band, 'the 4663 reason no longer names the sane-price band with a line cite');
+
+  // The undercount itself, banned by shape rather than by the one phrasing that was there before.
+  assert.doesNotMatch(
+    reason,
+    /only guard|as the only|only remaining|heartbeat alone|sole guard/i,
+    'the 4663 reason is back to claiming a single surviving guard; two survive a zero uptime feed',
+  );
+
+  const src = fs.readFileSync(path.join(REPO, 'contracts', 'src', 'oracle', 'ChainlinkOracle.sol'), 'utf8');
+  const lines = src.split(/\r?\n/);
+
+  // Read-time, not construction-time: the cites must sit inside priceWad's own braces.
+  const fn = extractFunctionSource(src, 'function priceWad(address asset) external view returns (uint256)');
+  assert.ok(fn, 'priceWad(address) is no longer declared in ChainlinkOracle.sol with that signature');
+  const firstLine = src.slice(0, src.indexOf(fn)).split(/\r?\n/).length;
+  const lastLine = firstLine + fn.split(/\r?\n/).length - 1;
+
+  const at = (cite, label) => {
+    const n = Number(cite);
+    assert.ok(
+      n >= firstLine && n <= lastLine,
+      `the ${label} cite ChainlinkOracle.sol:${n} is outside priceWad (lines ${firstLine}-${lastLine})`,
+    );
+    return lines[n - 1] ?? '';
+  };
+
+  const heartbeatLine = at(heartbeat[1], 'heartbeat');
+  assert.match(heartbeatLine, /updatedAt < minUpdated/, `ChainlinkOracle.sol:${heartbeat[1]} is not the staleness bound`);
+  assert.match(heartbeatLine, /revert StaleOracle/, `ChainlinkOracle.sol:${heartbeat[1]} no longer fails closed`);
+
+  const bandLine = at(band[1], 'sane-price band');
+  assert.match(bandLine, /cfg\.maxPriceWad != 0/, `ChainlinkOracle.sol:${band[1]} is not the sane-price band check`);
+  assert.match(bandLine, /cfg\.minPriceWad/, `ChainlinkOracle.sol:${band[1]} no longer compares against the band floor`);
 });
 
 test('the deploy script exempts the same three ids, so the two lists cannot drift apart', () => {

--- a/scripts/verify-chainlink-oracle.mjs
+++ b/scripts/verify-chainlink-oracle.mjs
@@ -125,12 +125,15 @@ if (!RPC) {
 // are not exempt for the same reason and a single message cannot be true of all of them: 31337 and
 // 84532 are test environments, 4663 is a mainnet whose vendor publishes no feed at all. The set is
 // derived from these keys, so an id can never be exempted without a reason being written down.
-const SEQUENCER_EXEMPT_REASONS = new Map([
+// Exported for scripts/test/verify-chainlink-oracle.test.mjs, which pins the 4663 reason: the
+// string below is PRINTED as that row's detail, so it is a public claim about what still guards
+// pricing on 4663 and a test has to hold it to the contract.
+export const SEQUENCER_EXEMPT_REASONS = new Map([
   [31337, 'local anvil / forge — no sequencer exists to have an uptime feed'],
   [84532, 'Base Sepolia — the committed config leaves it empty by design (contracts/config/base-sepolia.json, sequencerUptimeFeedNote); the uptime gate itself is mock-tested in ChainlinkOracle.t.sol'],
   [
     4663,
-    'Robinhood Chain — Chainlink publishes no L2 Sequencer Uptime Feed for this chain, so there is no address to supply. Owner-approved weakening dated 2026-09-04: with the feed at address(0), ChainlinkOracle._requireSequencerUp returns early and priceWad answers straight through a sequencer outage, leaving the per-asset heartbeat as the only guard. See docs/DEPLOYMENT.md "Robinhood Chain 4663"',
+    'Robinhood Chain — Chainlink publishes no L2 Sequencer Uptime Feed for this chain, so there is no address to supply. Owner-approved weakening dated 2026-09-04: with the feed at address(0), ChainlinkOracle._requireSequencerUp returns early and priceWad answers straight through a sequencer outage. Two guards survive that, not one: the per-asset heartbeat/staleness bound (ChainlinkOracle.sol:294) and the sane-price band (ChainlinkOracle.sol:299). See docs/DEPLOYMENT.md "Robinhood Chain 4663"',
   ],
 ]);
 export const SEQUENCER_EXEMPT_CHAIN_IDS = new Set(SEQUENCER_EXEMPT_REASONS.keys());
@@ -453,7 +456,8 @@ function main() {
 
   // 1. Sequencer uptime feed — mandatory on every chain outside the exempt allowlist. An exempt
   // chain PASSES this row with an empty feed, and the row states that chain's own reason: the
-  // three exempt ids are exempt for different reasons and only one of them is a test environment.
+  // three exempt ids are exempt for different reasons, and only one of them — 4663, a mainnet — is
+  // NOT a test environment (SEQUENCER_EXEMPT_REASONS above states that split the same way).
   const seq = co.sequencerUptimeFeed;
   if (!seq || seq === ZERO) {
     check(


### PR DESCRIPTION
Closes #212. Found by the round-4 reviewer of #203 (merged 860d7bcf), nits 1 and 2.

Two sentences about the Robinhood Chain 4663 sequencer-uptime-feed exemption undercounted what survives a zero feed. One of them is **printed**, so it is a public claim: `SEQUENCER_EXEMPT_REASONS.get(4663)` is interpolated into the `sequencer uptime feed` row detail an operator reads off a passing pre-deploy run.

## What is true, read from the contract

With `sequencerUptimeFeed` at `address(0)`, `ChainlinkOracle._requireSequencerUp` returns early (`contracts/src/oracle/ChainlinkOracle.sol:314`) and `priceWad` answers through a sequencer outage. Two guards survive that, not one:

- the per-asset heartbeat/staleness bound — `contracts/src/oracle/ChainlinkOracle.sol:294`, `if (updatedAt < minUpdated) revert StaleOracle(asset);`
- the sane-price band — `contracts/src/oracle/ChainlinkOracle.sol:299`, `if (cfg.maxPriceWad != 0 && (priceWad_ < cfg.minPriceWad || priceWad_ > cfg.maxPriceWad))`

Both sit inside `priceWad`. The band is *also* enforced at construction (`:218-220`); only the read-time one survives an outage, which is why the new test requires both cites to fall inside `priceWad` rather than merely somewhere in the file.

## Changes

1. **`scripts/verify-chainlink-oracle.mjs:136`** — the printed 4663 reason ended "leaving the per-asset heartbeat as the only guard". It now names both guards with their cites.
2. **`scripts/verify-chainlink-oracle.mjs:459-460`** — the exempt-row comment said "only one of them is a test environment". The map comment at `:124-127` already had the split right (31337 and 84532 are test environments, 4663 is a mainnet). Corrected to "only one of them — 4663, a mainnet — is NOT a test environment".
3. **`contracts/script/DeployChainlinkOracle.s.sol:54-58`** — a third instance of the same shape, not named in the issue, found by the sweep. Corrected the same way. Comment-only: the `ROBINHOOD_CHAIN_ID` declaration and the `requiresSequencerUptimeFeed` body are byte-identical, so the test that extracts that function is untouched.
4. **`scripts/test/verify-chainlink-oracle.test.mjs`** — `SEQUENCER_EXEMPT_REASONS` is now exported, and a new pin asserts the 4663 reason names both guards, bans the undercount **by shape** (`only guard|as the only|only remaining|heartbeat alone|sole guard`), and checks each cited line against `ChainlinkOracle.sol` itself — so the string is held to the contract and not to the other prose.

## Sweep

Grepped REPO-WIDE (every `.md`, `.html`, `.json`, `.mjs`, `.js`, `.ts`, `.tsx`, `.txt`, `.sol`, `.yml` outside `node_modules` and `.git` — so `packages/` and the root files are in scope alongside `scripts/`, `docs/` incl. `docs/vault/`, `apps/site/` and `contracts/config/`) for `only guard`, `heartbeat alone`, `heartbeat as the only`, `guards left`, `carry this risk alone`, `carries this risk alone`, `sole guard`, `only remaining guard`, `carrying this one alone`.

| file:line (pre-fix) | text | verdict |
| --- | --- | --- |
| `scripts/verify-chainlink-oracle.mjs:133` | "leaving the per-asset heartbeat as the only guard" | **undercount fixed** — named in the issue; PRINTED |
| `scripts/verify-chainlink-oracle.mjs:456` | "only one of them is a test environment" | **undercount fixed** — named in the issue |
| `contracts/script/DeployChainlinkOracle.s.sol:55` | "the per-asset heartbeat/staleness bound is therefore the only guard left standing" | **undercount fixed** — not named in the issue; same shape, same chain, same claim, and `requiresSequencerUptimeFeed`'s own comment points back at it |
| `docs/DEPLOYMENT.md:146-147` | "the same two guards that carry every other bad-price case, now carrying this one alone" | true — names both |
| `apps/site/how-it-works.html:194` | "the per-feed heartbeat and the sane-price band below are the only guards left standing" | true — names both |
| `apps/site/risks.html:128` | "the per-feed heartbeat and the sane-price band carry this risk alone there" | true — names both |
| `contracts/config/robinhood-mainnet.json:99` | "What is left carrying every bad-price case is the per-asset heartbeat (`ChainlinkOracle.sol:294`) and the sane-price band (`:218-220` … `:299-300`)" | true — names both, with cites |
| `scripts/test/claims-lede-truth.test.mjs:113, :308` | "only guard 4 honors RECORD_DIRS" / "Guard 4 is the ONLY guard here" | not-the-shape — guard numbering in that harness, nothing to do with pricing |

After the fix the repo-wide grep returns exactly the rows above that were already true, the two not-the-shape rows, and two lines of the new test — the one that quotes the old wording as rationale and the one that bans it by regex. No instance of the pricing-guard undercount remains.

## Mutation proof

Both legs, one at a time, restoring by file copy between them:

- dropped ` and the sane-price band (ChainlinkOracle.sol:299)` → `# tests 31 / # pass 30 / # fail 1`, the one failure being `not ok 30 - the 4663 exemption reason names BOTH surviving guards, and both cites land inside priceWad`
- replaced the whole two-guard sentence with `leaving the sane-price band (ChainlinkOracle.sol:299) as the only guard.` → the same single failure

Restored by copying the saved file back; `git diff` then showed only the three intended edits.

## Verification

| suite | result |
| --- | --- |
| `scripts/test/verify-chainlink-oracle.test.mjs` | 31 tests, 31 pass, 0 fail (30 on `protocol/main`; +1 is the new pin) |
| `scripts/test/config-doc-truth.test.mjs` | 21 tests, 21 pass, 0 fail |
| `scripts/test/claims-lede-truth.test.mjs` | 6 tests, 6 pass, 0 fail |

No key, no transaction, no broadcast. `contracts/script/DeployChainlinkOracle.s.sol` is a comment-only change.


