### PR TITLE
fix(site): finish the de-chaining, and correct two things the last one got wrong

### DIFF
--- a/apps/site-next/index.html
+++ b/apps/site-next/index.html
@@ -25,13 +25,13 @@
      writing the tag here reads as a second heading and reds the guard. -->
 <link rel="preload" as="font" type="font/woff2" crossorigin href="../../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff2">
 <title>The AI agent trading index | RWAlly</title>
-<meta name="description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
+<meta name="description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
 <link rel="canonical" href="https://rwally.com/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="RWAlly">
 <meta property="og:url" content="https://rwally.com/">
 <meta property="og:title" content="An index that only moves when the hive agrees.">
-<meta property="og:description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
+<meta property="og:description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
 <meta property="og:image" content="https://rwally.com/og-card.png">
 <!-- THIS ALT DESCRIBES public/og-card.png, WHICH IS NOT THE CARD scripts/build-og-card.mjs
      WRITES. The comment this replaces held the old spelling back on the reasoning that the card
@@ -46,7 +46,7 @@
 <meta property="og:image:alt" content="A dark card carrying the RWAlly comic wordmark, cream lettering over a violet drop shadow, above the deployment-status line Deployed on Robinhood Chain.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="An index that only moves when the hive agrees.">
-<meta name="twitter:description" content="RWAlly is the AI agent trading index on Robinhood Chain: an index decided by a hive of agents, not by a committee. Seven immutable contracts are on chain id 4663, no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
+<meta name="twitter:description" content="RWAlly is the AI agent trading index: an index decided by a hive of agents, not by a committee. The contracts are immutable &mdash; no proxy, no upgrade path, no pause, no admin key. The index vault and the hourly vote are design intent and not built.">
 <meta name="twitter:image" content="https://rwally.com/og-card.png">
 </head>
 <body>

--- a/apps/site-next/src/sections/index-marquee/copy.ts
+++ b/apps/site-next/src/sections/index-marquee/copy.ts
@@ -8,9 +8,14 @@
  *     member vote."
  *
  *   NO UPGRADE PATH
- *     A clause of the corpus sentence "The contracts carry no proxy, no upgrade
- *     path, no pause function and no admin key.", matched the same way NO ADMIN
- *     KEY is matched -- as a substring of it.
+ *     `apps/site/faq.html`: "...no proxy and no upgrade path."
+ *
+ *     THE FIRST DRAFT CITED THE WRONG SENTENCE. It said this phrase was a
+ *     substring of "The contracts carry no proxy, no upgrade path, no pause
+ *     function and no admin key." the way NO ADMIN KEY is. It is not -- that
+ *     sentence has a COMMA after "path", not a period, so "No upgrade path."
+ *     does not occur in it. NO ADMIN KEY genuinely does occur in it, which is
+ *     exactly what made the wrong claim read as obviously true.
  *
  *     IT REPLACED "SEVEN IMMUTABLE CONTRACTS." ON 2026-09-09, on the owner's
  *     instruction to stop marketing a contract count. The count was also the one

--- a/apps/site-next/test/site.test.mjs
+++ b/apps/site-next/test/site.test.mjs
@@ -1683,8 +1683,8 @@ test('probe: the purchase ban catches every invitation shape and spares the site
   const SPARED = [
     ...SPARED_FROM_PAGES,
     // RESTORED 2026-09-09. This string was dropped when the five real page sentences replaced the
-    // invented ones, and a review then proved it had been the SOLE pinner of the `some` word
-    // boundary in the first pattern: widening `some` to `some` newly reds exactly this entry and
+    // invented ones, and a review then proved it had been the SOLE pinner of the `some\b` word
+    // boundary in the first pattern: widening `some\b` to `some` newly reds exactly this entry and
     // nothing else. Dropping it left the boundary deletable by anyone who ran the suite and saw
     // green -- which is the specific failure the probe exists to prevent, reintroduced by the commit
     // that was fixing it.
@@ -2347,11 +2347,17 @@ const OWNER_AND_LIVE_STRINGS = [
   // and no admin key.", and "Every position put to a vote." is promo script line 7.
   'The hive decides.',
   // 'Seven immutable contracts.' WAS HERE AND CAME OUT ON 2026-09-09, on the owner's instruction to
-  // stop marketing a contract count. It was the only marquee phrase that needed this list at all;
-  // its replacement, 'No upgrade path.', resolves against the corpus sentence "The contracts carry
-  // no proxy, no upgrade path, no pause function and no admin key." exactly as 'No admin key.' does.
-  // Removing a permitted source string is a tightening -- there is now one fewer sentence that may
-  // appear on the page without the corpus behind it.
+  // stop marketing a contract count. It was the only marquee phrase that needed this list at all,
+  // so removing it is a tightening: one fewer sentence may appear on the page with no corpus behind
+  // it.
+  //
+  // ITS REPLACEMENT, 'No upgrade path.', RESOLVES AGAINST `apps/site/faq.html`, and the first draft
+  // of this comment named the wrong sentence. It claimed the phrase was a substring of "The
+  // contracts carry no proxy, no upgrade path, no pause function and no admin key." the way
+  // 'No admin key.' is. It is not: that sentence has a COMMA after "path", not a period, so
+  // 'No upgrade path.' does not occur in it at all. 'No admin key.' genuinely does, which is what
+  // made the wrong claim read as obviously true. Found by grep, not by eye, and the same grep is
+  // the only way to check the next one.
 
   // --- the live panel's labels, from `src/sections/index-live/copy.ts` ---
   //


### PR DESCRIPTION
Three findings from the review of #232. All three are mine.

## The owner's instruction was half-delivered

`apps/site/index.html` lost the contract count and the chain from its three meta descriptions. **`apps/site-next/index.html` still had all three, word for word.** Six exist across the two apps, and #232's body said "the three meta descriptions" as though that were all of them.

The redesign is not deployed yet, so nothing public was wrong — but it ships the day site-next does, and a half-applied instruction is the kind that gets rediscovered by whoever trusted it was finished.

## The marquee phrase cited a sentence it does not occur in

Both the copy file and the test said `No upgrade path.` is a substring of *"The contracts carry no proxy, no upgrade path, no pause function and no admin key."* the way `No admin key.` is.

It is not — that sentence has a **comma** after "path", not a period. Grepped this time rather than eyeballed: the phrase occurs in exactly one corpus page, `apps/site/faq.html`, in *"The contracts carry no pause function, no proxy and no upgrade path."*

`No admin key.` genuinely **is** a substring of the sentence I named, which is precisely what made the wrong claim read as obviously true.

## Two literal `0x08` bytes where `\b` was intended

A shell heredoc ate the backslash, so the comment restoring the `some\b` word boundary rendered as *"widening `some` to `some`"* — self-contradictory, in the one line whose whole job is to record why that boundary must not be deleted. Rebuilt the backslash from its code point so no shell layer can eat it again. Verified: the file now contains zero `0x08` bytes and the three `some\b` occurrences all read correctly.

## Not fixed here, and worth its own look

The review also found that **none of the four marquee phrases is guarded at all**: the sentence extractor drops anything under four words, and all four are three. That is pre-existing and independent of this change, and widening the extractor is likely to red things across the suite — it wants its own change with its own evidence rather than riding along here.

## Evidence

`npm run gate` PASSED; site-next 46/46.