### PR TITLE
feat(x402): resolve the payment capability by network name, not only by chain id

### DIFF
--- a/apps/api/test/x402-capability.test.mjs
+++ b/apps/api/test/x402-capability.test.mjs
@@ -35,7 +35,7 @@ import { resolveApiConfig } from '../src/serve.mjs';
 import { HEADERS } from '../src/x402.mjs';
 import { createStubFacilitator } from '../src/facilitator.mjs';
 import { createRateLimiter } from '../src/ratelimit.mjs';
-import { x402Capability, DEFAULT_CONFIG_DIR } from '../../../packages/chain-config/src/x402.mjs';
+import { x402Capability, DEFAULT_CONFIG_DIR, DEFAULT_NETWORK_DIR, loadNetworkCapabilities } from '../../../packages/chain-config/src/x402.mjs';
 import { applyAll } from '../../../packages/indexer/src/projections.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
@@ -280,4 +280,118 @@ test('on 4663 an unknown route still 404s, and a non-GET is still refused', asyn
   const api = seededApi({ x402: x402Capability(ROBINHOOD) });
   assert.equal((await api.handle('GET', '/nope', {})).status, 404);
   assert.equal((await api.handle('POST', '/vaults', {})).status, 405);
+});
+
+/*
+ * ── NETWORKS WITH NO EVM CHAIN ID ───────────────────────────────────────────────────────────────
+ *
+ * ADDED 2026-09-09, when the owner asked for x402 on Solana. The resolver took a chain id and did
+ * `Number(key)`, rejecting anything non-finite, which was right while every target was EVM.
+ *
+ * THE BUG THAT PRODUCED IS THE FIRST THING PINNED BELOW, because it is the kind that reads as
+ * working: `x402Capability('solana-mainnet')` gave `NaN`, fell into the "no chain id configured"
+ * branch, and returned `enabled: true` having consulted no config at all. Fail-CLOSED, so no
+ * payment gate came off by accident — but Solana metering was UNCONFIGURABLE, and no file anywhere
+ * could have turned it off. That is not a capability, it is a constant wearing one's clothes.
+ */
+
+test('a Solana network resolves by NAME, out of its own directory', () => {
+  const cap = x402Capability('solana-mainnet');
+  assert.equal(cap.enabled, true);
+  assert.equal(cap.network, 'solana-mainnet', 'the network name is echoed, so a boot log says which network answered');
+  assert.equal(cap.chainId, null, 'Solana has no EVM chain id and must not be given a fake one');
+  assert.equal(cap.scheme, 'exact-svm', 'the scheme is carried so a caller picks a facilitator without a second lookup');
+  assert.match(cap.source, /solana-mainnet\.json sets x402\.enabled = true/);
+});
+
+test('the network name is matched case-insensitively', () => {
+  // `NETWORK=Solana-Mainnet` in a .env is the same network. A lookup that disagreed would take a
+  // payment gate off by capitalisation, which is the least debuggable way to lose one.
+  for (const spelling of ['solana-mainnet', 'Solana-Mainnet', 'SOLANA-MAINNET', '  solana-mainnet  ']) {
+    const cap = x402Capability(spelling);
+    assert.equal(cap.network, 'solana-mainnet', `${JSON.stringify(spelling)} must resolve to the same network`);
+    assert.equal(cap.enabled, true);
+  }
+});
+
+test('a network name that no file declares still means ENABLED, and says so', () => {
+  const cap = x402Capability('a-network-nobody-configured');
+  assert.equal(cap.enabled, true, 'an unknown network must not switch a payment gate off');
+  assert.equal(cap.network, 'a-network-nobody-configured');
+  assert.match(cap.source, /no network config for a-network-nobody-configured/);
+});
+
+test('a network config CAN turn metering off — which is the whole point of the change', () => {
+  // Before this existed there was no file that could produce this result for a non-EVM network.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-net-off-'));
+  try {
+    writeFileSync(path.join(dir, 'off.json'), JSON.stringify({
+      network: 'somewhere-metering-is-off', chainName: 'test', scheme: 'exact-svm', x402: { enabled: false, note: 'because a test says so' },
+    }));
+    const cap = x402Capability('somewhere-metering-is-off', { networkDir: dir });
+    assert.equal(cap.enabled, false);
+    assert.equal(cap.note, 'because a test says so');
+    assert.match(cap.source, /off\.json sets x402\.enabled = false/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a network file with no x402 block resolves to enabled, read from a real directory', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-net-absent-'));
+  try {
+    writeFileSync(path.join(dir, 'bare.json'), JSON.stringify({ network: 'bare-network', chainName: 'bare' }));
+    const cap = x402Capability('bare-network', { networkDir: dir });
+    assert.equal(cap.enabled, true, 'an absent block must mean enabled here for the same reason it does on the chain-id path');
+    assert.equal(cap.chainName, 'bare', 'the entry was read, not defaulted past');
+    assert.match(cap.source, /declares no x402 block/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a missing network directory degrades to enabled rather than throwing on a boot path', () => {
+  const cap = x402Capability('solana-mainnet', { networkDir: path.join(tmpdir(), 'no-such-dir-' + process.pid) });
+  assert.equal(cap.enabled, true);
+  assert.match(cap.source, /no network config for solana-mainnet/);
+});
+
+test('a malformed network file is skipped, and does not take the lookup down with it', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-net-bad-'));
+  try {
+    writeFileSync(path.join(dir, 'broken.json'), '{ this is not json');
+    writeFileSync(path.join(dir, 'fine.json'), JSON.stringify({ network: 'fine', x402: { enabled: false } }));
+    const loaded = loadNetworkCapabilities({ dir });
+    assert.equal(loaded.size, 1, 'the broken file is skipped, the good one still loads');
+    assert.equal(x402Capability('fine', { networkDir: dir }).enabled, false);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a file with no `network` key is not indexed, so a stray json cannot claim a name', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-net-noname-'));
+  try {
+    writeFileSync(path.join(dir, 'stray.json'), JSON.stringify({ chainId: 8453, chainName: 'base', x402: { enabled: false } }));
+    assert.equal(loadNetworkCapabilities({ dir }).size, 0);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('the EVM path is untouched: numeric keys still resolve out of contracts/config', () => {
+  // The regression that matters. Every chain-id caller predates this change and none of them may
+  // move, including the `source` strings other tests in this file match on.
+  const rh = x402Capability(ROBINHOOD);
+  assert.equal(rh.enabled, false, '4663 stays off');
+  assert.equal(rh.chainId, 4663);
+  assert.equal(rh.network, null, 'an EVM chain answers with a chain id, not a network name');
+  assert.equal(x402Capability(BASE_SEPOLIA).enabled, true);
+  assert.equal(x402Capability('4663').enabled, false, 'a numeric STRING is still a chain id, not a network name');
+  assert.equal(x402Capability(null).enabled, true);
+  assert.equal(x402Capability('').enabled, true);
+});
+
+test('every shipped network file declares the block out loud, and names a scheme', () => {
+  // The same non-vacuity discipline the chain configs are held to: a directory that has gone empty
+  // would make every assertion above pass by walking nothing.
+  const shipped = loadNetworkCapabilities({ dir: DEFAULT_NETWORK_DIR });
+  assert.ok(shipped.size >= 2, `expected at least two shipped network configs, found ${shipped.size}`);
+  for (const [name, entry] of shipped) {
+    assert.ok(entry.x402, `${entry.file}: declares no x402 block — say it out loud rather than relying on the default`);
+    assert.ok(entry.scheme, `${entry.file}: declares no scheme, so a caller cannot pick a facilitator`);
+    assert.equal(name, name.toLowerCase(), 'the index key is lower-cased');
+  }
 });

--- a/config/networks/README.md
+++ b/config/networks/README.md
@@ -1,0 +1,46 @@
+# `config/networks` — x402 capability for networks that have no EVM chain id
+
+One file per payment network. `packages/chain-config/src/x402.mjs` reads this directory
+non-recursively and indexes every `*.json` that declares a string `network`.
+
+This is **not** a deployment configuration and must not become one. The vault contracts are
+Solidity; nothing in this directory deploys, and nothing here is read by Solidity. It answers one
+question — *may this network meter reads over x402, and by which scheme* — for networks the
+`contracts/config` directory cannot describe because they have no `chainId`.
+
+## Why it is separate from `contracts/config`
+
+`contracts/config/*.json` is the vault deployment configuration: oracle parameters, governance
+defaults, asset lists. `vm.readFile` reads those files inside forge tests, and
+`scripts/test/config-doc-truth.test.mjs` enumerates every `*-mainnet.json` there and asserts a
+`govDefencesNote` on each. A payment network has no governance defences, so `solana-mainnet.json`
+in that directory would red the suite on the day it landed and the fix would be an exemption list
+inside a guard whose whole value is that it enumerates rather than lists.
+
+## Shape
+
+```json
+{
+  "network": "solana-mainnet",
+  "chainName": "Solana mainnet-beta",
+  "scheme": "exact-svm",
+  "x402": { "enabled": true, "note": "why, and since when" }
+}
+```
+
+- **`network`** — required, and the key. Matched case-insensitively, because `NETWORK=Solana-Mainnet`
+  in a `.env` is the same network as `solana-mainnet`, and a lookup that says otherwise takes a
+  payment gate off by capitalisation.
+- **`scheme`** — which x402 settlement scheme this network speaks. EVM chains use `exact-evm`
+  (EIP-3009 `transferWithAuthorization`); Solana uses `exact-svm` (SPL `TransferChecked`, with the
+  facilitator signing as fee payer). The resolver returns it so a caller can pick a facilitator
+  without a second lookup.
+- **`x402.enabled`** — only an explicit `false` disables. An absent block, a partial block, an
+  unknown network, or a missing directory all mean **enabled**: x402 is a payment gate, and a gate
+  must not come off because a lookup could not read its source.
+
+## Adding a network
+
+Add the file. Nothing else — the directory is enumerated from the filesystem, never from a list, so
+a network added today is covered today. Then add a case to
+`apps/api/test/x402-capability.test.mjs`, which is where the resolver's behaviour is pinned.

--- a/config/networks/solana-devnet.json
+++ b/config/networks/solana-devnet.json
@@ -1,0 +1,15 @@
+{
+  "network": "solana-devnet",
+  "chainName": "Solana devnet",
+  "scheme": "exact-svm",
+  "x402": {
+    "enabled": true,
+    "note": "The devnet twin of solana-mainnet, and the only Solana network anything should be pointed at until a facilitator exists. Declared explicitly for the same reason the mainnet file is."
+  },
+  "settlement": {
+    "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    "assetNote": "Circle's USDC devnet mint, 6 decimals. Same caveat as the mainnet file: recorded, NOT read back from chain.",
+    "decimals": 6,
+    "schemeNote": "Devnet SOL is free, so a facilitator keypair here costs nothing to fund and is the right place to prove the fee-payer half of the scheme before any mainnet key exists."
+  }
+}

--- a/config/networks/solana-mainnet.json
+++ b/config/networks/solana-mainnet.json
@@ -1,0 +1,15 @@
+{
+  "network": "solana-mainnet",
+  "chainName": "Solana mainnet-beta",
+  "scheme": "exact-svm",
+  "x402": {
+    "enabled": true,
+    "note": "Declared explicitly on 2026-09-09 rather than left to the enabled-by-default. Before this file existed the resolver did Number('solana-mainnet'), got NaN, and returned enabled with no config consulted -- fail-closed, but unconfigurable: no file anywhere could have turned Solana metering off. Nothing is deployed on Solana; this records the payment capability only."
+  },
+  "settlement": {
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "assetNote": "Circle USDC on Solana mainnet-beta, 6 decimals. NOT READ BACK FROM CHAIN YET -- this is the widely published mint address and it is recorded here as a starting point, not as a verified fact. Verify with getAccountInfo against the SPL token program and confirm decimals before any sentence on a public page cites it.",
+    "decimals": 6,
+    "schemeNote": "x402 exact on SVM is an SPL TransferChecked. The client builds and partially signs the transaction; the facilitator adds its own signature as fee payer and submits. That is a different trust shape from the EVM path, where the client signs an EIP-3009 authorization and never builds a transaction at all -- on Solana the facilitator pays the network fee, so it needs a funded keypair and a rate limit."
+  }
+}

--- a/packages/chain-config/src/x402.mjs
+++ b/packages/chain-config/src/x402.mjs
@@ -48,12 +48,35 @@ export const DEFAULT_CONFIG_DIR = path.resolve(
 );
 
 /**
+ * `config/networks` — the same question for a network that has no EVM chain id.
+ *
+ * WHY A SECOND DIRECTORY RATHER THAN A FILE IN `contracts/config`. That directory is the vault
+ * DEPLOYMENT configuration: oracle parameters, governance defaults, asset lists, read by Solidity
+ * through `vm.readFile` and by `DeployTestnet.s.sol`. Solana has no vault deployment and never
+ * will from this repository — the contracts are Solidity. Putting `solana-mainnet.json` there
+ * would also walk straight into `scripts/test/config-doc-truth.test.mjs`, which enumerates every
+ * `*-mainnet.json` under `contracts/config` and asserts a `govDefencesNote` on each. A payment
+ * network has no governance defences, so that file would red the suite the day it landed, and the
+ * fix would be an exemption — a list of "not really a chain config" entries inside a guard whose
+ * whole value is that it enumerates rather than lists.
+ *
+ * So: EVM chains keep answering by chain id out of the deployment configs, unchanged and with no
+ * gas-snapshot risk, and non-EVM payment networks answer by NAME out of their own directory.
+ */
+export const DEFAULT_NETWORK_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..', '..', '..', 'config', 'networks',
+);
+
+/**
  * @typedef {Object} X402Capability
  * @property {number|null} chainId    the chain the answer is about (null = no chain id supplied)
+ * @property {string|null} network    the network NAME the answer is about, for non-EVM networks
  * @property {string|null} chainName  the config's `chainName`, when a config matched
  * @property {boolean} enabled        may this chain meter reads over x402?
  * @property {string} source          how the answer was reached — for the boot log and for tests
  * @property {string} [note]          the config's own `x402.note`, verbatim
+ * @property {string} [scheme]        the settlement scheme this network uses, e.g. `exact-svm`
  */
 
 /**
@@ -95,28 +118,112 @@ export function loadChainCapabilities({ dir = DEFAULT_CONFIG_DIR } = {}) {
 }
 
 /**
- * Resolve the x402 capability for a chain id.
+ * Read every `*.json` directly under `dir` and index the ones that declare a string `network`.
  *
- * @param {number|string|null|undefined} chainId
+ * Same shape and same failure posture as `loadChainCapabilities`: a malformed file is skipped, not
+ * thrown on, and a partial `x402` block does not disable. Names are indexed lower-cased, because
+ * `NETWORK=Solana-Mainnet` in a `.env` is the same network as `solana-mainnet` and a capability
+ * lookup that says otherwise switches a payment gate off by capitalisation.
+ *
  * @param {{dir?:string}} [opts]
+ * @returns {Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>}
+ */
+export function loadNetworkCapabilities({ dir = DEFAULT_NETWORK_DIR } = {}) {
+  /** @type {Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>} */
+  const byName = new Map();
+  /** @type {string[]} */
+  let files;
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
+  } catch {
+    return byName;
+  }
+  for (const file of files) {
+    let json;
+    try {
+      json = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!json || typeof json !== 'object' || typeof json.network !== 'string' || !json.network.trim()) continue;
+    const declared = json.x402 && typeof json.x402 === 'object' ? json.x402 : null;
+    byName.set(json.network.trim().toLowerCase(), {
+      network: json.network.trim(),
+      chainName: typeof json.chainName === 'string' ? json.chainName : null,
+      scheme: typeof json.scheme === 'string' ? json.scheme : null,
+      x402: declared ? { enabled: declared.enabled !== false, ...(typeof declared.note === 'string' ? { note: declared.note } : {}) } : null,
+      file,
+    });
+  }
+  return byName;
+}
+
+/**
+ * Resolve the x402 capability for a chain id OR a network name.
+ *
+ * ## Why this takes two kinds of key
+ *
+ * It used to take a chain id and do `Number(key)`, rejecting anything non-finite. That was right
+ * while every target was EVM. Solana has no chain id, and the consequence was not a clean failure:
+ * `x402Capability('solana-mainnet')` produced `NaN`, fell into the "no chain id configured" branch
+ * and returned `enabled: true` with no config consulted. Fail-CLOSED, so nothing came off a payment
+ * gate by accident — but Solana metering was **unconfigurable**, and no file anywhere could have
+ * turned it off. A capability that cannot be configured is not a capability.
+ *
+ * So a numeric key still resolves by chain id out of `contracts/config`, and a non-numeric key
+ * resolves by name out of `config/networks`. Nothing about the EVM path changed, including its
+ * defaults and its `source` strings, which several tests match on.
+ *
+ * ## The default is still ENABLED, on both paths
+ *
+ * An absent block, an unknown key, a missing directory: all of them mean enabled. x402 is a payment
+ * gate, and a gate must not come off because a lookup could not read its source. Disabling stays
+ * opt-in, per network, and visible in a config diff.
+ *
+ * @param {number|string|null|undefined} key  an EVM chain id, or a network name such as `solana-mainnet`
+ * @param {{dir?:string, networkDir?:string}} [opts]
  * @returns {X402Capability}
  */
-export function x402Capability(chainId, { dir = DEFAULT_CONFIG_DIR } = {}) {
-  const id = chainId === null || chainId === undefined || chainId === '' ? null : Number(chainId);
-  if (id === null || !Number.isFinite(id))
-    return { chainId: null, chainName: null, enabled: true, source: 'no chain id configured — x402 metering left on (default)' };
+export function x402Capability(key, { dir = DEFAULT_CONFIG_DIR, networkDir = DEFAULT_NETWORK_DIR } = {}) {
+  if (key === null || key === undefined || (typeof key === 'string' && key.trim() === ''))
+    return { chainId: null, network: null, chainName: null, enabled: true, source: 'no chain id or network configured — x402 metering left on (default)' };
 
-  const entry = loadChainCapabilities({ dir }).get(id);
+  const id = Number(key);
+  if (Number.isFinite(id)) {
+    const entry = loadChainCapabilities({ dir }).get(id);
+    if (!entry)
+      return { chainId: id, network: null, chainName: null, enabled: true, source: `no chain config for chain ${id} — x402 metering left on (default)` };
+    if (!entry.x402)
+      return { chainId: id, network: null, chainName: entry.chainName, enabled: true, source: `${entry.file} declares no x402 block — metering left on (default)` };
+
+    return {
+      chainId: id,
+      network: null,
+      chainName: entry.chainName,
+      enabled: entry.x402.enabled,
+      source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}`,
+      ...(entry.x402.note ? { note: entry.x402.note } : {}),
+    };
+  }
+
+  const name = String(key).trim();
+  const entry = loadNetworkCapabilities({ dir: networkDir }).get(name.toLowerCase());
   if (!entry)
-    return { chainId: id, chainName: null, enabled: true, source: `no chain config for chain ${id} — x402 metering left on (default)` };
+    return { chainId: null, network: name, chainName: null, enabled: true, source: `no network config for ${name} — x402 metering left on (default)` };
   if (!entry.x402)
-    return { chainId: id, chainName: entry.chainName, enabled: true, source: `${entry.file} declares no x402 block — metering left on (default)` };
+    return {
+      chainId: null, network: entry.network, chainName: entry.chainName, enabled: true,
+      source: `${entry.file} declares no x402 block — metering left on (default)`,
+      ...(entry.scheme ? { scheme: entry.scheme } : {}),
+    };
 
   return {
-    chainId: id,
+    chainId: null,
+    network: entry.network,
     chainName: entry.chainName,
     enabled: entry.x402.enabled,
     source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}`,
     ...(entry.x402.note ? { note: entry.x402.note } : {}),
+    ...(entry.scheme ? { scheme: entry.scheme } : {}),
   };
 }


### PR DESCRIPTION
Owner, 2026-09-09: *"Solana is now opening x402 — see if we can integrate that chain as well"*, then *"for x402 on solana, go ahead and build the infra for it"*. This is the first piece — the capability layer, which is also where the latent bug was.

## The bug, which read as working

`x402Capability` took a chain id and did `Number(key)`, rejecting anything non-finite. Right while every target was EVM. Solana has no chain id, and the failure was not clean: `x402Capability('solana-mainnet')` produced `NaN`, fell into the *"no chain id configured"* branch, and returned `enabled: true` **having consulted no config at all**.

Fail-**closed**, so no payment gate came off by accident — but Solana metering was **unconfigurable**, and no file anywhere could have turned it off. That is not a capability; it is a constant wearing one's clothes. It is pinned first in the new tests for that reason.

## What changed

A numeric key still resolves by chain id out of `contracts/config`, byte for byte as before — including its `source` strings, which several existing tests match on. A non-numeric key resolves by **name** out of a new `config/networks` directory, matched case-insensitively: `NETWORK=Solana-Mainnet` in a `.env` is the same network as `solana-mainnet`, and a lookup that disagreed would take a payment gate off by capitalisation.

The default is still **enabled** on both paths — absent block, unknown key, missing directory, malformed file. A gate must not come off because a lookup could not read its source.

## Why a second directory rather than a file in `contracts/config`

That directory is the vault **deployment** configuration: oracle parameters, governance defaults, asset lists, read by Solidity through `vm.readFile`. Solana has no vault deployment and never will from this repository — the contracts are Solidity.

A `solana-mainnet.json` there would also walk straight into `scripts/test/config-doc-truth.test.mjs`, which enumerates every `*-mainnet.json` under `contracts/config` and asserts a `govDefencesNote` on each. A payment network has no governance defences, so that file would red the suite on the day it landed, and the fix would be an exemption list inside a guard whose whole value is that it enumerates rather than lists.

The two Solana configs record the settlement asset and scheme, and both say out loud that **the mint addresses are not read back from chain yet**. That is a fact about the record, not a hedge: nothing on a public page may cite them until somebody verifies them with `getAccountInfo`.

## Evidence

Ten new cases, **27/27** in the file. Six mutations of the resolver each red it **by name**:

| mutation | reds |
|---|---|
| the original `NaN` bug restored | 7 cases |
| case-insensitive matching removed | the case test |
| unknown network turns metering **off** | 2 cases |
| absent network block disables | the absent-block test |
| scheme no longer carried | 2 cases |
| malformed file no longer skipped | the malformed-file test |

`npm run gate` PASSED.

## Not in this change

The SVM facilitator and the client envelope builder. The gate (`apps/api/src/x402.mjs`) already takes an **injected** facilitator and `PriceSpec` already carries `network`, which `facilitator-server.mjs:131` validates against the envelope — so Solana is a third facilitator beside the stub and the EIP-3009 one, and the gate needs no change at all. That lands next.