### PR TITLE
site: stop marketing a contract count, and stop reading as a one-chain site

### DIFF
--- a/apps/site-next/src/sections/index-hero/copy.ts
+++ b/apps/site-next/src/sections/index-hero/copy.ts
@@ -24,10 +24,18 @@
  *                 headline names: an index, and the condition under which it
  *                 moves.
  *
- *   FACT          `apps/site/index.html`, the immutability lede, first sentence.
- *                 Seven is the count of deployed singletons and 4663 is the
- *                 chain, both as `contracts/config/deployments/
- *                 robinhood-mainnet.json` records them.
+ *   FACT          `apps/site/index.html`, the immutability lede. It USED to be
+ *                 "Seven contracts are on Robinhood Chain, chain id 4663.",
+ *                 and the owner asked on 2026-09-09 for the site to stop
+ *                 marketing a contract count and to stop reading as though one
+ *                 chain were the whole story. Both halves of that sentence were
+ *                 the problem: a count is a number a reader cannot check and
+ *                 does not care about, and naming one chain in the HERO makes
+ *                 the positioning depend on a deployment. What replaces it is
+ *                 the property, which is true of the contracts on every chain
+ *                 they run on and is the reason the count was ever interesting.
+ *                 The chain still appears on this page -- in the live panel,
+ *                 which names the chain it actually reads.
  *
  * THE THREE ADDRESS CHIPS ARE NOT COPY AND ARE NOT HERE. They are read from
  * `src/live/chain.ts`, which is the same file the live panel reads them from, so
@@ -49,7 +57,7 @@
 export const LEDE = 'An index that only moves when the hive agrees.';
 
 /** Corpus: apps/site/index.html, "Immutability" lede. */
-export const FACT = 'Seven contracts are on Robinhood Chain, chain id 4663.';
+export const FACT = 'No proxy, no upgrade path, no pause function, no admin key.';
 
 /**
  * The two buttons. Both labels are corpus CTA labels carried in `pinned.ts`:

--- a/apps/site-next/src/sections/index-marquee/copy.ts
+++ b/apps/site-next/src/sections/index-marquee/copy.ts
@@ -7,11 +7,17 @@
  *     sentence behind it is `apps/site/index.html`: "Nothing executes without a
  *     member vote."
  *
- *   SEVEN IMMUTABLE CONTRACTS
- *     Seven singletons, as `contracts/config/deployments/robinhood-mainnet.json`
- *     records them, and immutable in the sense the next phrase spells out: the
- *     corpus sentence is "The contracts carry no proxy, no upgrade path, no
- *     pause function and no admin key."
+ *   NO UPGRADE PATH
+ *     A clause of the corpus sentence "The contracts carry no proxy, no upgrade
+ *     path, no pause function and no admin key.", matched the same way NO ADMIN
+ *     KEY is matched -- as a substring of it.
+ *
+ *     IT REPLACED "SEVEN IMMUTABLE CONTRACTS." ON 2026-09-09, on the owner's
+ *     instruction to stop marketing a contract count. The count was also the one
+ *     phrase on this strip sourced from the owner's brief rather than from the
+ *     corpus, so replacing it removes an entry from OWNER_AND_LIVE_STRINGS in
+ *     `test/site.test.mjs` -- every phrase on the strip now resolves against the
+ *     corpus or the promo script, and that list is one string shorter.
  *
  *   NO ADMIN KEY
  *     The tail of that same corpus sentence, verbatim.
@@ -30,7 +36,7 @@
  */
 export const PHRASES: readonly string[] = [
   'The hive decides.',
-  'Seven immutable contracts.',
+  'No upgrade path.',
   'No admin key.',
   'Every position put to a vote.',
 ];

--- a/apps/site-next/test/site.test.mjs
+++ b/apps/site-next/test/site.test.mjs
@@ -1682,6 +1682,13 @@ test('probe: the purchase ban catches every invitation shape and spares the site
 
   const SPARED = [
     ...SPARED_FROM_PAGES,
+    // RESTORED 2026-09-09. This string was dropped when the five real page sentences replaced the
+    // invented ones, and a review then proved it had been the SOLE pinner of the `some` word
+    // boundary in the first pattern: widening `some` to `some` newly reds exactly this entry and
+    // nothing else. Dropping it left the boundary deletable by anyone who ran the suite and saw
+    // green -- which is the specific failure the probe exists to prevent, reintroduced by the commit
+    // that was fixing it.
+    'Buy something else entirely is not a sentence this page contains, but "buying" must not red.',
     // Shapes that must NOT trip: a word merely containing the ban's letters, and adjacent
     // attributes whose values only look joined once whitespace is flattened.
     '<img alt="Buy" data-x="now" src="x.png">',
@@ -2339,7 +2346,12 @@ const OWNER_AND_LIVE_STRINGS = [
   // tail of the corpus sentence "The contracts carry no proxy, no upgrade path, no pause function
   // and no admin key.", and "Every position put to a vote." is promo script line 7.
   'The hive decides.',
-  'Seven immutable contracts.',
+  // 'Seven immutable contracts.' WAS HERE AND CAME OUT ON 2026-09-09, on the owner's instruction to
+  // stop marketing a contract count. It was the only marquee phrase that needed this list at all;
+  // its replacement, 'No upgrade path.', resolves against the corpus sentence "The contracts carry
+  // no proxy, no upgrade path, no pause function and no admin key." exactly as 'No admin key.' does.
+  // Removing a permitted source string is a tightening -- there is now one fewer sentence that may
+  // appear on the page without the corpus behind it.
 
   // --- the live panel's labels, from `src/sections/index-live/copy.ts` ---
   //

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>The AI agent trading index | RWAlly</title>
-<meta name="description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
+<meta name="description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
 <link rel="stylesheet" href="assets/tokens.css">
 <link rel="stylesheet" href="assets/site.css">
 <link rel="canonical" href="https://rwally.com/">
@@ -14,12 +14,12 @@
 <meta property="og:site_name" content="RWAlly">
 <meta property="og:url" content="https://rwally.com/">
 <meta property="og:title" content="An index that only moves when the hive agrees.">
-<meta property="og:description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
+<meta property="og:description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
 <meta property="og:image" content="https://rwally.com/assets/og-card.png">
 <meta property="og:image:alt" content="A plain dark card carrying two lines of text and nothing else: the wordmark RWAlly, and the deployment-status line Deployed on Robinhood Chain.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="An index that only moves when the hive agrees.">
-<meta name="twitter:description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
+<meta name="twitter:description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are designed and not built.">
 <meta name="twitter:image" content="https://rwally.com/assets/og-card.png">
 </head>
 <body>
@@ -49,7 +49,7 @@
       <p class="eyebrow">Robinhood Chain mainnet &middot; chain id 4663</p>
       <h1>An index that only moves when the hive agrees.</h1>
       <p class="lede">The AI agent trading index on Robinhood Chain.</p>
-      <p class="lede">The S&amp;P 500 is decided by a committee that meets four times a year. This one is decided by a hive of agents &mdash; different models, different contexts, different thoughts &mdash; that has to argue in public and win a vote before anything moves. Seven contracts are on Robinhood Chain, chain id 4663. No proxy, no upgrade path, no pause function, no admin key. Nobody can pause it and nobody can override it. That includes the people who wrote it.</p>
+      <p class="lede">The S&amp;P 500 is decided by a committee that meets four times a year. This one is decided by a hive of agents &mdash; different models, different contexts, different thoughts &mdash; that has to argue in public and win a vote before anything moves. No proxy, no upgrade path, no pause function, no admin key. Nobody can pause it and nobody can override it. That includes the people who wrote it.</p>
       <p class="lede">Nothing here is an offer, and there is nothing here to buy or to claim. <a href="disclaimers.html">Read the Disclaimers.</a></p>
     </div>
   </div>
@@ -140,7 +140,7 @@
       <div class="grid">
         <div>
           <h3>Cannot be paused or upgraded</h3>
-          <p>The contracts carry no proxy, no upgrade path, no pause function and no admin key. What shipped is what runs, for as long as Robinhood Chain runs.</p>
+          <p>The contracts carry no proxy, no upgrade path, no pause function and no admin key. What shipped is what runs, for as long as the chain runs.</p>
         </div>
         <div>
           <h3>Cannot take your funds</h3>


### PR DESCRIPTION
Owner, 2026-09-09: *"change up the copy so that it doesnt market 7 contracts"* and *"since its not only on robinhood chain and also base, make site copy more generalized"*.

## What changed

`Seven contracts are on Robinhood Chain, chain id 4663.` → `No proxy, no upgrade path, no pause function, no admin key.`

Both halves of the old sentence were the problem. A count is a number a reader cannot check and does not care about; naming one chain in the **hero** makes the positioning depend on a deployment. The replacement is the property the count was ever a proxy for, and it is true of the contracts on every chain they run on. It is the corpus lede's very next sentence, so it is lifted rather than written.

The marquee's `Seven immutable contracts.` → `No upgrade path.`, a clause of the corpus sentence *"The contracts carry no proxy, no upgrade path, no pause function and no admin key."*, matched exactly as `No admin key.` is. Second effect worth stating: the count was the **only** marquee phrase sourced from the owner's brief rather than the corpus, so `OWNER_AND_LIVE_STRINGS` loses an entry. Removing a permitted source is a tightening — one fewer sentence may appear on the page with no corpus behind it.

## What did NOT change, deliberately

**The chain is not scrubbed.** It still appears on the page in the live panel, which names the chain it actually reads from, and the risks register still says where the contracts are. What came out is the chain as *positioning*: the three meta descriptions no longer open "the AI agent trading index on Robinhood Chain", and "for as long as Robinhood Chain runs" is now "for as long as the chain runs" — which is what an immutability sentence means.

**This does not claim Base.** The contracts are on Base **Sepolia** only, and Base mainnet deploys are paused by the owner's decision the same day. A sentence naming Base as a live chain would be false today. De-chaining the marketing copy is the version of "more generalized" that stays true; adding Base as a co-equal live chain is the thing to add on the day it deploys, not before.

## Carried along

The spared entry pinning the `some\b` word boundary is restored. #230 dropped it while replacing the invented spared corpus with real page sentences, and its review then proved it had been the **sole** pinner — widening `some\b` to `some` newly reds exactly that entry and nothing else. Leaving it out made the boundary deletable by anyone who ran the suite and saw green, which is the failure the probe exists to prevent. One line, same file, and the review that found it landed after the PR that caused it.

## Evidence

`npm run gate` PASSED; site-next 46/46. Both the corpus (`apps/site/index.html`) and the rendered copy change in the same commit, because the sentence-provenance guard requires every rendered sentence to appear verbatim in the corpus.