### PR TITLE
fix(site): serve a real 404 for a path that does not exist

### DIFF
--- a/apps/site-next/404.html
+++ b/apps/site-next/404.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#07070b">
+<!-- THE FILENAME IS THE FEATURE. Cloudflare Pages' asset server, on a request that matches no
+     asset, walks up from the requested path looking for a `404.html` and serves the first one it
+     finds WITH A 404 STATUS. Finding none, it falls back to serving `/index.html` with a 200 —
+     the single-page-application behaviour — which is what rwally.com did until this file existed.
+     Measured against the live site on 2026-09-09:
+
+         /nonsense.html   200   13167 bytes
+         /vision.html     200   13167 bytes   (identical bytes to /)
+         /                200   13167 bytes
+
+     So every mistyped or stale path was a 200 duplicate of the homepage: indexable as such, and
+     invisible to anyone auditing links, because a broken link that answers 200 announces itself
+     nowhere. The redirect table was never the defect — `/vision` and `/faq` 301 correctly and
+     `/disclaimers.html` 308s to `/disclaimers` — the fallback for paths the table does not name
+     was. RENAMING OR REMOVING THIS FILE PUTS THAT BACK, silently and with no build error.
+
+     ONE MECHANISM, NOT TWO. There is deliberately no `/*  /404.html  404` catch-all in
+     `public/_redirects` beside it: a catch-all source there would sit in front of `/assets/*` and
+     `/media/*`, and it cannot be tested anywhere in this repository. -->
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<!-- NO `rel="canonical"` AND NO `og:url`, WHICH IS THE OTHER HALF OF THE FIX. This one document is
+     served at every address that does not exist, so there is no URL it could name that would be
+     true of the request that produced it. A canonical copied from index.html would declare each of
+     those addresses a duplicate of the homepage — the exact signal the 404 status is here to
+     withdraw. `robots: noindex` says the same thing to a crawler that reads meta but not status,
+     and this page is absent from `sitemap.xml` for the same reason it is absent from `PAGE_IDS`. -->
+<meta name="robots" content="noindex">
+<!-- The display face, preloaded. It sets the h1, the largest paint on the page, and the browser
+     would otherwise not learn it is needed until the stylesheet has arrived and been matched, one
+     round trip later. The href is a path into node_modules, rewritten by the build: Vite resolves
+     it through the same asset pipeline that rewrites the url() in fonts.css, emits ONE hashed copy
+     shared with the other two documents, and writes the /assets/ path here, so the preload cannot
+     go stale against the file the CSS actually loads. Do not hand-edit the hash. -->
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff2">
+<title>Page not found | RWAlly</title>
+<meta name="description" content="The address you asked for is not a document on this site.">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="RWAlly">
+<meta property="og:title" content="Page not found">
+<meta property="og:description" content="The address you asked for is not a document on this site.">
+<meta property="og:image" content="https://rwally.com/og-card.png">
+<meta property="og:image:alt" content="A dark card carrying the RWAlly comic wordmark, cream lettering over a violet drop shadow, above the deployment-status line Deployed on Robinhood Chain.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Page not found">
+<meta name="twitter:description" content="The address you asked for is not a document on this site.">
+<meta name="twitter:image" content="https://rwally.com/og-card.png">
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/entry-404.tsx"></script>
+</body>
+</html>

--- a/apps/site-next/README.md
+++ b/apps/site-next/README.md
@@ -47,7 +47,9 @@ Three rules follow from that, and each fails silently rather than loudly:
 ```
 index.html … status.html   eight entry HTMLs: head metadata, one #root div, one module script
 src/entry-<page>.tsx       eight thin client entries
-src/entry-server.tsx       render(pageId) — the interface the prerender calls
+404.html                   the not-found document; its ABSENCE is a soft-404, see below
+src/entry-404.tsx          its client entry — a plain import, not the page-body glob
+src/entry-server.tsx       render(pageId), and renderNotFound() for the document that is not one
 src/main.tsx               shared bootstrap; hydrates, imports the three stylesheets
 src/tokens.css             the palette, type scale, rhythm and motion curves
 src/fonts.css              three hand-written @font-face rules
@@ -75,6 +77,52 @@ the output. The middleware is not cosmetic: it 301s the `*.rwally.pages.dev` hos
 rwally.com, and the sanctions geofence is a WAF rule on the rwally.com zone that the pages.dev
 hostnames are not in. Losing it in the move reopens an unfiltered path to the same content.
 
+## A path that does not exist gets a 404, and that takes a file
+
+`dist/404.html` is the whole mechanism. Cloudflare Pages' asset server, on a request matching no
+asset, walks up from the requested path looking for a `404.html` and serves the first one it finds
+with a **404** status. Finding none, it falls back to serving `/index.html` with a **200** — the
+single-page-application behaviour — which is what rwally.com did until 2026-09-09:
+
+```
+/nonsense.html     200   13167 bytes
+/vision.html       200   13167 bytes   (identical bytes to /)
+/                  200   13167 bytes
+/disclaimers.html  308   -> /disclaimers   (correct)
+/vision            301   -> /              (correct)
+```
+
+The rule table in `public/_redirects` was never the defect — the last two lines are its work. The
+fallback for paths the table does not name was, and a soft-404 is expensive twice over: every
+mistyped or stale path is indexable as a duplicate of the homepage, and a broken internal link
+answers 200, so it appears in no log and no crawl.
+
+**Three things about that file are load-bearing, and none of them fails the build if undone.**
+`apps/site-next/test/edge.test.mjs` is what fails instead.
+
+1. **It is built, so it carries the chrome.** `vite.config.ts` names it as a third entry and
+   `scripts/prerender.mjs` splices the rendered markup in, the same as the two pages. A hand-written
+   file in `public/` could not link the content-hashed stylesheet, and `style-src 'self'` with no
+   `unsafe-inline` leaves it no other way to be styled.
+2. **Its in-site links are root-absolute.** Pages renders this document **at the path that was asked
+   for** rather than redirecting, so `/a/b/c` renders it and a relative `index.html` would resolve to
+   `/a/b/index.html` — a second 404, under a lost reader. `siteHref` in `src/shell/pinned.ts` is what
+   rewrites them, and it is the identity function on the two real pages, which must keep emitting the
+   byte-exact `href="index.html"` that `site.test.mjs` matches.
+3. **It is `noindex` and names no canonical.** It is served at every address that does not exist, so
+   there is no URL it could claim that is true of the request that produced it.
+
+It is deliberately **not** a `PageId`: it is in no nav, no sitemap and none of the per-page guards,
+because it is a document the site is never navigated to. `NOT_FOUND_ID` in `src/shell/pinned.ts`
+carries the long version. And there is deliberately **no** `/*  /404.html  404` catch-all in
+`_redirects` beside it — one mechanism, not two: a catch-all source there sits in front of
+`/assets/*` and `/media/*`, and nothing in this repository can test that it does not bite.
+
+**What none of this proves.** There is no wrangler here, so the live edge is not exercised by any
+test in this repository; the checks pin the preconditions the fix depends on, not the response. If
+the Pages project has `not_found_handling` set to single-page-application in the dashboard, that
+setting overrides the file and the soft-404 survives the deploy. Check it at publish time.
+
 ## Every request is same-origin
 
 The Content-Security-Policy in `public/_headers` is `default-src 'none'` with exactly two relaxations
@@ -101,10 +149,12 @@ The network panel must show zero non-self hosts. One request to a font host is a
   copy of each lives inside an answer body. The shell renders one of each, so a shell-only
   `faq.html` reads one and one. That second pair is the FAQ section's obligation, not the footer's.
 - The middleware test. `functions/_middleware.js` is here and is byte-identical to
-  `apps/site/functions/_middleware.js`, but nothing in this directory tests it: `test/` holds
-  `site.test.mjs` and nothing else, and `apps/site/test/middleware.test.mjs` still reads the copy
-  under `apps/site`. It is owed in the change that stops serving `apps/site` — a middleware left
-  behind under test at its old path is a middleware nobody is testing at the path that is served.
+  `apps/site/functions/_middleware.js`, but nothing in this directory tests it, and
+  `apps/site/test/middleware.test.mjs` still reads the copy under `apps/site`. `test/` now holds
+  `site.test.mjs` and `edge.test.mjs`, and the middleware belongs with the second of those: it is
+  edge behaviour, and that is the file for edge behaviour. It is owed in the change that stops
+  serving `apps/site` — a middleware left behind under test at its old path is a middleware nobody
+  is testing at the path that is served.
 
 ## What has landed
 

--- a/apps/site-next/package.json
+++ b/apps/site-next/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build && vite build --ssr && node scripts/prerender.mjs",
     "lint": "oxlint",
     "preview": "vite preview",
-    "test": "node --test --test-reporter=tap test/site.test.mjs"
+    "test": "node --test --test-reporter=tap test/*.test.mjs"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",

--- a/apps/site-next/scripts/prerender.mjs
+++ b/apps/site-next/scripts/prerender.mjs
@@ -1,7 +1,12 @@
 // @ts-check
 /**
- * Prerender: render the eight pages with React and write the markup into the
- * eight built HTML files.
+ * Prerender: render the site's documents with React and write the markup into
+ * the built HTML files.
+ *
+ * THREE FILES, TWO OF THEM PAGES. `pages` is the two `PageId`s, and `404.html`
+ * is written after the loop through `renderNotFound()`: it is a document the
+ * site is never navigated to, so it is in no nav, no sitemap and none of the
+ * per-page guards. See `NOT_FOUND_ID` in `src/shell/pinned.ts`.
  *
  * WHY THIS STEP EXISTS. Everything that checks this site reads the built HTML
  * as text. `apps/site/test/site.test.mjs` asserts banner strings, footer
@@ -11,8 +16,8 @@
  * React app ships `<div id="root"></div>` and fails all of it. So the markup has to be in the
  * file, and the browser's job is to hydrate what is already there.
  *
- * WHAT IT DOES. Imports the SSR bundle once, calls `render(page)` for each of
- * the eight, and replaces the empty `<div id="root"></div>` in the matching
+ * WHAT IT DOES. Imports the SSR bundle once, calls `render(page)` for each
+ * page and `renderNotFound()` once, and replaces the empty `<div id="root"></div>` in the matching
  * `dist/<page>.html` with the same div carrying the rendered markup. Nothing
  * else about the file is touched: the head — title, description, canonical and
  * social preview — was written by hand into the entry HTML and is copied
@@ -35,6 +40,11 @@ const SSR_ENTRY = path.join(APP, 'dist-ssr', 'entry-server.js');
 
 const ROOT_DIV = '<div id="root"></div>';
 
+/** The not-found document. Kept as a literal rather than imported from the SSR
+ *  bundle's `NOT_FOUND_ID`, so the two names disagreeing is a build failure at
+ *  `splice`'s first check rather than a page written to the wrong filename. */
+const NOT_FOUND_PAGE = '404.html';
+
 if (!existsSync(SSR_ENTRY)) {
   console.error(
     `prerender: no SSR bundle at ${SSR_ENTRY}\n` +
@@ -43,12 +53,24 @@ if (!existsSync(SSR_ENTRY)) {
   process.exit(1);
 }
 
-const { render, pages, landedPages } = await import(pathToFileURL(SSR_ENTRY).href);
+const { render, renderNotFound, pages, landedPages } = await import(pathToFileURL(SSR_ENTRY).href);
 
-const landed = new Set(landedPages());
-let wrote = 0;
-
-for (const page of pages) {
+/**
+ * Splice one page's markup into its built HTML, with the three checks that make
+ * a partial prerender an error rather than a silent shrug.
+ *
+ * EXTRACTED SO `404.html` GETS THE SAME THREE. It is written outside the `pages`
+ * loop below, because it is not a `PageId` — see `NOT_FOUND_ID` in
+ * `src/shell/pinned.ts` — and the first draft of that write was a bare
+ * `writeFileSync` with no checks at all. A 404 page that shipped as an empty
+ * root div would still return the 404 status Pages exists to give it, so
+ * nothing downstream would go red: the reader would just be told nothing.
+ *
+ * @param {string} page  file name in dist/
+ * @param {string} markup  the rendered inner HTML
+ * @returns {number} the markup's length in bytes, for the log line
+ */
+const splice = (page, markup) => {
   const file = path.join(DIST, page);
   if (!existsSync(file)) {
     console.error(`prerender: ${page} is missing from dist/ — check rollupOptions.input`);
@@ -64,19 +86,27 @@ for (const page of pages) {
     process.exit(1);
   }
 
-  const markup = render(page);
   if (!markup || markup.length === 0) {
     console.error(`prerender: ${page} rendered nothing`);
     process.exit(1);
   }
 
   writeFileSync(file, html.replace(ROOT_DIV, `<div id="root">${markup}</div>`), 'utf8');
+  return markup.length;
+};
+
+const landed = new Set(landedPages());
+let wrote = 0;
+
+for (const page of pages) {
+  const markup = render(page);
+  const bytes = splice(page, markup);
   wrote += 1;
 
   const h1s = markup.split('<h1').length - 1;
   const body = landed.has(page) ? 'page body' : 'SHELL ONLY — no page body yet';
   console.log(
-    `prerender: ${page.padEnd(18)} ${String(markup.length).padStart(7)} B  ` + `h1:${h1s}  ${body}`,
+    `prerender: ${page.padEnd(18)} ${String(bytes).padStart(7)} B  ` + `h1:${h1s}  ${body}`,
   );
 }
 
@@ -84,6 +114,28 @@ if (wrote !== pages.length) {
   console.error(`prerender: wrote ${wrote} of ${pages.length} pages`);
   process.exit(1);
 }
+
+/**
+ * `404.html`, WHICH IS WRITTEN HERE AND NOT COUNTED ABOVE.
+ *
+ * It is not a `PageId`, so it is not in `pages`, so `landedPages()` says
+ * nothing about it and the `wrote !== pages.length` check above must not see
+ * it. It still goes through `splice`, so a missing file, a missing root div or
+ * an empty render fails the build exactly as they do for the other two.
+ *
+ * WHY THE FILE HAS TO EXIST AT ALL: without a top-level `404.html` the
+ * Cloudflare Pages asset server falls back to serving `/index.html` with a 200
+ * for every path that matches no asset, which is the soft-404 measured on the
+ * live site on 2026-09-09. The long version is in `src/shell/pinned.ts` under
+ * `NOT_FOUND_ID`, and the entry HTML repeats it where a reader deleting the
+ * file would see it.
+ */
+const notFoundMarkup = renderNotFound();
+const notFoundBytes = splice(NOT_FOUND_PAGE, notFoundMarkup);
+console.log(
+  `prerender: ${NOT_FOUND_PAGE.padEnd(18)} ${String(notFoundBytes).padStart(7)} B  ` +
+    `h1:${notFoundMarkup.split('<h1').length - 1}  not-found document (not a PageId)`,
+);
 
 const missing = pages.filter((/** @type {string} */ p) => !landed.has(p));
 if (missing.length > 0) {

--- a/apps/site-next/src/entry-404.tsx
+++ b/apps/site-next/src/entry-404.tsx
@@ -1,0 +1,15 @@
+/**
+ * Client entry for `404.html`.
+ *
+ * A PLAIN IMPORT, NOT THE GLOB the other two entries use. That glob is the seam
+ * `src/shell/pageBody.ts` describes: Integrate owns the page bodies, Shell owns
+ * the entries, and the build has to succeed in the window where a page file
+ * does not exist yet. That window never applies here — the body landed in the
+ * same commit as this entry, and `404.html` is not a page Integrate is asked to
+ * fill — so the import says what it means and the type checker sees it.
+ */
+import { hydrate } from './main';
+import NotFoundPage from './pages/NotFoundPage';
+import { NOT_FOUND_ID } from './shell/pinned';
+
+hydrate(NOT_FOUND_ID, NotFoundPage);

--- a/apps/site-next/src/entry-server.tsx
+++ b/apps/site-next/src/entry-server.tsx
@@ -9,8 +9,9 @@
 import { StrictMode } from 'react';
 import { renderToString } from 'react-dom/server';
 import { App } from './shell/App';
+import NotFoundPage from './pages/NotFoundPage';
 import { PAGE_COMPONENT, pickPage } from './shell/pageBody';
-import { PAGE_IDS, type PageId } from './shell/pinned';
+import { NOT_FOUND_ID, PAGE_IDS, type PageId } from './shell/pinned';
 
 // Every page in one eager glob. Allowed here and nowhere else: the SSR
 // bundle is never sent to a reader, so there is no budget to blow. The client
@@ -26,6 +27,29 @@ export function render(page: PageId): string {
   return renderToString(
     <StrictMode>
       <App page={page} Body={Body} />
+    </StrictMode>,
+  );
+}
+
+/**
+ * Markup for `404.html`, which is NOT one of `pages` and must not become one.
+ *
+ * It is rendered through its own function rather than through the loop above
+ * because it is not a `PageId`: it is in no nav, in no sitemap, and in none of
+ * the per-page guards that iterate the two public documents. `NOT_FOUND_ID` in
+ * `src/shell/pinned.ts` carries the full reason, including what `site.test.mjs`
+ * would demand of the two real pages if this id joined `PAGE_IDS`.
+ *
+ * It also takes its body by plain import rather than through `pickPage`. The
+ * glob machinery exists so the build survives a page file that has not been
+ * written yet; this one was written in the same commit, so there is nothing to
+ * survive, and a body that silently resolved to `null` here would ship an empty
+ * 404 page with a masthead and a footer around it.
+ */
+export function renderNotFound(): string {
+  return renderToString(
+    <StrictMode>
+      <App page={NOT_FOUND_ID} Body={NotFoundPage} />
     </StrictMode>,
   );
 }

--- a/apps/site-next/src/live/LivePriceChip.tsx
+++ b/apps/site-next/src/live/LivePriceChip.tsx
@@ -25,12 +25,15 @@
 import type { JSX } from 'react';
 import { usd } from './chain';
 import { age, useLive } from './useLive';
-import type { PageId } from '../shell/pinned';
+import { siteHref, type ShellPage } from '../shell/pinned';
 import styles from './live-chip.module.css';
 
-export function LivePriceChip({ page }: { page: PageId }): JSX.Element {
+export function LivePriceChip({ page }: { page: ShellPage }): JSX.Element {
   const live = useLive();
-  const href = page === 'index.html' ? '#live' : 'index.html#live';
+  // On the homepage the live reads are a section of this same document, so the
+  // chip is an in-page anchor. Anywhere else it is a navigation, and `siteHref`
+  // makes it root-absolute on the 404 page, which Pages serves at any depth.
+  const href = page === 'index.html' ? '#live' : siteHref(page, 'index.html#live');
 
   if (live.status !== 'ok') {
     // The reserved slot. `aria-hidden` because there is nothing here to

--- a/apps/site-next/src/main.tsx
+++ b/apps/site-next/src/main.tsx
@@ -19,13 +19,13 @@
 import { StrictMode, type ComponentType } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { App } from './shell/App';
-import type { PageId } from './shell/pinned';
+import type { ShellPage } from './shell/pinned';
 
 import './tokens.css';
 import './fonts.css';
 import './index.css';
 
-export function hydrate(page: PageId, Body: ComponentType | null): void {
+export function hydrate(page: ShellPage, Body: ComponentType | null): void {
   const container = document.getElementById('root');
   if (!container) {
     // Nothing to attach to means the entry HTML was edited out from under the

--- a/apps/site-next/src/pages/NotFoundPage.tsx
+++ b/apps/site-next/src/pages/NotFoundPage.tsx
@@ -1,0 +1,20 @@
+/**
+ * `404.html`: one section, and the shell around it.
+ *
+ * NOT ONE OF THE `PageId` PAGES, and `src/pages/README.md`'s table does not
+ * list it, deliberately. That table maps each id in `PAGE_IDS` to the file
+ * `src/shell/pageBody.ts` resolves for it; this document is not in `PAGE_IDS`
+ * and is not resolved through `PAGE_COMPONENT`, because it is a document the
+ * site is never navigated TO — see `NOT_FOUND_ID` in `src/shell/pinned.ts`.
+ * `src/entry-404.tsx` imports it directly, and `src/entry-server.tsx` renders
+ * it through `renderNotFound()` rather than through the `pages` loop.
+ *
+ * COMPOSITION ONLY, the same as every other file here. The masthead,
+ * `<main id="main">` and the footer come from PageShell; the page's single
+ * `<h1>` comes from its one section.
+ */
+import NotFound from '../sections/not-found/NotFound';
+
+export default function NotFoundPage() {
+  return <NotFound />;
+}

--- a/apps/site-next/src/sections/not-found/NotFound.module.css
+++ b/apps/site-next/src/sections/not-found/NotFound.module.css
@@ -1,0 +1,80 @@
+/* ===========================================================================
+   not-found — the body of 404.html
+   ---------------------------------------------------------------------------
+   THE SAME RESTRAINT AS THE DEEP-PAGE HERO, for the same reason and one more.
+   No canvas, no pin, no parallax: the build brief puts the one WebGL field on
+   index.html, and this document is rendered when a reader has already failed to
+   reach what they wanted. The extra reason is that Pages serves this file at
+   WHATEVER PATH WAS ASKED FOR, including a path under /assets/ — so it is the
+   one document on the site that can be rendered by a request that never wanted
+   a page at all, and it should cost as little as it can.
+
+   EVERY COLOUR IS var(--token) FROM tokens.css. No hex literal reaches this
+   file and no token is defined here, which is the rule every other stylesheet
+   in this build follows.
+
+   THE ACTIONS USE THE GLOBAL .door AND .quiet, not classes of their own. They
+   are the same two link treatments the homepage hero uses; a fourth button
+   style invented for the page nobody plans to visit is a style nobody
+   maintains.
+   =========================================================================== */
+
+.notFound {
+  /* The one section on the page, so it carries the whole vertical rhythm: the
+     hero's opening measure above, and enough below that the footer band does
+     not ride up under the actions on a tall viewport. Both values are from the
+     --s scale tokens.css calls "one scale, used for every margin, gap and
+     pad". */
+  padding-block: var(--s8) var(--s9);
+  background: linear-gradient(180deg, var(--surface) 0%, var(--ground) 100%);
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 var(--s3);
+  max-width: none;
+  font-family: var(--mono);
+  font-size: var(--step-eyebrow);
+  line-height: 1.4;
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--muted); /* ratio recorded in src/tokens.css */
+}
+
+.title {
+  /* One step under the display maximum, matching the deep-page hero: this
+     document announces a fact and gets out of the way. The scale is still
+     --step-display, so a change to the token still lands here.
+
+     In em rather than ch, for the reason RisksHero.module.css records at
+     length: `ch` resolves against the used font's advance for "0", which the
+     metric-adjusted fallback does not equalise, and the mismatch was a measured
+     layout shift on the deep-page headline. */
+  font-size: min(var(--step-display), 4rem);
+  max-width: 11.33em;
+  margin: 0 0 var(--s5);
+  color: var(--ink); /* ratio recorded in src/tokens.css */
+}
+
+.lede {
+  max-width: 62ch;
+  margin: 0 0 var(--s6);
+  font-size: clamp(1.0625rem, 1rem + 0.45vw, 1.3125rem);
+  line-height: 1.5;
+  color: var(--muted); /* ratio recorded in src/tokens.css */
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s5);
+}
+
+@media (max-width: 40rem) {
+  .title {
+    /* A twenty-character cap on a phone leaves the headline in a narrow ribbon
+       down the left of a full-width column. Let it use the measure it has. */
+    max-width: none;
+  }
+}

--- a/apps/site-next/src/sections/not-found/NotFound.tsx
+++ b/apps/site-next/src/sections/not-found/NotFound.tsx
@@ -1,0 +1,92 @@
+/**
+ * not-found — the body of `404.html`, the document Cloudflare Pages serves with
+ * a 404 status for a path that matches no asset and no `_redirects` rule.
+ *
+ * WHY THE FILE EXISTS AT ALL is written where the id is declared, in
+ * `src/shell/pinned.ts` under `NOT_FOUND_ID`: without a top-level `404.html`
+ * the Pages asset server falls back to serving `/index.html` with a 200, so
+ * every mistyped or stale path was a 200 duplicate of the homepage. Read that
+ * note before changing anything here.
+ *
+ * TWO CONSTRAINTS THIS COPY IS WRITTEN UNDER, and neither is a style
+ * preference:
+ *
+ *   IT MUST NOT GUESS. This component is rendered for `/nonsense.html` and for
+ *   `/assets/typo.js` alike, and it has no way to know which. So it states what
+ *   is true of every one of them — the address is not a document of this site —
+ *   and never speculates about what the reader meant.
+ *
+ *   IT IS WALKED BY THE CLAIMS SUITE. `scripts/test/claims-lede-truth.test.mjs`
+ *   deliberately does not skip `dist`, and `claims-token-absence.test.mjs`
+ *   reads every `.html` under `apps/site-next/dist`. So the sentences below are
+ *   public surface with the same standing as the homepage's, and a sentence
+ *   about the protocol written here has to be as true as one written there.
+ *   The safest copy for this page is copy that describes only this page, which
+ *   is what it does.
+ *
+ * THE TWO ACTIONS ARE ROOT-ABSOLUTE, and that is not decoration. Pages renders
+ * this document at whatever path was asked for rather than redirecting, so a
+ * relative `index.html` here resolves against the failed path's directory and
+ * lands on a second 404. `siteHref` is what makes them absolute, and the
+ * chrome's own links go through it for the same reason.
+ */
+import type { JSX } from 'react';
+import { Reveal } from '../../motion/Reveal';
+import { RISE_HERO_PX, STAGGER } from '../../motion/easings';
+import { DISCLAIMERS_PAGE_LABEL, NOT_FOUND_ID, siteHref } from '../../shell/pinned';
+import s from './NotFound.module.css';
+
+const EYEBROW = '404';
+
+const TITLE = 'This page is not here.';
+
+const LEDE =
+  'The address you asked for is not a document on this site. It was either retired, or the link that sent you here is wrong. This site has two documents, and both are one click away.';
+
+/**
+ * The primary action. Written as an instruction rather than as a noun, which is
+ * the rule the rest of this site's button labels follow — `APP_NAV.label` is
+ * "Open the app" for the same reason. It names the same document the footer
+ * lists as "Overview"; the two are worded differently on purpose, because one
+ * is a nav entry and this is a button.
+ */
+const HOME_LABEL = 'Go to the overview';
+
+/**
+ * Seconds. The same enter the deep-page hero uses. It sits inside the 0.24-0.8
+ * band easings.ts describes but is not one of its four named durations, so it
+ * is written here rather than mis-mapped onto DUR.mid or DUR.slow.
+ */
+const ENTER_SECONDS = 0.6;
+
+export default function NotFound(): JSX.Element {
+  return (
+    <section className={s.notFound}>
+      <div className="wrap">
+        {/*
+          THE RESTING STATE IS WHAT RENDERS. <Reveal> prerenders its children at
+          their final position and full opacity and only then, in a layout
+          effect, pushes them back to animate forward — so every sentence here
+          is in dist/404.html whether or not anything scrolls, and a reader with
+          reduced motion, or with the module script blocked, gets the finished
+          page rather than an empty one. On a document that exists to tell
+          somebody their link is broken, that is the only acceptable failure
+          mode.
+        */}
+        <Reveal stagger={STAGGER.normal} duration={ENTER_SECONDS} rise={RISE_HERO_PX}>
+          <p className={s.eyebrow}>{EYEBROW}</p>
+          <h1 className={s.title}>{TITLE}</h1>
+          <p className={s.lede}>{LEDE}</p>
+          <div className={s.actions}>
+            <a className="door" href={siteHref(NOT_FOUND_ID, 'index.html')}>
+              {HOME_LABEL}
+            </a>
+            <a className="quiet" href={siteHref(NOT_FOUND_ID, 'disclaimers.html')}>
+              {DISCLAIMERS_PAGE_LABEL}
+            </a>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/apps/site-next/src/shell/App.tsx
+++ b/apps/site-next/src/shell/App.tsx
@@ -15,9 +15,9 @@
 import type { ComponentType, JSX } from 'react';
 import { LenisProvider } from '../motion/LenisProvider';
 import { PageShell } from './PageShell';
-import type { PageId } from './pinned';
+import type { ShellPage } from './pinned';
 
-export function App({ page, Body }: { page: PageId; Body: ComponentType | null }): JSX.Element {
+export function App({ page, Body }: { page: ShellPage; Body: ComponentType | null }): JSX.Element {
   return (
     <LenisProvider>
       <PageShell page={page}>{Body ? <Body /> : null}</PageShell>

--- a/apps/site-next/src/shell/Footer.tsx
+++ b/apps/site-next/src/shell/Footer.tsx
@@ -48,14 +48,15 @@ import {
   FOOTER_LICENCE,
   FOOTER_PAGES,
   REPO_URL,
+  siteHref,
   TAGLINE,
   X_URL,
-  type PageId,
+  type ShellPage,
 } from './pinned';
 import { Pinned } from './PinnedText';
 import styles from './footer.module.css';
 
-export function Footer({ page }: { page: PageId }): JSX.Element {
+export function Footer({ page }: { page: ShellPage }): JSX.Element {
   const art = STILLS.mascot;
   const band = useRef<HTMLDivElement>(null);
   const picture = useRef<HTMLImageElement>(null);
@@ -81,7 +82,7 @@ export function Footer({ page }: { page: PageId }): JSX.Element {
       </div>
 
       <div className={styles.inner}>
-        <a className={styles.brand} href="index.html" aria-label={BRAND_NAME}>
+        <a className={styles.brand} href={siteHref(page, 'index.html')} aria-label={BRAND_NAME}>
           <Mark className={styles.mark} />
           <span className={styles.lockup}>
             <span className={styles.name} aria-hidden="true">
@@ -107,7 +108,7 @@ export function Footer({ page }: { page: PageId }): JSX.Element {
             <a
               className={styles.link}
               key={item.id}
-              href={item.id}
+              href={siteHref(page, item.id)}
               aria-current={item.id === page ? 'page' : undefined}
             >
               {item.label}

--- a/apps/site-next/src/shell/Masthead.tsx
+++ b/apps/site-next/src/shell/Masthead.tsx
@@ -55,7 +55,15 @@
 import type { JSX } from 'react';
 import { Mark } from '../brand/Mark';
 import { LivePriceChip } from '../live/LivePriceChip';
-import { APP_NAV, BRAND_NAME, HEADER_NAV, TAGLINE, X_URL, type PageId } from './pinned';
+import {
+  APP_NAV,
+  BRAND_NAME,
+  HEADER_NAV,
+  siteHref,
+  TAGLINE,
+  X_URL,
+  type ShellPage,
+} from './pinned';
 import styles from './masthead.module.css';
 
 /** The X glyph. One path, drawn at the viewBox X publishes for it. */
@@ -85,14 +93,14 @@ function DoorArrow(): JSX.Element {
   );
 }
 
-export function Masthead({ page }: { page: PageId }): JSX.Element {
+export function Masthead({ page }: { page: ShellPage }): JSX.Element {
   return (
     <header className={styles.masthead}>
       <div className={styles.pill}>
         <div className={styles.left}>
           <a
             className={styles.brand}
-            href="index.html"
+            href={siteHref(page, 'index.html')}
             aria-label={BRAND_NAME}
             aria-current={page === 'index.html' ? 'page' : undefined}
           >
@@ -117,7 +125,7 @@ export function Masthead({ page }: { page: PageId }): JSX.Element {
             <a
               key={item.label}
               className={styles.navLink}
-              href={item.href}
+              href={siteHref(page, item.href)}
               rel={item.external ? 'noopener' : undefined}
               aria-current={item.page === page ? 'page' : undefined}
             >

--- a/apps/site-next/src/shell/PageShell.tsx
+++ b/apps/site-next/src/shell/PageShell.tsx
@@ -25,12 +25,12 @@
  * one.
  */
 import type { JSX, ReactNode } from 'react';
-import type { PageId } from './pinned';
+import type { ShellPage } from './pinned';
 import { Footer } from './Footer';
 import { Masthead } from './Masthead';
 import { SkipLink } from './SkipLink';
 
-export function PageShell({ page, children }: { page: PageId; children?: ReactNode }): JSX.Element {
+export function PageShell({ page, children }: { page: ShellPage; children?: ReactNode }): JSX.Element {
   return (
     <>
       <SkipLink />

--- a/apps/site-next/src/shell/pinned.ts
+++ b/apps/site-next/src/shell/pinned.ts
@@ -310,6 +310,76 @@ export const PAGE_IDS = ['index.html', 'disclaimers.html'] as const;
 export type PageId = (typeof PAGE_IDS)[number];
 
 /**
+ * THE 404 DOCUMENT, WHICH IS DELIBERATELY NOT A `PageId`.
+ *
+ * `dist/404.html` is the file Cloudflare Pages serves, with a 404 status, for a
+ * path that matches no asset and no `_redirects` rule. Its absence is not a
+ * missing nicety: the Pages asset server walks up from the requested path
+ * looking for a `404.html`, and when it finds none it falls back to serving
+ * `/index.html` WITH A 200. Measured against the live site on 2026-09-09,
+ * before this file existed:
+ *
+ *     /nonsense.html   200   13167 bytes
+ *     /               200   13167 bytes   (identical bytes)
+ *
+ * So every mistyped or stale path was a 200 duplicate of the homepage, and a
+ * broken internal link announced itself nowhere. The fix is the file, and the
+ * file has to be built, so `vite.config.ts` names it as an entry and
+ * `scripts/prerender.mjs` splices its markup in.
+ *
+ * WHY IT IS NOT A `PageId`, WHICH IS THE PART TO NOT UNDO. A `PageId` is a
+ * document the site NAVIGATES TO, and `site.test.mjs` enforces exactly that:
+ * "every page links to every other page" asserts `href="<other>"` on every one
+ * of them. Adding this id to the list would put a link to the 404 page in the
+ * nav of both real pages, which is the opposite of what a 404 page is for. It
+ * is also absent from `NAV`, `FOOTER_PAGES`, `HEADER_NAV` and `sitemap.xml`,
+ * and its entry HTML carries `robots: noindex` and NO canonical, for the same
+ * reason: a page nobody should link to is a page nobody should index either.
+ */
+export const NOT_FOUND_ID = '404.html';
+
+/**
+ * Every document `PageShell` can render: the two public pages plus the 404.
+ * The shell is typed on this; everything that builds a nav or a sitemap stays
+ * typed on `PageId`.
+ */
+export type ShellPage = PageId | typeof NOT_FOUND_ID;
+
+/**
+ * Rewrite an in-site href for the document it is being rendered into.
+ *
+ * ON THE TWO REAL PAGES THIS IS THE IDENTITY FUNCTION, and it has to be. Both
+ * are served at depth one, so the relative `index.html` the masthead and footer
+ * write resolves correctly from either, and `site.test.mjs` matches the
+ * attribute BYTE FOR BYTE: `html.includes('href="index.html"')`. A prefix added
+ * here unconditionally reds that guard.
+ *
+ * ON THE 404 PAGE IT IS NOT, and that is the whole reason this exists. Pages
+ * serves `404.html` at WHATEVER PATH WAS ASKED FOR — `/a/b/c` renders it
+ * without redirecting — so a relative `index.html` resolves against `/a/b/`
+ * and lands on another 404. The chrome would be broken exactly where a lost
+ * reader needs it. Every in-site href on that document is therefore made
+ * root-absolute, and a bare fragment (`#how`, a section of the homepage) is
+ * repointed at the homepage rather than at a section this document does not
+ * have.
+ *
+ * `#main` IS THE ONE FRAGMENT THIS MUST NOT TOUCH: the skip link targets the
+ * 404 page's own `<main>`. `SkipLink` writes it directly and never calls this,
+ * which is why this function is applied at the call sites in `Masthead`,
+ * `Footer` and `LivePriceChip` rather than swept over the rendered markup.
+ */
+export const siteHref = (page: ShellPage, href: string): string => {
+  if (page !== NOT_FOUND_ID) return href;
+  // Off-site (`https://app.rwally.com`) or already root-absolute: leave it alone.
+  if (href.startsWith('/') || href.includes('://')) return href;
+  // A relative page path (`index.html`) or a homepage fragment (`#how`). Both
+  // become root-absolute: `/#how` reaches the homepage's section, and
+  // `/index.html` reaches the homepage through the 308 Pages already serves for
+  // it — the same hop the two real pages' own relative links take.
+  return `/${href}`;
+};
+
+/**
  * THE HEADER NAV IS EMPTY, AND THE HEADER'S OWN NAV IS `HEADER_NAV` BELOW.
  *
  * `NAV` is the list of PAGE ids the footer composes `FOOTER_PAGES` from, and it

--- a/apps/site-next/test/edge.test.mjs
+++ b/apps/site-next/test/edge.test.mjs
@@ -1,0 +1,306 @@
+// @ts-check
+/**
+ * EDGE BEHAVIOUR: what Cloudflare Pages does with a path, as opposed to what a
+ * page says. Two artefacts decide it, and neither is JavaScript this suite can
+ * call:
+ *
+ *   `dist/404.html`        the file Pages serves, with a 404 status, for a path
+ *                          matching no asset and no redirect rule
+ *   `public/_redirects`    the static rule table, copied to `dist/_redirects`
+ *
+ * WHY A SECOND FILE RATHER THAN MORE OF `site.test.mjs`. That suite iterates
+ * `PAGES`, the two documents the site is navigated to, and nearly every guard in
+ * it is written as `for (const p of PAGES)`. Neither artefact here is one of
+ * those pages: the 404 document is deliberately outside `PAGE_IDS` (see
+ * `NOT_FOUND_ID` in `src/shell/pinned.ts`), and `_redirects` is not a page at
+ * all. Adding them to `PAGES` would put a link to the 404 document in both real
+ * pages' navs, because that suite asserts every page links to every other.
+ *
+ * =========================================================================
+ * THE DEFECT THIS FILE EXISTS FOR, measured against the live site 2026-09-09
+ * =========================================================================
+ *
+ *     /nonsense.html     200   13167 bytes
+ *     /vision.html       200   13167 bytes   (identical bytes to /)
+ *     /                  200   13167 bytes
+ *     /disclaimers.html  308   -> /disclaimers   (correct)
+ *     /vision            301   -> /              (correct)
+ *     /faq               301   -> /              (correct)
+ *
+ * `curl -s https://rwally.com/nonsense.html | grep -o "<title>[^<]*</title>"`
+ * returned the HOMEPAGE title. The redirect table was never the defect — the
+ * three correct lines above are its work. The defect was the fallback for paths
+ * the table does not name: the Pages asset server walks up from the requested
+ * path looking for a `404.html`, and finding none serves `/index.html` with a
+ * 200. So every mistyped or stale path was an indexable duplicate of the
+ * homepage, and a broken internal link announced itself in no log and no crawl.
+ *
+ * =========================================================================
+ * WHAT THESE TESTS DO NOT DO, AND WHY THAT IS A DECISION
+ * =========================================================================
+ *
+ * THEY DO NOT SIMULATE PAGES. Writing a resolver here that walks `dist` and
+ * `_redirects` and returns `{status, location}` would let this file assert
+ * "/nonsense.html -> 404" in one line, and the line would be worthless: it
+ * would test a model of Cloudflare written in this repository, pass whether or
+ * not the real edge agrees, and go on passing after a Pages behaviour change is
+ * exactly what broke the site. There is no wrangler in this repository and
+ * publishing is the owner's call, so the real thing cannot be exercised here at
+ * all.
+ *
+ * SO THEY PIN THE PRECONDITIONS INSTEAD — the things that are true in this
+ * repository, that the fix depends on, and that a later change could quietly
+ * remove:
+ *
+ *   1. `dist/404.html` exists at the TOP LEVEL of the output. Its absence is
+ *      the whole defect, and nothing else in the build fails without it.
+ *   2. It went through the prerender, so it carries the site's chrome as
+ *      markup rather than as an empty root div a blocked script never fills.
+ *   3. It is `noindex` and carries NO canonical — the half of the fix that is
+ *      about what a crawler is told, rather than about the status code.
+ *   4. Its in-site links are ROOT-ABSOLUTE, because Pages renders this document
+ *      at whatever path was asked for and a relative link would resolve against
+ *      that failed path.
+ *   5. Every rule in `_redirects` still parses, and every destination is a
+ *      place that exists — the currently-working behaviour this change must not
+ *      disturb.
+ *
+ * ONE MECHANISM, NOT TWO. There is deliberately no `/*  /404.html  404`
+ * catch-all in `_redirects`: a catch-all source would sit in front of
+ * `/assets/*` and `/media/*`, and it is untestable here for the same reason
+ * everything else about the live edge is. Test 5's rule-shape check is what
+ * keeps one from being added without a reader of this file noticing.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SITE = path.join(APP, 'dist');
+
+/** The one filename this whole file is about. Pages recognises no other. */
+const NOT_FOUND = '404.html';
+
+/** The two real pages, for the "a destination exists" check on the rule table. */
+const PAGES = ['index.html', 'disclaimers.html'];
+
+/**
+ * The hosts this site may point a reader at, NAVIGATION ONLY — nothing on this
+ * origin loads a byte from any of them. Copied from `site.test.mjs`'s
+ * `ALLOWED_HOSTS`, and it has to be copied rather than imported: that file is a
+ * test module, not a fixture, and importing it would run all forty-five of its
+ * checks a second time inside this one.
+ *
+ * WHY THIS SET IS HERE AT ALL. `site.test.mjs`'s external-host guard is keyed on
+ * `PAGES`, and the 404 document is deliberately not one of them — so the site's
+ * headline technical claim about itself, the one `public/_headers` spends its
+ * whole length establishing, would have been unenforced on a page that IS
+ * published. It is enforced below instead, on the same set.
+ */
+const ALLOWED_HOSTS = new Set(['github.com', 'app.rwally.com', 'x.com']);
+
+const BUILT = existsSync(SITE);
+const SKIP = 'apps/site-next/dist is not built, run `npm run build` in apps/site-next first';
+const t = (name, fn) => test(name, BUILT ? {} : { skip: SKIP }, fn);
+
+const notFoundHtml = () => readFileSync(path.join(SITE, NOT_FOUND), 'utf8');
+
+/**
+ * The document with its HTML COMMENTS REMOVED.
+ *
+ * WRITTEN BECAUSE IT BIT IMMEDIATELY. `404.html` explains at its top, where
+ * somebody about to delete the file will read it, that the file carries no
+ * canonical and why. That explanation names the attribute, the comment survives
+ * the build into `dist/404.html`, and the first version of the canonical check
+ * below matched it and reported the page as carrying the thing its comment says
+ * it must not. `index.html` carries a note about the same trap for the
+ * heading-count guard and works around it by not writing the tag in prose.
+ *
+ * The general fix is better than that workaround: these checks are about
+ * MARKUP, and a comment is not markup. Stripping first means a file may
+ * document its own constraints in the words that describe them.
+ */
+const withoutComments = (html) => html.replace(/<!--[\s\S]*?-->/g, ' ');
+
+/* ===========================================================================
+   1. THE FILE
+   ======================================================================== */
+
+t('the build emits a top-level 404.html, without which Pages serves a soft-404', () => {
+  assert.ok(
+    existsSync(path.join(SITE, NOT_FOUND)),
+    `dist/${NOT_FOUND} is missing. With no top-level ${NOT_FOUND} in the output, the Cloudflare\n` +
+      'Pages asset server falls back to serving /index.html WITH A 200 for every path that\n' +
+      'matches no asset — the soft-404 measured on the live site on 2026-09-09, where\n' +
+      '/nonsense.html returned 200 and bytes identical to /. Nothing else in this build fails\n' +
+      'when the file goes, which is why this check is the one that has to.\n' +
+      "Restore it: `notFound: entry('404.html')` in vite.config.ts, and the splice at the end\n" +
+      'of scripts/prerender.mjs.',
+  );
+});
+
+/* ===========================================================================
+   2. IT CARRIES THE SITE'S CHROME, AS MARKUP
+   ======================================================================== */
+
+t('the 404 document is prerendered with the shell, not shipped as an empty root', () => {
+  const html = notFoundHtml();
+
+  assert.ok(
+    !html.includes('<div id="root"></div>'),
+    `${NOT_FOUND} still holds the EMPTY root div, so the prerender did not write it. A reader\n` +
+      'whose module script is blocked, slow or refused by the CSP gets a blank page telling them\n' +
+      'nothing — on the one document that exists to tell somebody their link is broken.',
+  );
+
+  // The shell, in the order PageShell renders it. Each of these is a separate
+  // assertion rather than one regex, so a failure names which part went.
+  assert.ok(html.includes('href="#main"'), `${NOT_FOUND}: no skip link`);
+  assert.ok(html.includes('<main id="main">'), `${NOT_FOUND}: no <main id="main">`);
+  assert.ok(html.includes('<header'), `${NOT_FOUND}: no masthead`);
+  assert.ok(html.includes('<footer'), `${NOT_FOUND}: no footer`);
+
+  // Exactly one h1, the same obligation every page of this site carries.
+  assert.equal(html.split('<h1').length - 1, 1, `${NOT_FOUND}: expected exactly one h1`);
+});
+
+/* ===========================================================================
+   3. WHAT IT TELLS A CRAWLER
+   ======================================================================== */
+
+t('the 404 document is noindex and claims no canonical URL', () => {
+  const html = withoutComments(notFoundHtml());
+
+  assert.match(
+    html,
+    /<meta\s+name="robots"\s+content="noindex">/,
+    `${NOT_FOUND} must carry <meta name="robots" content="noindex">. The 404 STATUS is the\n` +
+      'primary signal; this is the one a crawler that reads meta but not status still sees.',
+  );
+
+  // A canonical here would name a URL — index.html's, if copied from it — and
+  // declare every address that does not exist a duplicate of that page, which
+  // is the exact signal the 404 status withdraws. `og:url` is the same claim
+  // spelled differently, so neither is permitted.
+  assert.ok(
+    !/rel="canonical"/.test(html),
+    `${NOT_FOUND} carries a canonical link. This document is served at EVERY address that does\n` +
+      'not exist, so there is no URL it can name that is true of the request that produced it.',
+  );
+  assert.ok(
+    !/property="og:url"/.test(html),
+    `${NOT_FOUND} carries og:url, which is a canonical claim under another name.`,
+  );
+});
+
+/* ===========================================================================
+   4. ITS LINKS SURVIVE BEING SERVED AT ANY DEPTH
+   ======================================================================== */
+
+t('every link on the 404 document is root-absolute, or a permitted off-site host', () => {
+  const html = withoutComments(notFoundHtml());
+  let checked = 0;
+
+  for (const m of html.matchAll(/(?:href|src)\s*=\s*"([^"]*)"/gi)) {
+    const v = m[1];
+    if (v === '' || v.startsWith('#')) continue; // in-page anchor: correct as-is
+
+    // OFF-SITE: held to the same rule as the two real pages rather than waved
+    // through. `no external requests` in site.test.mjs iterates PAGES, which
+    // this document is not in, so without this line the one page nothing else
+    // guards would be the one page free to reach off this origin.
+    if (/^(?:https?:)?\/\//i.test(v)) {
+      checked++;
+      const host = v.replace(/^(?:https?:)?\/\//i, '').split('/')[0].toLowerCase();
+      assert.ok(
+        ALLOWED_HOSTS.has(host),
+        `${NOT_FOUND}: external host ${host} is not permitted. This origin makes no external\n` +
+          'request, and the CSP in public/_headers is what enforces it — a stylesheet, font or\n' +
+          'image from anywhere else is refused by the browser, so it would fail silently here.',
+      );
+      continue;
+    }
+
+    checked++;
+    assert.ok(
+      v.startsWith('/'),
+      `${NOT_FOUND}: relative link "${v}". Pages serves this document AT THE PATH THAT WAS\n` +
+        'ASKED FOR rather than redirecting, so /a/b/c renders it and "index.html" here resolves\n' +
+        'to /a/b/index.html — a second 404, on the page a lost reader landed on. Route it\n' +
+        'through `siteHref` from src/shell/pinned.ts.',
+    );
+  }
+
+  // NON-VACUITY. The chrome alone is a dozen links; near zero means the regex
+  // stopped matching the markup and this passed over nothing.
+  assert.ok(checked >= 8, `only ${checked} in-site links were read on ${NOT_FOUND}`);
+});
+
+t('the skip link is the ONE fragment left alone, because it targets this document', () => {
+  // `#main` is not a homepage section — it is the 404 document's own <main>.
+  // Rewriting it to /#main the way `#how` is rewritten would send a keyboard
+  // reader to the homepage instead of past the masthead.
+  assert.ok(notFoundHtml().includes('href="#main"'), `${NOT_FOUND}: the skip link was rewritten`);
+});
+
+/* ===========================================================================
+   5. THE RULE TABLE THIS CHANGE MUST NOT DISTURB
+   ======================================================================== */
+
+/**
+ * Parse `_redirects` the way Pages documents it: comments at column 0, and
+ * otherwise `from  to  status` separated by whitespace. Read from `dist`, not
+ * from `public`, because `dist/_redirects` is the copy that is uploaded.
+ */
+const redirectRules = () =>
+  readFileSync(path.join(SITE, '_redirects'), 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+    .map((line) => {
+      const [from, to, status] = line.split(/\s+/);
+      return { line, from, to, status };
+    });
+
+t('every redirect rule is well formed, and none of them is a catch-all', () => {
+  const rules = redirectRules();
+
+  // NON-VACUITY, and a count with a reason: /risks plus the seven pages the v3
+  // brief of 2026-09-05 retired. A file that parsed to nothing would pass every
+  // assertion in the loop below.
+  assert.equal(rules.length, 8, `expected 8 redirect rules, parsed ${rules.length}`);
+
+  for (const { line, from, to, status } of rules) {
+    assert.ok(from.startsWith('/'), `rule source is not a path: ${line}`);
+    assert.match(status, /^30[128]$/, `rule has no usable status: ${line}`);
+    assert.ok(to.startsWith('/'), `rule destination is not a path: ${line}`);
+
+    // A SOURCE CONTAINING `*` IS THE THING TO REFUSE. `_redirects` matches on
+    // path only, so a catch-all here sits in front of /assets/ and /media/ and
+    // can shadow the hashed bundles the pages load — and unlike everything
+    // else in this file, its effect cannot be checked anywhere in this
+    // repository. The 404 document is the one mechanism; see this file's
+    // header.
+    assert.ok(
+      !from.includes('*'),
+      `rule source is a wildcard: ${line}\n` +
+        'Unmatched paths are handled by dist/404.html, not by a catch-all rule. A wildcard\n' +
+        'source here can shadow /assets/ and /media/, and nothing in this repository can test\n' +
+        'that it does not.',
+    );
+  }
+});
+
+t('every redirect lands somewhere that exists', () => {
+  for (const { line, to } of redirectRules()) {
+    if (to === '/') continue; // the homepage, which index.html is
+    // Destinations are written extensionless, the form Pages serves.
+    const file = `${to.replace(/^\//, '')}.html`;
+    assert.ok(
+      PAGES.includes(file) && existsSync(path.join(SITE, file)),
+      `redirect points at a page that is not in the build: ${line} -> ${file}`,
+    );
+  }
+});

--- a/apps/site-next/vite.config.ts
+++ b/apps/site-next/vite.config.ts
@@ -1,12 +1,21 @@
 /**
  * Build configuration for the public site.
  *
- * EIGHT ENTRIES, NOT ONE APP. `rollupOptions.input` names the eight root-level
- * entry HTMLs, so `dist/` carries eight flat files with exactly the filenames
- * the current site uses — `dist/risks.html`, never `dist/risks/index.html`.
- * There is no router and no client navigation: a nav link is an ordinary
- * document navigation, and `site.test.mjs` asserts the `.html` suffix on every
- * one of them.
+ * ONE ENTRY PER DOCUMENT, NOT ONE APP. `rollupOptions.input` names the
+ * root-level entry HTMLs, so `dist/` carries flat files with exactly the
+ * filenames the site serves — `dist/disclaimers.html`, never
+ * `dist/disclaimers/index.html`. There is no router and no client navigation: a
+ * nav link is an ordinary document navigation, and `site.test.mjs` asserts the
+ * `.html` suffix on every one of them.
+ *
+ * THREE ENTRIES, AND THE THIRD IS NOT A PAGE. `index` and `disclaimers` are the
+ * two `PageId`s. `notFound` builds `404.html`, which Cloudflare Pages serves —
+ * with a 404 status — for any path matching no asset and no `_redirects` rule.
+ * DROPPING IT FROM THIS LIST DOES NOT FAIL THE BUILD, it reinstates a soft-404:
+ * with no top-level `404.html` in the output, the Pages asset server falls back
+ * to serving `/index.html` with a 200 for every unmatched path. That was the
+ * live behaviour of rwally.com until 2026-09-09, and `src/shell/pinned.ts`
+ * records the measurement under `NOT_FOUND_ID`.
  *
  * TWO BUILDS, THEN A SPLICE. `npm run build` runs this config twice — once for
  * the client, once with `--ssr` for the server bundle — and then
@@ -50,7 +59,7 @@ export default defineConfig(({ isSsrBuild }) => ({
         //
         // `ssr: true` plus an explicit `input` rather than `ssr: '<entry>'`.
         // Under Vite 8 the string form leaves the ssr environment's input as
-        // the seven entry HTMLs, and the build stops with "rolldownOptions.
+        // the entry HTMLs, and the build stops with "rolldownOptions.
         // input should not be an html file when building for SSR" — a message
         // that reads like a config typo and is really the two forms diverging.
         ssr: true,
@@ -67,6 +76,7 @@ export default defineConfig(({ isSsrBuild }) => ({
           input: {
             index: entry('index.html'),
             disclaimers: entry('disclaimers.html'),
+            notFound: entry('404.html'),
           },
         },
       },

--- a/scripts/test/claims-lede-truth.test.mjs
+++ b/scripts/test/claims-lede-truth.test.mjs
@@ -692,7 +692,24 @@ const SITE_NEXT = 'apps/site-next';
 // reached the pages the redesign actually publishes. Its only failure mode is being longer than
 // reality, which reds honestly, or shorter, which is the silent one. The two names below come from
 // `PAGE_IDS`, so the way to keep it in step is to keep reading them from there.
-const PRERENDERED = ['index.html', 'disclaimers.html'].map((page) => `${SITE_NEXT}/dist/${page}`);
+//
+// THE THIRD NAME IS NOT A PAGE, AND IT IS HERE ANYWAY. `404.html` is not in
+// `PAGE_IDS` — it is in no nav, no sitemap and none of the per-page guards in
+// `apps/site-next/test/site.test.mjs`, because it is a document the site is
+// never navigated TO. `src/shell/pinned.ts` carries the reason under
+// `NOT_FOUND_ID`: without it in the build output, Cloudflare Pages serves
+// `/index.html` with a 200 for every path that matches no asset, which is the
+// soft-404 measured on the live site on 2026-09-09.
+//
+// It is listed here because THIS test asks a different question from that one.
+// Not "is it a page of the site" but "did the guards above read the prose a
+// reader receives" — and a reader receives this document at every address that
+// does not exist, so its sentences are public surface with exactly the standing
+// of the homepage's. Being outside `PAGE_IDS` is precisely what would have made
+// it the silent omission this test's own comment warns about.
+const PRERENDERED = ['index.html', 'disclaimers.html', '404.html'].map(
+  (page) => `${SITE_NEXT}/dist/${page}`,
+);
 
 test('every prerendered redesign page is inside the walk', () => {
   // A checkout with no redesign owes nothing. `dist` alone is not the condition to test on: it is


### PR DESCRIPTION
## The defect

`rwally.com` answered an unknown path ending in `.html` with **HTTP 200 and the homepage shell**.
Measured against the live site on 2026-09-09:

```
/nonsense.html    200  13167 bytes
/vision.html      200  13167 bytes   (identical bytes to /)
/                 200  13167 bytes
/disclaimers.html 308  -> /disclaimers   (correct)
/vision           301  -> /              (correct)
/faq              301  -> /              (correct)
```

`curl -s https://rwally.com/nonsense.html | grep -o "<title>[^<]*</title>"` returned
`<title>The AI agent trading index | RWAlly</title>` — the homepage title.

## Which layer produced the 200

Not `_redirects`, and not `functions/_middleware.js`. The three correct lines above are the rule
table's work, and the middleware only rewrites the host. The Cloudflare Pages **asset server** walks
up from a requested path looking for a `404.html` and, finding none, falls back to serving
`/index.html` with a 200 — the single-page-application behaviour. `dist/` had no such file.

Cost: every mistyped or stale path is indexable as a duplicate of the homepage, and a broken
internal link answers 200, so it appears in no log and no crawl.

## The fix

`apps/site-next/404.html`, built as a third Vite entry and prerendered like the two pages. A
hand-written file in `public/` was not an option: it could not link the content-hashed stylesheet,
and `style-src 'self'` with no `unsafe-inline` leaves it no other way to be styled.

Three properties, each load-bearing and none of which fails the build if undone — `test/edge.test.mjs`
fails instead:

- **It is not a `PageId`.** `site.test.mjs` asserts every page links to every other, so adding the id
  would put a link to the 404 document in both real pages' navs. It is in no nav, no sitemap, no
  `sitemap.xml`, and none of the per-page guards.
- **Its in-site links are root-absolute.** Pages renders this document *at the path that was asked
  for* rather than redirecting, so `/a/b/c` renders it and a relative `index.html` would resolve to
  `/a/b/index.html` — a second 404, under a lost reader. `siteHref` in `src/shell/pinned.ts` does the
  rewrite and is the **identity function** on the two real pages, which keep emitting the byte-exact
  `href="index.html"` the link guard matches. Verified in the built output: `dist/index.html` and
  `dist/disclaimers.html` are unchanged in their hrefs.
- **It is `noindex` and names no canonical.** Served at every address that does not exist, it has no
  URL it could claim that is true of the request that produced it. A canonical copied from
  `index.html` would re-assert the exact duplicate-content signal the 404 status withdraws.

Everything currently working is untouched: `/disclaimers.html` → 308 → `/disclaimers`, `/vision` → `/`,
`/faq` → `/`, and `/` and `/disclaimers` serving 200. No rule in `_redirects` was added, removed or
reordered.

## The test

`apps/site-next/test/edge.test.mjs`, a second file beside `site.test.mjs` because nearly every guard
there is written as `for (const p of PAGES)` and neither artefact here is one of those pages.
`apps/site-next`'s `test` script now globs `test/*.test.mjs`; both files run under the gate's
`site-test` step and under CI's, confirmed by the count going 45 → 52.

It **deliberately does not simulate the Pages resolver.** A resolver written here would assert
`/nonsense.html -> 404` in one line and the line would be worthless: it would test a model of
Cloudflare written in this repository, and pass whether or not the real edge agreed. It pins the
preconditions instead — the file exists at the top level, it went through the prerender and carries
the chrome as markup, it is `noindex` with no canonical, its in-site links are root-absolute, every
redirect rule parses and lands somewhere real, and no rule source is a wildcard.

Each of the seven checks was probed to fail when its subject is undone: file deleted (1, 2), empty
root div restored (2), `noindex` stripped (3), one link made relative (4), a wildcard rule added (6, 7),
a rule dropped (6), a destination pointed at a page that does not exist (7).

## Verified

- `npm run gate` from the repo root, on the rebased SHA: **PASSED** (327 s, 1 advisory slither warning,
  unchanged from `protocol/main`).
- The page rendered from a served `dist/` at 1280×900: full chrome, one `<h1>`, both actions, and the
  primary action clicked through to the homepage.

## What this does NOT prove

There is no wrangler in this repository and publishing is the owner's call, so **the live response is
not exercised by any test here.** One thing the gate cannot see: if the Pages project has
`not_found_handling` set to single-page-application in the dashboard, that setting overrides the file
and the soft-404 survives the deploy. Worth checking at publish time — the README now says so.

Not published. No screenshot review requested here.
