### PR TITLE
site: status.html carries the RWLY record, and the record is what checks it

### DIFF
--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -202,6 +202,38 @@ from an old copy reds. Retiring it also removed the only exemption that made `ai
 `presale` legal anywhere under `apps/site`, which is a tightening: those two words are now banned
 outright on all nine pages.
 
+That sentence was doing a **second** job nothing replaced when it went false. It said the token did
+not exist, and it also made a call to action self-evidently absurd. RWLY launched 2026-09-05 and
+trades on a curve, so the second half is a rule rather than an implication: `PURCHASE_INVITE` bans seven invitation
+phrases on every page, and `PURCHASE_VERB` bans a second-person purchase verb in any sentence that
+names RWLY. `buy RWLY` carries a negative lookahead on `back`, because `vision.html` describes fees
+buying RWLY back as design intent and that sentence invites nobody.
+
+The window rule is a **pure function with a probe** (`rwlyUnqualified`, and the `probe:` test beside
+it) rather than a loop inlined in the leg. A character window fails green in two ways, by measuring
+the wrong distance and by an alternation wide enough to match anything, and neither shows up as a
+red. The probe pins five shapes that must be caught and four that must be spared.
+
+### `status.html` transcribes the token record
+
+Every RWLY figure in the token section of `status.html`, starting with the address stem
+`0x2eed8ae7`, is transcribed from `contracts/config/deployments/rwly-robinhood-mainnet.json`, and a test asserts it field by field:
+the address, the supply, the chain id, the creation transaction and block, the curve, and the
+graduation transaction, block, timestamp, threshold, recipient and token count. The graduation flag
+is checked **symmetrically**, meaning the record says which way round it is and the page must say the
+same way round, because a one-directional assertion is how copy survives the event it denies.
+
+This exists because the record was bound by nothing until 2026-09-06:
+`scripts/test/claims-robinhood-deployment.test.mjs` binds the seven deployed contracts to
+`robinhood-mainnet.json` and stops there, so every RWLY figure on this site, the address
+`0x2eed8ae7` included, agreed with the record only because one author had both files open. The first draft of the graduation prose said the curve
+had **not** graduated, carried over from a session note; `graduated()` returns true and the
+graduation transaction is 55 minutes after the launch.
+
+The record follows the creator position only as far as the launch transaction and says so in
+`creatorBuy.scope`. No page may claim where that position is now, and a test bans the phrasings
+that would (`have not moved`, `still holds those tokens`, `remains unmoved`).
+
 ### The negation exceptions
 
 A few banned words have exactly one legitimate use here, and it is always inside a negation: the

--- a/apps/site/status.html
+++ b/apps/site/status.html
@@ -158,8 +158,13 @@
       <h2>RWLY is live.</h2>
       <p class="tight">Launched 2026-09-05 on Pons, a third-party launchpad this project did not write, at <code>0x2eed8ae78AE1aa6824e1C378F46d5C51b6B7FDF9</code> on Robinhood Chain, chain id 4663.</p>
       <p class="tight">An ERC-20 named RWAlly, fixed supply 1,000,000,000, no owner, no mint function, no pause and no upgrade path.</p>
+      <p class="tight">It was created in transaction <code>0x1672a086c16547fcb533478521311cb4d703c815d38d2db1650ef71c2fd1b5d9</code>, in block 55456054, whose own timestamp is the launch time above.</p>
+      <p class="tight">Trading opened on a bonding curve at <code>0x0032fEc43109AD0F24bbaae9A92562DC96ba2BB5</code>, quoted in native ETH and not in a stock token: the curve&rsquo;s <code>pairToken()</code> returns the zero address and its <code>isNativeQuote()</code> returns true.</p>
+      <p class="tight">That curve has graduated, and this page says so rather than leaving the reader to assume it is still running. Its threshold was 4.2 ETH and it raised 4.2 ETH, exceeding the threshold by 78 wei.</p>
+      <p class="tight">Graduation was transaction <code>0x43d4caf89f31999ab76ef454772e5e2c09617312c244e1f140511db1818a7e7c</code>, in block 55488695, timestamped 2026-09-05T22:46:51Z, which is 54 minutes and 54 seconds after the launch. It moved the raised ETH and 285,714,285 RWLY, 28.5714% of the fixed supply, to the launchpad&rsquo;s own factory at <code>0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e</code>. The curve has held nothing and emitted nothing since.</p>
+      <p class="tight">What that factory did with those tokens next was not read, so this page does not say. A figure this page does not carry is a figure nobody checked, and that is the honest version.</p>
       <p class="tight">No contract this protocol deployed references it, and the staking, the epochs and the fee accrual into stock tokens are design intent. The design is on the <a href="vision.html">Vision page</a>.</p>
-      <p class="tight">The record is <code>contracts/config/deployments/rwly-robinhood-mainnet.json</code>, which carries the launch transaction, the launchpad addresses, the fee terms and what the protocol&rsquo;s own deployer address took in the launch transaction. The <a href="disclaimers.html">Disclaimers</a> state that last one in prose.</p>
+      <p class="tight">The record is <code>contracts/config/deployments/rwly-robinhood-mainnet.json</code>, which carries the launch transaction, the graduation transaction, the launchpad addresses, the fee terms and what the protocol&rsquo;s own deployer address took in the launch transaction. Every figure in this section is transcribed from it, and the <a href="disclaimers.html">Disclaimers</a> state that last one in prose.</p>
     </div>
   </section>
 
@@ -169,6 +174,7 @@
       <h2>How to check every line above.</h2>
       <ul>
         <li><a href="https://github.com/SlumperSan/agent-governed-vaults/blob/protocol/main/contracts/config/deployments/robinhood-mainnet.json">The deployment record</a>: every address above, plus the note recording how each was read back on-chain.</li>
+        <li><a href="https://github.com/SlumperSan/agent-governed-vaults/blob/protocol/main/contracts/config/deployments/rwly-robinhood-mainnet.json">The token record</a>: every figure in the token section above, including the launch and the graduation transactions, each with the command that reads it back off chain.</li>
         <li><a href="https://github.com/SlumperSan/agent-governed-vaults/blob/protocol/main/contracts/config/robinhood-mainnet.json">The chain configuration</a>: every parameter this site quotes for chain 4663, each annotated with how it was read.</li>
         <li><a href="https://github.com/SlumperSan/agent-governed-vaults/blob/protocol/main/apps/site/test/site.test.mjs">The wording guard for this site</a>: it pins the exact sentences here and reads the contract configuration to catch a page that has gone stale against it.</li>
         <li><a href="https://github.com/SlumperSan/agent-governed-vaults/blob/protocol/main/scripts/test/claims-lede-truth.test.mjs">The repository-wide claims guard</a>.</li>

--- a/apps/site/test/site.test.mjs
+++ b/apps/site/test/site.test.mjs
@@ -1096,13 +1096,14 @@ const RWLY_QUALIFIER = /does not exist|design intent|designed to|not built|0x2ee
 // mention to a checkable date rather than borrowing a qualifier from the prose beside it.
 const RWLY_CHIP = 'Designed, not built. RWLY launched 2026-09-05.';
 const VISION_PAGE = 'vision.html';
-// RE-MEASURED 2026-09-05, after the launch flip: siteFiles() finds 51 occurrences of `RWLY` across
-// apps/site (test/ and images excluded, per siteFiles() below) -- 18 of them on vision.html alone,
-// where the chip accounts for nine. It was 46 before the flip; the five it gained are the launch
-// facts the six flipped pages now state. Set a few below that measurement, not at it, so a small
-// future edit does not immediately red this floor; re-measure and move this number the next time
-// RWLY mentions are added or removed anywhere under apps/site.
-const RWLY_FLOOR = 45;
+// RE-MEASURED 2026-09-06, after the token record landed on status.html: siteFiles() finds 61
+// occurrences of `RWLY` across apps/site (test/ and images excluded, per siteFiles() below) -- 18
+// of them on vision.html alone, where the chip accounts for nine. It was 51 after the launch flip
+// the day before and 46 before it. The ten it gained are the graduation record on status.html and
+// the README section describing the rules that record is checked by. Set a few below that
+// measurement, not at it, so a small future edit does not immediately red this floor; re-measure
+// and move this number the next time RWLY mentions are added or removed anywhere under apps/site.
+const RWLY_FLOOR = 55;
 
 /**
  * `vision.html`'s top-level `<section>` blocks, in document order. Assumes flat, non-overlapping
@@ -1110,6 +1111,75 @@ const RWLY_FLOOR = 45;
  * section nested inside another.
  */
 const sectionsOf = (html) => html.match(/<section\b[^>]*>[\s\S]*?<\/section>/gi) ?? [];
+
+/**
+ * The windows around every `RWLY` in a piece of text that carry none of the qualifiers.
+ *
+ * EXTRACTED FROM THE LOOP BELOW SO THE PROBE CAN PROVE IT BITES. The logic is unchanged; only its
+ * location moved. It was inlined, which meant the only evidence the window rule worked was that it
+ * was green -- and a window check has two failure modes that both report green: measuring the wrong
+ * distance, and an alternation so wide that everything matches it. This repository has been caught
+ * by the green-because-it-measured-nothing shape more than once (the soak's freeze-safety leg read
+ * a variable nobody set; the `.pre-launch` selector survived a rename into a stylesheet check that
+ * matched no blocks and asserted nothing), and the sibling suite in `apps/site-next` extracted its
+ * copy of this function for exactly this reason. The probe below is the point of the extraction.
+ *
+ * Takes text as given rather than stripping tags, which is what the caller has always passed: the
+ * three qualified mentions on `index.html` sit inside `content="…"` meta attributes, so this file's
+ * window is deliberately measured over markup. `apps/site-next` strips tags first because its build
+ * emits hashed CSS-module class names that would eat the window; this build's markup is hand-
+ * written and does not.
+ */
+const rwlyUnqualified = (text) => {
+  const flat = text.replace(/\s+/g, ' ');
+  /** @type {string[]} */
+  const out = [];
+  for (const m of flat.matchAll(/RWLY/g)) {
+    const at = m.index ?? 0;
+    const window = flat.slice(Math.max(0, at - RWLY_WINDOW), at + RWLY_WINDOW);
+    if (!RWLY_QUALIFIER.test(window)) out.push(window.trim().slice(0, 200));
+  }
+  return out;
+};
+
+/**
+ * Purchase INVITATIONS, banned anywhere on a page whether or not RWLY is in the same sentence.
+ *
+ * ADDED 2026-09-06, PORTED FROM `apps/site-next`, AND IT IS THE HOLE THAT MATTERS MOST NOW. Until
+ * 2026-09-05T21:51:57Z there was no token to invite anyone to buy, and this suite's whole defence
+ * was a sentence saying so. The sentence is retired because it went false; nothing replaced the
+ * defence it provided. A named token that trades is the single easiest thing on these pages for a
+ * well-meaning editor to attach a call to action to, and this site has no venue link and no funnel
+ * by design, so every one of these phrases would be new.
+ *
+ * BANNED, not merely qualified. Unlike the window rule above there is no legitimate form: none of
+ * these phrases has a use in copy that must not solicit.
+ */
+const PURCHASE_INVITE = [
+  // NEGATIVE LOOKAHEAD ON `back`, AND IT WAS THE PROBE THAT FOUND IT. `apps/site-next` carries this
+  // list as a bare /\bbuy\s+RWLY\b/i, which is correct for that build's copy and wrong for this
+  // one: `vision.html` says "10% is designed to buy RWLY back, hourly, as a TWAP", which describes
+  // the designed buyback and invites nobody. Porting the sibling's regex unchanged reddened a page
+  // whose copy is fine. The narrower form still catches every second-person shape, because "buy
+  // RWLY back" is the only phrase in English where those two words are not an instruction.
+  /\bbuy\s+RWLY\b(?!\s+back\b)/i,
+  /\bbuy\s+the\s+token\b/i,
+  /\bhow\s+to\s+buy\b/i,
+  /\bwhere\s+to\s+buy\b/i,
+  /\byou\s+can\s+buy\b/i,
+  /\bbuy\s+now\b/i,
+  /\bavailable\s+to\s+(?:buy|purchase)\b/i,
+];
+
+/**
+ * Second-person purchase verbs, banned only in a sentence that also names RWLY.
+ *
+ * SENTENCE-SCOPED RATHER THAN PAGE-SCOPED, and the distinction is load-bearing: `how-it-works.html`
+ * legitimately describes a vault buying stock, and `vision.html` describes fees buying RWLY back as
+ * design intent. Neither addresses the reader. What this bans is the shape that turns a record into
+ * an offer: a sentence that names the token and tells the reader what they might do with it.
+ */
+const PURCHASE_VERB = /\byou\s+(?:can|could|may|might|should)\s+(?:buy|purchase|acquire|swap|trade|hold|stake)\b|\byour\s+RWLY\b/i;
 
 test('every mention of RWLY sits beside its address, its fixed supply, or a design-intent qualifier', () => {
   const files = siteFiles();
@@ -1145,16 +1215,12 @@ test('every mention of RWLY sits beside its address, its fixed supply, or a desi
       continue;
     }
 
-    for (const m of text.matchAll(/RWLY/g)) {
-      const at = m.index ?? 0;
-      const window = text.slice(Math.max(0, at - RWLY_WINDOW), at + RWLY_WINDOW);
-      assert.ok(
-        RWLY_QUALIFIER.test(window),
-        `${f}: names RWLY without its address, "fixed supply", or a design-intent qualifier within ${RWLY_WINDOW} characters. ` +
-          'RWLY launched 2026-09-05; every mention must anchor to the launch facts or say which part is still design. ' +
-          `— ${JSON.stringify(window.trim().slice(0, 200))}`,
-      );
-    }
+    assert.deepEqual(
+      rwlyUnqualified(text),
+      [],
+      `${f}: names RWLY without its address, "fixed supply", or a design-intent qualifier within ${RWLY_WINDOW} characters. ` +
+        'RWLY launched 2026-09-05; every mention must anchor to the launch facts or say which part is still design.',
+    );
   }
   assert.ok(
     seen >= RWLY_FLOOR,
@@ -1190,6 +1256,36 @@ test('every mention of RWLY sits beside its address, its fixed supply, or a desi
     }
   }
 
+  // AND NO PAGE MAY INVITE A PURCHASE, which is the defence the retired sentence used to provide.
+  //
+  // `No token. No points. No airdrop. No presale.` was doing two jobs, and only one of them was
+  // replaced when it went false. It said the token did not exist, which is the half every commit
+  // since has been busy correcting; it also made a call to action self-evidently absurd, which is
+  // the half nothing replaced. RWLY now exists and trades, so that half has to be a rule.
+  for (const p of PAGES) {
+    const fileText = raw.get(p) ?? '';
+    for (const re of PURCHASE_INVITE) {
+      const hit = fileText.match(re);
+      assert.equal(
+        hit,
+        null,
+        `${p}: ${JSON.stringify(hit?.[0])} invites a purchase. This site has no venue link and no funnel, ` +
+          'and the sentence that used to make that obvious was retired when the token launched',
+      );
+    }
+    for (const s of sentencesOf(publishedProse(fileText))) {
+      if (!/RWLY/.test(s)) continue;
+      const hit = s.match(PURCHASE_VERB);
+      assert.equal(
+        hit,
+        null,
+        `${p}: a sentence naming RWLY also says ${JSON.stringify(hit?.[0])}. Describe what a transaction ` +
+          'did, in the past tense, against a named address; never what a reader might do, ' +
+          JSON.stringify(s.trim().slice(0, 200)),
+      );
+    }
+  }
+
   // WHAT EACH PAGE MUST STATE, not merely avoid getting wrong.
   //
   // This half used to pin the exact sentence `RWLY does not exist yet.` on index.html -- a
@@ -1213,6 +1309,161 @@ test('every mention of RWLY sits beside its address, its fixed supply, or a desi
           'never names the token, which is how a disclosure disappears without any guard going red',
       );
     }
+  }
+});
+
+/**
+ * PROBE: the window rule bites, and it spares the forms this site actually publishes.
+ *
+ * WITHOUT THIS THE LEG ABOVE IS UNFALSIFIED, and this file has the scar tissue to know it. The
+ * `.pre-launch` stylesheet check below survived a class rename in the sibling build by matching
+ * nothing, iterating an empty array and reporting a pass; the soak's freeze-safety leg read a
+ * variable nobody set and its empty `.map()` was indistinguishable from an all-clear. A character
+ * window is the same shape of risk twice over: it can measure the wrong distance, and its qualifier
+ * alternation can grow wide enough to match anything. Neither shows up as a failure.
+ *
+ * The `bad` cases are the ones an editor actually writes. The last of them is the trap this file
+ * warns about in prose: a qualifier that IS on the page but is a paragraph away.
+ */
+test('probe: the RWLY window rule catches a bare mention and spares the approved forms', () => {
+  const PAD = 'x'.repeat(RWLY_WINDOW + 40);
+  for (const bad of [
+    'RWLY is live.',
+    'Hold RWLY.',
+    `RWLY trades today. ${PAD} It has a fixed supply of 1,000,000,000.`,
+    `The staking is design intent. ${PAD} RWLY is a token.`,
+    `RWLY is a token. ${PAD} 0x2eed8ae78AE1aa6824e1C378F46d5C51b6B7FDF9`,
+  ]) {
+    assert.notDeepEqual(rwlyUnqualified(bad), [], `the window rule no longer catches: ${JSON.stringify(bad.slice(0, 60))}`);
+  }
+  for (const ok of [
+    // The status page's own beat.
+    'RWLY is live. Launched 2026-09-05 on Pons, a third-party launchpad this project did not write.',
+    // An address chip, which is a label and an address and nothing else. The STEM, not the full
+    // string: a chip is all a narrow column can render, and a rule written against the full address
+    // reds correct copy.
+    'RWLY 0x2eed8ae7…b6B7FDF9',
+    // The hedge every mention of the unbuilt half has to carry.
+    'RWLY is designed to accrue fees into stock tokens, and that mechanism is design intent.',
+    // The vision page's chip, which is why `launched 2026-09-05` is in the alternation: it has to
+    // anchor its own mention rather than borrow one from the prose beside it.
+    RWLY_CHIP,
+  ]) {
+    assert.deepEqual(rwlyUnqualified(ok), [], `the window rule reds approved copy: ${JSON.stringify(ok.slice(0, 60))}`);
+  }
+
+  // AND THE PURCHASE BANS BITE. Same reasoning: a regex list that matches nothing reads exactly
+  // like a regex list that matches nothing because the copy is clean.
+  assert.ok(PURCHASE_INVITE.some((re) => re.test('Here is how to buy RWLY.')));
+  assert.ok(PURCHASE_INVITE.some((re) => re.test('It is available to purchase now.')));
+  assert.ok(!PURCHASE_INVITE.some((re) => re.test('The deployer address bought 72,978,672 RWLY in the launch transaction.')));
+  // The buyback sentence on vision.html, which the ported regex reddened until the lookahead went
+  // in. Both halves are asserted so a future widening of the pattern cannot quietly take it out.
+  assert.ok(!PURCHASE_INVITE.some((re) => re.test('10% is designed to buy RWLY back, hourly, as a TWAP.')));
+  assert.ok(PURCHASE_INVITE.some((re) => re.test('Buy RWLY on the curve.')));
+  assert.ok(PURCHASE_VERB.test('You can buy RWLY on a bonding curve.'));
+  assert.ok(PURCHASE_VERB.test('Stake your RWLY to vote.'));
+  assert.ok(!PURCHASE_VERB.test('10% is designed to buy RWLY back, hourly, as a TWAP.'));
+});
+
+/**
+ * STATUS.HTML TRANSCRIBES THE TOKEN RECORD, RATHER THAN RESTATING IT FROM MEMORY.
+ *
+ * WHY THIS IS THE LEG THAT MATTERED MOST ON 2026-09-06. Until this test, `rwly-robinhood-mainnet
+ * .json` was bound by nothing: `claims-robinhood-deployment.test.mjs` binds the seven deployed
+ * contracts to `robinhood-mainnet.json` and stops there, so every RWLY address, hash and figure on
+ * this site was a free-floating string that agreed with the record only because one author had both
+ * files open. That is the failure the record guard's own header names: rewriting a false claim into
+ * a second set of unsourced assertions is easier than rewriting it into a sourced one.
+ *
+ * It is not hypothetical here. The prose that this leg now checks was first drafted saying the
+ * launch had NOT graduated, carried across from a session note; `graduated()` returns true and the
+ * graduation transaction is 55 minutes after the launch. A record the page is checked against is
+ * the difference between catching that and shipping it.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO: read the chain. A test that calls an RPC is a test that fails
+ * when a third-party endpoint is down, and CI would learn to ignore it. The record is the artefact
+ * that gets reviewed; this asserts the page and the record agree, and the record's own `reproduce`
+ * array carries the commands that check the record against the chain.
+ */
+test('status.html transcribes the RWLY record, figure for figure', () => {
+  const RECORD_PATH = path.join(REPO, 'contracts/config/deployments/rwly-robinhood-mainnet.json');
+  assert.ok(existsSync(RECORD_PATH), `the token record is missing: ${RECORD_PATH}`);
+  const record = JSON.parse(readFileSync(RECORD_PATH, 'utf8'));
+  const html = raw.get(STATUS_PAGE) ?? '';
+
+  // Every pair is [what the record holds, how the page is allowed to render it]. The second
+  // element exists because a page renders `1,000,000,000` where a record holds a wei string; where
+  // the two are identical it is the same value twice, which is the case that needs no translation.
+  /** @type {Array<[string, string, string]>} */
+  const transcribed = [
+    ['token.address', record.token.address, record.token.address],
+    ['token.totalSupplyHuman', record.token.totalSupplyHuman, record.token.totalSupplyHuman],
+    ['chainId', String(record.chainId), String(record.chainId)],
+    ['creation.creationTx', record.creation.creationTx, record.creation.creationTx],
+    ['creation.creationBlock', String(record.creation.creationBlock), String(record.creation.creationBlock)],
+    ['launchpad.curve', record.launchpad.curve, record.launchpad.curve],
+    ['graduation.graduationTx', record.graduation.graduationTx, record.graduation.graduationTx],
+    ['graduation.graduationBlock', String(record.graduation.graduationBlock), String(record.graduation.graduationBlock)],
+    ['graduation.graduatedAt', record.graduation.graduatedAt, record.graduation.graduatedAt],
+    ['graduation.thresholdHuman', record.graduation.thresholdHuman, record.graduation.thresholdHuman],
+    ['graduation.recipient', record.graduation.recipient, record.graduation.recipient],
+    [
+      'graduation.tokensSentToLaunchpadFactoryHuman',
+      record.graduation.tokensSentToLaunchpadFactoryHuman,
+      record.graduation.tokensSentToLaunchpadFactoryHuman,
+    ],
+    [
+      'graduation.tokensSentToLaunchpadFactoryShareOfSupply',
+      record.graduation.tokensSentToLaunchpadFactoryShareOfSupply,
+      record.graduation.tokensSentToLaunchpadFactoryShareOfSupply,
+    ],
+  ];
+  assert.ok(transcribed.length >= 13, 'the transcription table shrank; a value stopped being checked');
+  for (const [field, , onPage] of transcribed) {
+    assert.ok(
+      html.includes(onPage),
+      `${STATUS_PAGE}: the record's ${field} is ${JSON.stringify(onPage)} and the page does not carry it. ` +
+        'Every figure in the token section is transcribed from the record, not restated from a session',
+    );
+  }
+
+  // THE STATE FLAG IS SYMMETRIC, in the shape claims-robinhood-deployment.test.mjs uses for the
+  // first vault: the record says which way round it is, and the page must say the same way round.
+  // A one-directional assertion is how copy survives the event it denies.
+  if (record.graduation.graduated === true) {
+    assert.ok(
+      /has graduated/.test(html),
+      `${STATUS_PAGE}: the record says the curve graduated (tx ${record.graduation.graduationTx}) and the ` +
+        'page does not say so',
+    );
+    assert.ok(
+      !/not graduated|has not yet graduated/i.test(html),
+      `${STATUS_PAGE}: the record says the curve graduated and the page still says it has not`,
+    );
+  } else {
+    assert.ok(
+      /not graduated/i.test(html),
+      `${STATUS_PAGE}: the record says the curve has not graduated and the page does not say so`,
+    );
+  }
+
+  // WHAT THE RECORD REFUSES TO SAY, THE PAGE MAY NOT SAY EITHER. The record does not follow the
+  // creator position past the launch transaction, and it says so in `creatorBuy.scope`; a sibling
+  // surface asserted those tokens were unmoved and was wrong. No page gets to hold a fact the
+  // record does not.
+  assert.ok(
+    typeof record.creatorBuy.scope === 'string' && /not recorded here/i.test(record.creatorBuy.scope),
+    'the record no longer scopes creatorBuy to the launch transaction; this leg checks a boundary that moved',
+  );
+  for (const p of PAGES) {
+    const hit = (raw.get(p) ?? '').match(/(?:have|has) not moved|still holds? (?:those|these) tokens|remain(?:s)? unmoved/i);
+    assert.equal(
+      hit,
+      null,
+      `${p}: says ${JSON.stringify(hit?.[0])} about a token position. The record follows the creator ` +
+        'position only as far as the launch transaction, so no page may claim where it is now',
+    );
   }
 });
 

--- a/contracts/config/deployments/rwly-robinhood-mainnet.json
+++ b/contracts/config/deployments/rwly-robinhood-mainnet.json
@@ -39,6 +39,30 @@
     "creatorFeeRecipient": "0xC73Bd58725afF051109b97B7Be40a8E31C6CAD4c",
     "creatorFeeRecipientNote": "A 1-of-1 multisig whose only owner is the deployer EOA above, on version 1.4.1. getThreshold() returns 1 and getOwners() returns that one address, checked against a known 2-of-3 multisig as a positive control. One key can move whatever it holds, so nothing it holds is locked by it."
   },
+  "graduation": {
+    "graduated": true,
+    "graduatedNote": "THE CURVE HAS GRADUATED. This section was added on 2026-09-06, and it is recorded as a TRANSACTION rather than as a getter reading: graduated() returning true is a fact about a block, while the transaction below is a fact about the chain's history and stays true however the getter later behaves. It is written down because the first draft of the prose that cites this file said the launch had NOT graduated, which was carried over from a session note rather than read, and was false by 55 minutes.",
+    "graduationTx": "0x43d4caf89f31999ab76ef454772e5e2c09617312c244e1f140511db1818a7e7c",
+    "graduationBlock": 55488695,
+    "graduationBlockTimestamp": 1788648411,
+    "graduatedAt": "2026-09-05T22:46:51Z",
+    "graduatedAtNote": "The graduation block's own timestamp, read with eth_getBlockByNumber. 3,294 seconds, which is 54 minutes and 54 seconds, after the creation block's timestamp above.",
+    "thresholdWei": "4200000000000000000",
+    "thresholdHuman": "4.2 ETH",
+    "thresholdNote": "graduationThreshold() read from the curve. The figure was previously written into prose on one surface without a record behind it; this is that figure read from the contract.",
+    "quoteRaisedWei": "4200000000000000078",
+    "quoteRaisedHuman": "4.2 ETH",
+    "quoteRaisedNote": "The second word of the graduation event's payload. It exceeds the threshold by 78 wei, which is what a threshold crossed by a trade rather than by a target looks like.",
+    "tokensSentToLaunchpadFactory": "285714285714285714285714285",
+    "tokensSentToLaunchpadFactoryHuman": "285,714,285",
+    "tokensSentToLaunchpadFactoryShareOfSupply": "28.5714%",
+    "recipient": "0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e",
+    "recipientNote": "The launchpad factory address recorded above. The graduation transaction transfers the tokens to it and the event's first word names it. WHERE THE FACTORY ROUTED THEM NEXT WAS NOT READ, so no surface citing this file may say what became of that position, how it is held, or whether it can be withdrawn.",
+    "curveAfterwards": "The curve holds 0 wei and 0 RWLY, and emitted no log after the graduation block. quoteReserve() returns 1680000000000000000, which equals phantomQuote() exactly: the virtual reserve the curve was seeded with, and not a balance.",
+    "buybackEnabled": false,
+    "buybackEnabledNote": "buybackEnabled() returns false on this curve. The hourly buyback described on the Vision page is design intent and is not this flag.",
+    "provenance": "ONCHAIN, read 2026-09-06 against https://rpc.mainnet.chain.robinhood.com. The transaction, its block and its logs came from eth_getTransactionReceipt and eth_getBlockByNumber; graduated(), graduationThreshold(), quoteReserve() and buybackEnabled() were called at the head block, and their selectors were first confirmed to be PUSH4 immediates in the curve's own runtime so that a getter which does not exist could not answer zero and be read as false. The node serves no state older than roughly 1,024 blocks, so the graduation was located from the curve's event log rather than by bisecting graduated() over history."
+  },
   "creatorBuy": {
     "inSameTransactionAsLaunch": true,
     "spentWei": "133700000000000000",
@@ -50,7 +74,8 @@
     "snipeTaxPaid": "none",
     "snipeTaxNote": "currentSnipeTaxBps(deployer) returns 0 in the launch block while a stranger address returns 9900 in the same block. The exemption is the launchpad's own automatic one for the creator: the transaction's exemption list argument decodes to length zero.",
     "characterisation": "Not a pre-mine and not a reserved allocation: nothing was set aside before trading opened, and the buy executed against the same curve at the same formula price any address could have paid. It is nonetheless a 7.2979% position taken at the opening price under a zero tax rate no other address had in that block, and both halves belong together.",
-    "verification": "The tokens delivered match the curve's own constant-product expectation to zero wei, computed from launchSupply(), phantomQuote(), feeBps() and creatorTaxBps() alone."
+    "verification": "The tokens delivered match the curve's own constant-product expectation to zero wei, computed from launchSupply(), phantomQuote(), feeBps() and creatorTaxBps() alone.",
+    "scope": "EVERY FIELD IN THIS SECTION DESCRIBES THE LAUNCH TRANSACTION AND NOTHING AFTER IT. What later became of this position is deliberately not recorded here and has not been decided by the owner, so no surface citing this file may say that these tokens are still held, are unmoved, or are anywhere in particular. A surface that wants to say something about where the position is now needs a record entry that does not exist yet."
   },
   "relationshipToOurDeployedContracts": {
     "referencedByAnyDeployedContract": false,
@@ -65,6 +90,13 @@
     "cast call 0x2eed8ae78AE1aa6824e1C378F46d5C51b6B7FDF9 'totalSupply()(uint256)' --rpc-url https://rpc.mainnet.chain.robinhood.com",
     "cast call 0x2eed8ae78AE1aa6824e1C378F46d5C51b6B7FDF9 'name()(string)' --rpc-url https://rpc.mainnet.chain.robinhood.com",
     "cast tx 0x1672a086c16547fcb533478521311cb4d703c815d38d2db1650ef71c2fd1b5d9 --rpc-url https://rpc.mainnet.chain.robinhood.com",
-    "cast block 55456054 --field timestamp --rpc-url https://rpc.mainnet.chain.robinhood.com"
+    "cast block 55456054 --field timestamp --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast call 0x0032fEc43109AD0F24bbaae9A92562DC96ba2BB5 'graduated()(bool)' --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast call 0x0032fEc43109AD0F24bbaae9A92562DC96ba2BB5 'graduationThreshold()(uint256)' --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast call 0x0032fEc43109AD0F24bbaae9A92562DC96ba2BB5 'buybackEnabled()(bool)' --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast tx 0x43d4caf89f31999ab76ef454772e5e2c09617312c244e1f140511db1818a7e7c --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast receipt 0x43d4caf89f31999ab76ef454772e5e2c09617312c244e1f140511db1818a7e7c --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast block 55488695 --field timestamp --rpc-url https://rpc.mainnet.chain.robinhood.com",
+    "cast balance 0x0032fEc43109AD0F24bbaae9A92562DC96ba2BB5 --rpc-url https://rpc.mainnet.chain.robinhood.com"
   ]
 }


### PR DESCRIPTION
Stacks on #222 (`feat/site-redesign-infra-r6`), which is where the first two thirds of the RWLY launch flip landed. This is the `apps/site` remainder.

## The ticket's last fact was false

It asked for the token record on `status.html`, ending with "the launch is ETH-quoted and has not graduated."

`graduated()` returns **true**. The curve graduated in `0x43d4caf89f31999ab76ef454772e5e2c09617312c244e1f140511db1818a7e7c`, block 55488695, at 2026-09-05T22:46:51Z, which is 54 minutes and 54 seconds after the launch. It raised 4,200,000,000,000,000,078 wei against a 4,200,000,000,000,000,000 wei threshold and moved that ETH plus 285,714,285 RWLY, 28.5714% of the fixed supply, to the launchpad's own factory at `0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e`. The curve has held nothing and emitted nothing since.

The page states that. The 4.2 ETH threshold already existed in the tree, in `apps/site-next` prose and in no record; it is **not** transcribed from there. `graduationThreshold()` was read from the curve after confirming its selector is a PUSH4 immediate in the curve's own runtime, so a getter that does not exist could not answer zero and be read as false. The node serves no state older than roughly 1,024 blocks, so the graduation was located from the curve's event log rather than by bisecting `graduated()` over history.

## Six of the seven listed surfaces were already done

`ca0039c2`, `99a18b18`, `e5d20a59` and `957ae59a` flipped `index.html`, `faq.html`, `disclaimers.html`, `agents.html`, `vision.html` and the chip. Re-read before starting, as the ticket asked. Only `status.html` remained, plus the guard work.

## What the record refuses to say, the page does not say

Where the launchpad factory routed that position was not read, and the page says so rather than implying custody it did not check. `creatorBuy` gains a `scope` field stating it describes the launch transaction and nothing after it.

## The record is now what checks the page

`claims-robinhood-deployment.test.mjs` binds the seven deployed contracts to `robinhood-mainnet.json` and stops there, so until this commit every RWLY figure on this site agreed with `rwly-robinhood-mainnet.json` only because one author had both files open. A new leg asserts `status.html` carries thirteen of the record's values, with the graduation flag checked **symmetrically** so copy cannot survive the event it denies.

Mutation-tested rather than asserted. Four perturbations each turn it red and the baseline is green:

| mutation | result |
|---|---|
| page's graduation block 55488695 -> 55488696 | red |
| page says "has not graduated" | red |
| record flips `graduated` to false, page unchanged | red |
| a page claims the tokens "have not moved" | red |
| baseline | 51/51 green |

## Two tightenings ported from `apps/site-next`

- **The window rule is a pure function with a probe** (`rwlyUnqualified`) rather than a loop inlined in the leg. A character window fails green two ways, by measuring the wrong distance and by an alternation wide enough to match anything, and neither shows up as a red.
- **`PURCHASE_INVITE` / `PURCHASE_VERB`.** The retired `No token. No points. No airdrop. No presale.` was doing two jobs and only one was replaced: it also made a call to action self-evidently absurd. A token that trades needs that as a rule. `buy RWLY` carries a negative lookahead on `back`, which **the probe found**: the sibling's bare regex reds `vision.html`'s designed buyback.

The `vision.html` section-chip branch is deliberately **not** rewritten into site-next's proximity walk. The ticket asked for that, but it was written before `e5d20a59`/`957ae59a` gave this file a working, documented chip solution that follows the security-review attestation shape already in it. Refactoring working code with no truth benefit is not a tightening.

`RWLY_FLOOR` re-measured 51 -> 61, set to 55.

## Two things I found and did not fix here

1. **`apps/site-next/src/sections/risks-hero/RisksHero.tsx` says "it has not graduated".** False, per the transaction above.
2. **The same file says the creator position's tokens "have not moved since".** Also false. The deployer's 72,978,672.48 RWLY moved in one transfer at block 55476142 (`0x71e2f0fa…`) to the creator-fee multisig, which has since sent 33,146,132.4 RWLY in ten transfers to a contract at `0x8366a39c…` and holds 39,832,540.18 RWLY and 1.6231 ETH. I have not read that contract's identity and make no claim about what those transfers were.

Both are `apps/site-next`, outside this ticket's stated scope, and the second needs new disclosure prose that is the owner's call rather than mine. Raised with the owner separately.

Also noted, not fixed: `apps/site-next/test/site.test.mjs` carries a stale comment saying `llms.txt` "is NOT flipped yet" because "apps/site's suite still requires the retired clause". `99a18b18` flipped it and `apps/site` now bans that clause outright.

## Verification

`npm run gate` passes (323s, one advisory Slither warning, pre-existing). `apps/site` 51/51. `apps/site-next` 46/46, run separately because `test:backend` does not enumerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
