### PR TITLE
fix(site): flatten whitespace before matching purchase invitations

### DIFF
--- a/apps/site-next/test/site.test.mjs
+++ b/apps/site-next/test/site.test.mjs
@@ -1487,7 +1487,7 @@ t('the sequencer guard is not presented as a proven mitigation', () => {
  */
 test('no built page invites the reader to buy or to acquire anything', () => {
   const INVITATIONS = [
-    /\bbuy (?:now|in\b|it|one|a |the |your |some |more|today|shares?|tokens?)/i,
+    /\bbuy (?:now|in\b|it|one|a |the |your |some\b|more|today|shares?|tokens?)/i,
     /\bhow to (?:buy|purchase|acquire|get in)/i,
     /\bwhere to (?:buy|purchase|acquire)/i,
     /\bavailable (?:to (?:buy|purchase)|for (?:purchase|sale))/i,
@@ -1509,9 +1509,19 @@ test('no built page invites the reader to buy or to acquire anything', () => {
     // Raw first, then stripped. Raw carries the attribute copy — meta descriptions, og:/twitter:
     // cards, aria-labels, alt text — which stripping deletes; stripped joins text that inline tags
     // split. A phrase in either is a phrase a reader can meet.
-    const text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ');
+    //
+    // BOTH FORMS ARE WHITESPACE-FLATTENED FIRST, and the raw one is why this line exists. The
+    // patterns above spell their gaps as a literal single space, so before flattening, an attribute
+    // holding `content="Buy  now."` or a value wrapped across two source lines slipped every one of
+    // them — the retired ban this leg replaced used `\s+` and caught those. A prettier, a formatter,
+    // or a long meta description that an editor soft-wraps all produce exactly that shape, so the
+    // gap was a matter of when rather than whether. The sibling guard added the same day,
+    // `scripts/test/claims-token-absence.test.mjs`, opens with the identical `replace(/\s+/g, ' ')`
+    // and carries a probe for a term split across a newline; this is that treatment, applied here.
+    const flat = html.replace(/\s+/g, ' ');
+    const text = flat.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ');
     for (const pattern of INVITATIONS)
-      for (const [form, body] of [['raw', html], ['text', text]])
+      for (const [form, body] of [['raw', flat], ['text', text]])
         assert.ok(
           !pattern.test(body),
           `${name}: invites a purchase in the ${form} document (${pattern}). This project sells ` +


### PR DESCRIPTION
Non-blocking finding 1 from the third verdict on #227, fixed on its own.

The purchase-invitation ban spells its gaps as a literal single space and matched the unflattened document. The ban it replaced used `\s+`, so three shapes that were red before the guard was rewritten had gone green again:

```html
<meta name="description" content="Buy  now.">
<meta name="description" content="Buy
  now.">
<a aria-label="How  to buy">
```

**No live instance.** No attribute value in either built page carries a double space or a newline today, and the only `buy`/`purchase`/`acquire` strings under `apps/site-next` are two JSDoc comments. But a formatter, or an editor soft-wrapping a long meta description, produces exactly that shape.

The sibling guard that landed in the same PR was already doing it: `scripts/test/claims-token-absence.test.mjs` opens `tokenHits()` with the identical `replace(/\s+/g, ' ')` and carries a probe for a banned term split across a newline. Same file set, same day, opposite handling — now the same.

Also: `some ` carried a trailing space in the alternation, so `Buy some.` slipped while `Buy more.` caught. Anchored to `some\b`. The retired ban missed it too, so it was not a regression.

## Evidence

Eight injections into the built Disclaimers page, all red the leg **by name**:

| injection | |
|---|---|
| `content="Buy  now."` | CAUGHT |
| `content="Buy\n  now."` | CAUGHT |
| `aria-label="How  to buy"` | CAUGHT |
| `Buy some.` | CAUGHT |
| `Buy\n  now.` in body | CAUGHT |
| `content="Buy now."` (already worked) | CAUGHT |
| `Buy the token.` (already worked) | CAUGHT |
| `Buy <em>now</em>.` (already worked) | CAUGHT |

Clean tree 45/45; `npm run gate` PASSED (316.1s, slither advisory only).