### PR TITLE
docs(copy): Rwally positions the GitHub surfaces, and x402 leaves the public copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # Agent-Governed Index Vault Protocol
 
+Rwally is the AI agent trading index on Robinhood Chain.
 Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice, or
 move member funds — nothing rebalances until a proposal passes. Settlement in USDG on the stated
-target chain, Robinhood Chain mainnet (chain id 4663); metered read access via x402. The
+target chain, Robinhood Chain mainnet (chain id 4663). The
 contracts carry no chain-specific code, so the same immutable bytecode is deployable on any EVM
 chain; no CEX integrations. The next iteration, RWLY, is designed to accrue the protocol's fees
 into official Robinhood Stock Tokens; RWLY does not exist yet.
+
+The basket the chain configuration prices is ETH and BTC. On Robinhood Chain those are WETH
+(`0x0bd7…ad73`) and cbBTC (`0xcec1…0be4`), priced from that chain's own Chainlink `ETH / USD` and
+`CBBTC / USD` feeds, with USDG (`0x5fc5…d168`) as the settlement token. Every one of those
+addresses was read off chain 4663 rather than typed from memory, and all of them are committed in
+[`contracts/config/robinhood-mainnet.json`](contracts/config/robinhood-mainnet.json).
 
 **Not on mainnet. The launch verdict is NO-GO** — read [Status](#status) before anything else in
 this file.
@@ -200,9 +207,10 @@ with `forge snapshot --nmt "testFuzz|testFork"`).
 
 ## Agent integration
 
-Agents bootstrap from one free call — `GET /.well-known/x402` (pricing, routes, spec pointers) —
-then discover vaults (`GET /vaults`), read metered data, and act on-chain. See
-[docs/AGENT-QUICKSTART.md](docs/AGENT-QUICKSTART.md), [docs/api/openapi.yaml](docs/api/openapi.yaml),
+Agents integrate against the contracts. Read the chain configuration, build the ABIs with
+`forge build`, and call the vault directly — there is no key to request and no gateway in between.
+See [docs/AGENT-QUICKSTART.md](docs/AGENT-QUICKSTART.md),
+[`contracts/config/robinhood-mainnet.json`](contracts/config/robinhood-mainnet.json),
 and [`/llms.txt`](llms.txt).
 
 License: BUSL-1.1 — see [LICENSE](LICENSE).

--- a/apps/site/llms.txt
+++ b/apps/site/llms.txt
@@ -20,7 +20,6 @@
   bands and settlement token every public claim is checked against.
 - [Agent Quickstart](docs/AGENT-QUICKSTART.md): the contract calls an agent makes, and the
   semantics it must respect before making them.
-- [Agent SDK](packages/agent-sdk): env-agnostic JS client for the contracts.
 
 ## Protocol reference
 - [Architecture](docs/ARCHITECTURE.md): NAV/share math, two-mode exits, governance, sub-vaults, safety.

--- a/apps/site/llms.txt
+++ b/apps/site/llms.txt
@@ -1,11 +1,14 @@
 # Index Vault Protocol
 
+> Rwally is the AI agent trading index on Robinhood Chain.
 > Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 > every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 > proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice,
 > or move member funds — nothing rebalances until a proposal passes. Settlement in USDG on the
-> stated target chain, Robinhood Chain mainnet (chain id 4663); metered read access via x402
-> (EIP-3009 — the reference client is pinned to the Base Sepolia testnet and its USDC domain).
+> stated target chain, Robinhood Chain mainnet (chain id 4663). The basket that configuration
+> prices is ETH and BTC — on that chain WETH 0x0bd7…ad73 and cbBTC 0xcec1…0be4, priced from its
+> own Chainlink ETH / USD and CBBTC / USD feeds, settled in USDG 0x5fc5…d168, every address
+> committed in contracts/config/robinhood-mainnet.json.
 > The contracts carry no chain-specific code (zero uses of block.chainid in contracts/src), so the
 > same immutable bytecode is deployable on any EVM chain; Robinhood Chain is the stated target,
 > not a constraint the code enforces. The next iteration, RWLY, is designed to accrue the protocol's
@@ -13,9 +16,11 @@
 > integrating the protocol.
 
 ## Start here (agents)
-- [Agent Quickstart](docs/AGENT-QUICKSTART.md): read metered data, pay via x402, act on-chain.
-- [OpenAPI spec](docs/api/openapi.yaml): the metered API contract (3.1; generate a client).
-- [Agent SDK](packages/agent-sdk): env-agnostic JS; handles the x402 402→authorize→retry loop.
+- [Chain configuration](contracts/config/robinhood-mainnet.json): the assets, feeds, sane-price
+  bands and settlement token every public claim is checked against.
+- [Agent Quickstart](docs/AGENT-QUICKSTART.md): the contract calls an agent makes, and the
+  semantics it must respect before making them.
+- [Agent SDK](packages/agent-sdk): env-agnostic JS client for the contracts.
 
 ## Protocol reference
 - [Architecture](docs/ARCHITECTURE.md): NAV/share math, two-mode exits, governance, sub-vaults, safety.
@@ -28,6 +33,8 @@
   not published on this site — the committed address book records that current deployment. Launch
   verdict is NO-GO (docs/LAUNCH-READINESS.md, docs/NOW.md). There is nothing live to integrate
   against on mainnet, and no token, presale or airdrop exists.
+- One High -- the purchasable member count below five members -- remains open at the launch
+  configuration; see docs/LAUNCH-READINESS.md.
 - First deposit sits in a 4-hour observation window (no shares, no vote) unless skipWindow().
 - Exits are forward-priced (settle at post-rebalance NAV) from the moment a live proposal reaches
   its REVEAL phase -- not from the moment one passes -- and while a passed proposal is inside its

--- a/docs/AGENT-QUICKSTART.md
+++ b/docs/AGENT-QUICKSTART.md
@@ -1,59 +1,20 @@
 # Agent Quickstart
 
-Integrate an AI agent with the index-vault protocol in minutes. This page is written for
-machines and the humans wiring them: everything an agent needs to **read metered data**, **pay
-via x402**, and **act on-chain** (deposit, vote, exit) is here or one link away.
+Integrate an AI agent with the index-vault protocol in minutes. This page is written for machines
+and the humans wiring them: everything an agent needs to **act on-chain** — deposit, propose, vote,
+exit — is here or one link away. The contracts are the whole integration surface; there is no key
+to request and no gateway between an agent and a vault.
 
-- **API contract:** [api/openapi.yaml](api/openapi.yaml) (OpenAPI 3.1 — generate a client from it)
-- **SDK:** [`packages/agent-sdk`](../packages/agent-sdk) (env-agnostic JS; handles the x402 loop)
 - **On-chain ABIs:** `contracts/out/*/*.json` after `forge build`
+- **Chain configuration:** [`contracts/config/robinhood-mainnet.json`](../contracts/config/robinhood-mainnet.json)
+  — assets, feeds, sane-price bands and the settlement token
+- **SDK:** [`packages/agent-sdk`](../packages/agent-sdk) (env-agnostic JS client)
 - **Machine index:** [`/llms.txt`](../llms.txt)
 
-## 1. Read metered data (x402)
+## 1. Act on-chain
 
-Reads cost a few cents in USDC, settled by EIP-3009 authorization. The SDK does the whole
-402 → authorize → retry loop; you supply a wallet (address + EIP-712 signer) and the USDC domain.
-
-```js
-import { createProtocolClient } from '@x402-vaults/agent-sdk';
-
-const client = createProtocolClient({
-  baseUrl: 'https://api.example.xyz',
-  wallet: {
-    address: agentWalletAddress,
-    sign: (typedData) => wallet.signTypedData(typedData), // any EIP-712 signer
-  },
-  domain: { name: 'USD Coin', version: '2', chainId: 8453, verifyingContract: USDC_BASE },
-});
-
-const disc = await client.discovery();          // free: pricing + routes + spec pointers
-const { data } = await client.listVaults();     // discover the vault set (paid)
-const { data: lb } = await client.leaderboard();// operator leaderboard (paid)
-const vault = await client.getVault(vaultAddr); // { data: VaultView, receipt }
-await client.health();                          // free
-```
-
-**Spend control (recommended):** wrap the signer with a per-task budget and a per-tx cap so a
-compromised prompt can't drain the agent wallet. Use a dedicated hot wallet funded per session —
-never the treasury. (See the `llm-trading-agent-security` patterns.)
-
-## 2. The x402 flow, unwrapped
-
-If you're not using the SDK, the loop is:
-
-1. `GET /operators/leaderboard` → `402` with header
-   `PAYMENT-REQUIRED: {"scheme":"exact","x402Version":2,"asset":USDC,"amount":"10000","payTo":…,"network":"base","nonce":…}`
-2. Build an EIP-3009 `TransferWithAuthorization` for `(to=payTo, value≥amount, asset=USDC, nonce)`,
-   sign it (EIP-712) with the agent wallet, wrap as the envelope, base64-encode it.
-3. Retry with `PAYMENT-SIGNATURE: <base64 envelope>` → `200` + `PAYMENT-RESPONSE` receipt.
-
-The facilitator verifies and settles the authorization on-chain; the API server never holds keys.
-`packages/agent-sdk/src/eip3009.mjs` builds the typed data and envelope for you.
-
-## 3. Act on-chain
-
-The metered API is read-only. State changes go directly to the contracts (ABIs in
-`contracts/out/`). The agent-relevant entrypoints:
+Every state change goes directly to the contracts (ABIs in `contracts/out/` after `forge build`).
+The agent-relevant entrypoints:
 
 | Goal | Call | Notes |
 | --- | --- | --- |
@@ -66,7 +27,11 @@ The metered API is read-only. State changes go directly to the contracts (ABIs i
 **Read NAV/eligibility before acting:** `VaultCore.navPerShareWad()`,
 `pastVotingEligibleShares(member, ts)`, `exitFeeBpsOf(member)`.
 
-## 4. Things an integrating agent must know (protocol semantics)
+**Spend control (recommended):** wrap the signer with a per-task budget and a per-tx cap so a
+compromised prompt can't drain the agent wallet. Use a dedicated hot wallet funded per session —
+never the treasury. (See the `llm-trading-agent-security` patterns.)
+
+## 2. Things an integrating agent must know (protocol semantics)
 
 - **Observation window:** a first deposit is sequestered 4h with no shares and no vote. Budget for
   it; use `skipWindow()` only if you accept immediate entry.
@@ -91,8 +56,8 @@ The metered API is read-only. State changes go directly to the contracts (ABIs i
   that *same operator* from fees. Operator identity is the registry key, not display metadata —
   verify via `OperatorRegistry.operatorOf(vault)` before trusting a vault's branding.
 
-## 5. Index the chain yourself (optional)
+## 3. Index the chain yourself (optional)
 
 `packages/indexer` folds normalized events into vault/operator state with deterministic replay.
-Point `src/chain.mjs` at your RPC + the factory/registry addresses to run your own projection
-instead of (or alongside) the metered API.
+Point `src/chain.mjs` at your RPC + the factory/registry addresses to run your own projection of
+vault and operator state.

--- a/docs/AGENT-QUICKSTART.md
+++ b/docs/AGENT-QUICKSTART.md
@@ -8,7 +8,6 @@ to request and no gateway between an agent and a vault.
 - **On-chain ABIs:** `contracts/out/*/*.json` after `forge build`
 - **Chain configuration:** [`contracts/config/robinhood-mainnet.json`](../contracts/config/robinhood-mainnet.json)
   — assets, feeds, sane-price bands and the settlement token
-- **SDK:** [`packages/agent-sdk`](../packages/agent-sdk) (env-agnostic JS client)
 - **Machine index:** [`/llms.txt`](../llms.txt)
 
 ## 1. Act on-chain

--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,6 @@
   bands and settlement token every public claim is checked against.
 - [Agent Quickstart](docs/AGENT-QUICKSTART.md): the contract calls an agent makes, and the
   semantics it must respect before making them.
-- [Agent SDK](packages/agent-sdk): env-agnostic JS client for the contracts.
 
 ## Protocol reference
 - [Architecture](docs/ARCHITECTURE.md): NAV/share math, two-mode exits, governance, sub-vaults, safety.

--- a/llms.txt
+++ b/llms.txt
@@ -1,11 +1,14 @@
 # Index Vault Protocol
 
+> Rwally is the AI agent trading index on Robinhood Chain.
 > Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 > every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 > proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice,
 > or move member funds — nothing rebalances until a proposal passes. Settlement in USDG on the
-> stated target chain, Robinhood Chain mainnet (chain id 4663); metered read access via x402
-> (EIP-3009 — the reference client is pinned to the Base Sepolia testnet and its USDC domain).
+> stated target chain, Robinhood Chain mainnet (chain id 4663). The basket that configuration
+> prices is ETH and BTC — on that chain WETH 0x0bd7…ad73 and cbBTC 0xcec1…0be4, priced from its
+> own Chainlink ETH / USD and CBBTC / USD feeds, settled in USDG 0x5fc5…d168, every address
+> committed in contracts/config/robinhood-mainnet.json.
 > The contracts carry no chain-specific code (zero uses of block.chainid in contracts/src), so the
 > same immutable bytecode is deployable on any EVM chain; Robinhood Chain is the stated target,
 > not a constraint the code enforces. The next iteration, RWLY, is designed to accrue the protocol's
@@ -13,9 +16,11 @@
 > integrating the protocol.
 
 ## Start here (agents)
-- [Agent Quickstart](docs/AGENT-QUICKSTART.md): read metered data, pay via x402, act on-chain.
-- [OpenAPI spec](docs/api/openapi.yaml): the metered API contract (3.1; generate a client).
-- [Agent SDK](packages/agent-sdk): env-agnostic JS; handles the x402 402→authorize→retry loop.
+- [Chain configuration](contracts/config/robinhood-mainnet.json): the assets, feeds, sane-price
+  bands and settlement token every public claim is checked against.
+- [Agent Quickstart](docs/AGENT-QUICKSTART.md): the contract calls an agent makes, and the
+  semantics it must respect before making them.
+- [Agent SDK](packages/agent-sdk): env-agnostic JS client for the contracts.
 
 ## Protocol reference
 - [Architecture](docs/ARCHITECTURE.md): NAV/share math, two-mode exits, governance, sub-vaults, safety.
@@ -28,6 +33,8 @@
   not published on this site — the committed address book records that current deployment. Launch
   verdict is NO-GO (docs/LAUNCH-READINESS.md, docs/NOW.md). There is nothing live to integrate
   against on mainnet, and no token, presale or airdrop exists.
+- One High -- the purchasable member count below five members -- remains open at the launch
+  configuration; see docs/LAUNCH-READINESS.md.
 - First deposit sits in a 4-hour observation window (no shares, no vote) unless skipWindow().
 - Exits are forward-priced (settle at post-rebalance NAV) from the moment a live proposal reaches
   its REVEAL phase -- not from the moment one passes -- and while a passed proposal is inside its


### PR DESCRIPTION
The GitHub-facing half of the 2026-09-05 copy deck: the brand, the basket in the words a
reader uses, and x402 out of the public copy. Four files, all prose, no code.

## What changes

- **`README.md`** — the lede opens `Rwally is the AI agent trading index on Robinhood Chain.`;
  `; metered read access via x402` is deleted from the settlement sentence; a new paragraph names
  the basket in user language and anchors it to the tokens the configuration actually carries; the
  Agent integration section stops bootstrapping from `GET /.well-known/x402` and points at the
  contracts.
- **`llms.txt`** and **`apps/site/llms.txt`** (byte-identical, `cp`'d) — the same lede sentence and
  the same basket anchor; the three x402 entries under `Start here (agents)` are replaced by the
  chain configuration, the quickstart and a de-x402'd SDK line; and one new bullet under
  `Key semantics an integrator must respect` stating the open High, per the deck's §10 block.
- **`docs/AGENT-QUICKSTART.md`** — rewritten contracts-only per the owner's answer to the deck's
  open question 4. §1 (`Read metered data (x402)`) and §2 (`The x402 flow, unwrapped`) are deleted,
  the remaining three sections are renumbered, and the spend-control paragraph is kept because it
  now guards transaction signing. §3 and §4's bodies are otherwise byte-identical, so the
  `reveal phase` sentence, the Mode-F trigger wording and the oracle-breaker paragraph all survive
  verbatim.

## What it deliberately does not change

**Every deployment claim is left exactly as it stands on `protocol/main`.** The record
`contracts/config/deployments/robinhood-mainnet.json` is not in this tree, so nothing here could be
checked against it. That means `llms.txt`'s `NOT DEPLOYED TO MAINNET` bullet and `README.md`'s
`**Not on mainnet. The launch verdict is NO-GO**` line and whole `## Status` section are untouched,
byte for byte — they are #211's hunks, not claims this PR authors, and they are stale until #211
lands. Same reason for leaving `docs/DEPLOYMENT.md` (its intro line is #211's first hunk),
`docs/NOW.md`, `docs/LAUNCH-READINESS.md` and `docs/AUDIT-HANDOFF.md` alone.

Two edits do touch a line #211 also touches, and both are one line each: the x402 clause in the
`README.md` and `llms.txt` ledes. Deleting it is the owner instruction; there is no version of that
sentence that keeps x402 and satisfies the deck. Resolving it on rebase is `; metered read access
via x402` staying deleted.

`docs/AGENT-QUICKSTART.md` is the one place where this PR and #211 disagree rather than overlap:
#211 adds three caveats explaining that x402 does not work on chain 4663, and two of them sit
inside the sections this PR deletes. If #211 lands first, the resolution is that those two go with
their sections — their subject is gone — and #211's third caveat, on the oracle-breaker bullet,
survives untouched because this PR does not edit that bullet.

Also left alone on purpose: `docs/ARCHITECTURE.md` §9 and `docs/THREAT-MODEL.md` PX-2 describe the
x402 boundary and scope a security review; `docs/audit/README.md`'s one-paragraph summary is
already guard-clean and is a reviewer-facing scope statement, not product copy. The `apps/api/` and
`packages/agent-sdk` rows of the README layout table describe the repository rather than the
product, and stay factual. No `USDC` → `USDG` sweep: `config-doc-truth.test.mjs` pins docs against
`base-mainnet.json` and `base-sepolia.json`, which are USDC.

## Truth basis

- `Rwally is the AI agent trading index on Robinhood Chain.` — owner, 2026-09-05.
- The basket sentence is scoped to the configuration, not to a vault, because no vault exists:
  `chainlinkOracle.assets` in `contracts/config/robinhood-mainnet.json` is WETH
  `0x0bd7d308f8e1639fab988df18a8011f41eacad73` priced from `ETH / USD` and cbBTC
  `0xcec185eb182c47d1ba1efc84e6959e18cd620be4` priced from `CBBTC / USD`, settlement token USDG
  `0x5fc5360d0400a0fd4f2af552add042d716f1d168`, every one recorded under `verifiedOnChain` as read
  off chain 4663 on 2026-09-04.
- The absence sweep behind the repository description was re-run on this tree:
  `grep -rniE "onlyOwner|selfdestruct|delegatecall|function (pause|unpause)" --include=*.sol
  contracts/src/` returns nothing, and the `proxy`/`upgrade`/`owner` residue is three NatSpec lines
  (`Governance.sol:66`, `VaultDeployer.sol:26`, `VaultFactory.sol:47`) that state the claim rather
  than contradict it.
- No universal negative about the operator: the enumerated form
  (`confers no authority to vote, execute, pause, reprice, or move member funds`) is kept verbatim
  in both ledes.

## Guard legs this prose depends on

1. `claims-lede-truth.test.mjs` guard 1 — `the AI agent trading index` passes only because
   `AGENT_ACTS` alternates `trade|trades`, not `trading`. If that verb set is widened, land the
   deck's explicit exemption for that exact phrase in the same commit.
2. `site.test.mjs` `REPO_PROSE` — `README.md`, `llms.txt` and `docs/AGENT-QUICKSTART.md` must each
   keep `/reveal phase/i`. All three still do.
3. The open-High floor `seen >= 3`, with `H-8` or `purchasable member count` named in the same
   sentence. README's sentence is untouched, and **`llms.txt` gains the sentence the deck's §10
   replacement block carries**, because the floor is the one leg the site consolidation quietly
   breaks: today it counts six (README 1, `faq.html` 1, `index.html` 2, `risks.html` 2), and after
   `risks.html` retires and the site states it once on `disclaimers.html` it would count two.
   README plus `llms.txt` plus the consolidated page is the three the deck's leg 12 describes.
4. `apps/site/llms.txt` byte-identical to the root file.
5. The RWLY 160-character `does not exist` window and the floor of six under `apps/site` — the RWLY
   sentence is untouched and the inserted lines sit before it, not between its halves.

## Verification

`node --test --test-reporter=tap scripts/test/claims-lede-truth.test.mjs
scripts/test/config-doc-truth.test.mjs` — 27/27 pass, run against those two files as they stand on
`protocol/main` (they are being rewritten elsewhere; this PR does not touch them).
`apps/site/test/site.test.mjs` — 38/38. `npm run gate` green in the branch worktree.
