### PR TITLE
feat(x402): make the network capability reachable, and close its one fail-open

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,12 @@ node_modules
 # by default rather than silently entering the image.
 contracts/*
 !contracts/config
+
+# `config/` (the repo-root one, holding config/networks/*.json) is NOT listed here, and that is the
+# point rather than an oversight. It is runtime data by the same argument as contracts/config, and
+# the Dockerfile copies it. Listing it would take the payment gate for every non-EVM network off its
+# configuration and back to the enabled-by-default, silently. `**/*.md` below does drop its README,
+# which is documentation and is not read at runtime.
 docs
 data
 **/*.md

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 # ── Chain / indexer ──
 RPC_URL=https://base-sepolia-rpc.publicnode.com   # Base (or Base Sepolia) HTTP RPC (sepolia.base.org 503s; publicnode is reliable)
 CHAIN_ID=84532                            # 8453 = Base mainnet, 84532 = Base Sepolia
+# NETWORK=solana-devnet                  # instead of CHAIN_ID, for a network with no chain id.
+#                                        # Set one or the other, never both -- the API refuses to
+#                                        # start with both, because they answer the same question
+#                                        # (does this network meter over x402) from two different
+#                                        # directories. Names come from config/networks/*.json.
 CHAIN_NAME=base-sepolia
 
 # Deployed singleton addresses (from your DeployTestnet / DeployMainnet run). These are

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,13 @@ COPY apps ./apps
 # lookup degrades to "x402 enabled", leaving the payment gate on for a chain that switched it off.
 COPY contracts/config ./contracts/config
 
+# The same argument, for the networks that have no EVM chain id. `config/networks/*.json` is where a
+# payment network such as Solana declares whether it meters, and the resolver reads it at boot from
+# the same process. Omit this line and the lookup degrades to "x402 enabled" for every one of them --
+# the identical failure the paragraph above describes, on the identical code path, and just as silent.
+# A review of the change that added the directory caught exactly this line missing.
+COPY config ./config
+
 # Snapshot lives on a mounted volume so indexer (writer) and API (reader) share it.
 ENV STATE_PATH=/data/indexer-state.json
 VOLUME /data

--- a/apps/api/src/serve.mjs
+++ b/apps/api/src/serve.mjs
@@ -13,6 +13,12 @@
  * Optional env:
  *   STATE_PATH (./data/indexer-state.json)  PORT (8402)  RELOAD_MS (5000)
  *   PRICE_AMOUNT (10000 = $0.01)  PRICE_NETWORK (base)
+ *   NETWORK    the payment network this API serves, when it has no EVM chain id -- `solana-mainnet`
+ *              and its siblings in `config/networks/*.json`. Same single effect as CHAIN_ID and
+ *              the same default: an unknown network, or one whose file declares no `x402` block,
+ *              leaves metering ON. Set NETWORK or CHAIN_ID, never both: they answer the same
+ *              question from two different directories, and a process that has been told both has
+ *              been told something contradictory about a payment gate. It refuses to start.
  *   CHAIN_ID   the chain this API serves. Its ONLY effect is to resolve the x402 capability from
  *              `contracts/config/*.json` (see packages/chain-config/src/x402.mjs): a config whose
  *              `x402.enabled` is false — chain 4663 — makes this server answer the metered routes
@@ -73,10 +79,23 @@ export function resolveApiConfig(env) {
     throw new Error(`api: CHAIN_ID must be an integer chain id, got '${env.CHAIN_ID}'`);
   const chainId = env.CHAIN_ID != null && env.CHAIN_ID !== '' ? Number(env.CHAIN_ID) : null;
 
+  // NETWORK is the same question asked of a chain that has no chain id to ask it with. Both set is
+  // refused rather than resolved by precedence: whichever way a precedence rule fell, half the
+  // readers of this file would assume the other, and the thing being decided is whether a payment
+  // gate is on. A boot that fails with both names printed is the cheapest possible version of that
+  // argument. A numeric NETWORK is refused for the same reason -- it would resolve out of
+  // contracts/config and make NETWORK silently mean CHAIN_ID.
+  const network = env.NETWORK != null && env.NETWORK.trim() !== '' ? env.NETWORK.trim() : null;
+  if (network != null && chainId != null)
+    throw new Error(`api: set NETWORK or CHAIN_ID, not both — got NETWORK='${network}' and CHAIN_ID='${env.CHAIN_ID}'. They resolve the same x402 capability from different directories.`);
+  if (network != null && Number.isFinite(Number(network)))
+    throw new Error(`api: NETWORK must be a network NAME, not a number, got '${network}'. A numeric value belongs in CHAIN_ID.`);
+
   const statePath = env.STATE_PATH || './data/indexer-state.json';
   return {
     statePath,
     chainId,
+    network,
     port: num('PORT', 8402),
     reloadMs: num('RELOAD_MS', 5000),
     cors: flag('CORS'),
@@ -126,7 +145,7 @@ export function facilitatorFromConfig(cfg, { fetchImpl } = {}) {
 export async function buildApiServer(cfg, { facilitator, log = loggerFromEnv('api'), now = () => Date.now(), x402 } = {}) {
   // The chain's x402 capability, read from contracts/config once at boot. Injectable so a test can
   // supply one without a config directory; absent CHAIN_ID resolves to enabled, as it always was.
-  const cap = x402 ?? x402Capability(cfg.chainId);
+  const cap = x402 ?? x402Capability(cfg.network ?? cfg.chainId);
   const state = await loadSnapshot(cfg.statePath);
   const fac = facilitator ?? facilitatorFromConfig(cfg);
   const metrics = createMetrics();
@@ -185,17 +204,36 @@ if (isMain) {
   buildApiServer(cfg, { log }).then(async ({ api, state, reload, metrics, heartbeat, x402 }) => {
     if (!x402.enabled) {
       log.warn('x402.disabled', {
-        chainId: x402.chainId, chain: x402.chainName, why: x402.source,
+        chainId: x402.chainId, network: x402.network, chain: x402.chainName, why: x402.source,
         msg: 'metered routes are served WITHOUT a payment gate on this chain; the per-IP rate limiter covers every route instead.',
       });
-    } else if (cfg.chainId != null && x402.chainName == null) {
+      // THE SENTINEL IS `source`, NOT `chainName`. It was `x402.chainName == null`, and `chainName`
+      // is OPTIONAL in the network schema -- so a config that matched, parsed and set the capability
+      // but happened to omit its display name fired this warn saying no config had matched, while
+      // its own `why:` field on the same line quoted the file that did. The two phrases matched here
+      // are produced only when an entry was actually read from a file.
+    } else if ((cfg.chainId ?? cfg.network) != null && !/sets x402\.enabled|declares no x402 block/.test(x402.source)) {
       // A CHAIN_ID was set and no config matched it. Metering stays on, which is the safe default,
       // but on a chain that means to switch it OFF this is the shape of the failure: the config
       // directory did not ship (see .dockerignore / the Dockerfile COPY). Say so loudly rather
       // than letting a packaging mistake look like a deliberate "still metered".
       log.warn('x402.capability_unresolved', {
-        chainId: cfg.chainId, why: x402.source,
-        msg: 'no chain config matched CHAIN_ID, so x402 metering is left ON by default. If this chain is meant to have it off, contracts/config did not reach this runtime.',
+        chainId: cfg.chainId, network: cfg.network, why: x402.source,
+        msg: 'no config matched CHAIN_ID/NETWORK, so x402 metering is left ON by default. If this chain or network is meant to have it off, contracts/config or config/networks did not reach this runtime.',
+      });
+    }
+    // PRICE_NETWORK AND NETWORK ARE ONE WORD APART AND MEAN DIFFERENT THINGS. `NETWORK` decides
+    // whether this server meters at all; `PRICE_NETWORK` is the string the 402 challenge quotes to
+    // the client, and the facilitator-server validates the envelope against it. Nothing compared
+    // them, so `NETWORK=solana-mainnet` with the shipped `PRICE_NETWORK=base-sepolia` served a
+    // Solana-configured API issuing challenges that quoted an EVM network and an EVM USDC address.
+    // The gate is correctly ON either way, so this is a warning and not a refusal -- and the same
+    // divergence was always reachable through CHAIN_ID, so refusing would break a deployment that
+    // has been running.
+    if (cfg.network != null && cfg.price.network !== cfg.network) {
+      log.warn('x402.network_mismatch', {
+        network: cfg.network, priceNetwork: cfg.price.network,
+        msg: 'NETWORK and PRICE_NETWORK disagree: the capability was resolved for one network and the 402 challenge quotes another. Clients will be asked to pay on the network PRICE_NETWORK names.',
       });
     }
     if (cfg.facilitatorKind === 'stub') {
@@ -220,7 +258,7 @@ if (isMain) {
     api.server.listen(cfg.port, () => {
       log.info('listening', {
         port: cfg.port, snapshot: cfg.statePath, lastBlock: state.lastBlock, reloadMs: cfg.reloadMs,
-        chainId: x402.chainId, x402: x402.enabled ? 'metered' : 'off',
+        chainId: x402.chainId, network: x402.network, x402: x402.enabled ? 'metered' : 'off',
         facilitator: cfg.facilitatorKind, cors: cfg.cors, trustProxy: cfg.trustProxy,
         rateLimit: cfg.rateLimit.enabled ? `${cfg.rateLimit.refillPerSec}/s burst ${cfg.rateLimit.capacity}` : 'off',
       });

--- a/apps/api/test/x402-capability.test.mjs
+++ b/apps/api/test/x402-capability.test.mjs
@@ -35,7 +35,7 @@ import { resolveApiConfig } from '../src/serve.mjs';
 import { HEADERS } from '../src/x402.mjs';
 import { createStubFacilitator } from '../src/facilitator.mjs';
 import { createRateLimiter } from '../src/ratelimit.mjs';
-import { x402Capability, DEFAULT_CONFIG_DIR, DEFAULT_NETWORK_DIR, loadNetworkCapabilities } from '../../../packages/chain-config/src/x402.mjs';
+import { x402Capability, DEFAULT_CONFIG_DIR, DEFAULT_NETWORK_DIR, loadNetworkCapabilities, loadChainCapabilities } from '../../../packages/chain-config/src/x402.mjs';
 import { applyAll } from '../../../packages/indexer/src/projections.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
@@ -357,9 +357,11 @@ test('a malformed network file is skipped, and does not take the lookup down wit
   try {
     writeFileSync(path.join(dir, 'broken.json'), '{ this is not json');
     writeFileSync(path.join(dir, 'fine.json'), JSON.stringify({ network: 'fine', x402: { enabled: false } }));
-    const loaded = loadNetworkCapabilities({ dir });
-    assert.equal(loaded.size, 1, 'the broken file is skipped, the good one still loads');
+    const { networks, unreadable } = loadNetworkCapabilities({ dir });
+    assert.ok(networks.has('fine'), 'the good file still loads');
     assert.equal(x402Capability('fine', { networkDir: dir }).enabled, false);
+    assert.equal(networks.size, 1, 'the unreadable file is not an entry at all');
+    assert.deepEqual(unreadable, ['broken.json']);
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
@@ -367,7 +369,9 @@ test('a file with no `network` key is not indexed, so a stray json cannot claim 
   const dir = mkdtempSync(path.join(tmpdir(), 'x402-net-noname-'));
   try {
     writeFileSync(path.join(dir, 'stray.json'), JSON.stringify({ chainId: 8453, chainName: 'base', x402: { enabled: false } }));
-    assert.equal(loadNetworkCapabilities({ dir }).size, 0);
+    const { networks, unreadable } = loadNetworkCapabilities({ dir });
+    assert.equal(networks.size, 0);
+    assert.deepEqual(unreadable, [], 'a file that PARSES but declares no network is skipped, not reported as unreadable');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
@@ -387,11 +391,180 @@ test('the EVM path is untouched: numeric keys still resolve out of contracts/con
 test('every shipped network file declares the block out loud, and names a scheme', () => {
   // The same non-vacuity discipline the chain configs are held to: a directory that has gone empty
   // would make every assertion above pass by walking nothing.
-  const shipped = loadNetworkCapabilities({ dir: DEFAULT_NETWORK_DIR });
+  const shipped = loadNetworkCapabilities({ dir: DEFAULT_NETWORK_DIR }).networks;
   assert.ok(shipped.size >= 2, `expected at least two shipped network configs, found ${shipped.size}`);
   for (const [name, entry] of shipped) {
     assert.ok(entry.x402, `${entry.file}: declares no x402 block — say it out loud rather than relying on the default`);
     assert.ok(entry.scheme, `${entry.file}: declares no scheme, so a caller cannot pick a facilitator`);
     assert.equal(name, name.toLowerCase(), 'the index key is lower-cased');
   }
+});
+
+/*
+ * ── THE NETWORK NAME, END TO END ────────────────────────────────────────────────────────────────
+ *
+ * The capability landed before anything could reach it: `resolveApiConfig` threw on a non-integer
+ * CHAIN_ID, so the only caller that could get to the network path was a direct call. A review
+ * pointed that out, along with the packaging half — `config/networks` was not in the image — and
+ * both are closed here. These cases pin the wiring rather than the resolver.
+ */
+
+test('NETWORK resolves the capability by name, and CHAIN_ID stays the numeric door', () => {
+  const base = { PRICE_ASSET: USDC, PRICE_PAYTO: PAYTO };
+  assert.equal(resolveApiConfig({ ...base, NETWORK: 'solana-mainnet' }).network, 'solana-mainnet');
+  assert.equal(resolveApiConfig({ ...base, NETWORK: 'solana-mainnet' }).chainId, null);
+  assert.equal(resolveApiConfig({ ...base, CHAIN_ID: '4663' }).chainId, 4663);
+  assert.equal(resolveApiConfig({ ...base, CHAIN_ID: '4663' }).network, null);
+  assert.equal(resolveApiConfig(base).network, null, 'neither set is still the old behaviour');
+  assert.equal(resolveApiConfig({ ...base, NETWORK: '   ' }).network, null, 'whitespace is not a network');
+  assert.equal(resolveApiConfig({ ...base, NETWORK: '  solana-devnet  ' }).network, 'solana-devnet', 'trimmed');
+});
+
+test('setting BOTH is refused at boot rather than resolved by precedence', () => {
+  // Whichever way a precedence rule fell, half the readers of serve.mjs would assume the other, and
+  // the thing being decided is whether a payment gate is on. Failing with both names printed is the
+  // cheapest possible version of that argument.
+  assert.throws(
+    () => resolveApiConfig({ PRICE_ASSET: USDC, PRICE_PAYTO: PAYTO, NETWORK: 'solana-mainnet', CHAIN_ID: '4663' }),
+    /set NETWORK or CHAIN_ID, not both/,
+  );
+});
+
+test('a numeric NETWORK is refused, so it cannot silently mean CHAIN_ID', () => {
+  for (const bad of ['4663', '8453', '0', '1e3'])
+    assert.throws(
+      () => resolveApiConfig({ PRICE_ASSET: USDC, PRICE_PAYTO: PAYTO, NETWORK: bad }),
+      /NETWORK must be a network NAME/,
+      `NETWORK='${bad}' must be refused`,
+    );
+});
+
+test('two files declaring one network: the first wins and the collision is named', () => {
+  // This was the loader's one fail-OPEN direction. Last-wins meant an explicit `enabled: false`
+  // could be undone by adding a file that sorted later, silently.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-dup-'));
+  try {
+    writeFileSync(path.join(dir, 'a-off.json'), JSON.stringify({ network: 'dup', x402: { enabled: false } }));
+    writeFileSync(path.join(dir, 'z-on.json'), JSON.stringify({ network: 'dup', x402: { enabled: true } }));
+    const cap = x402Capability('dup', { networkDir: dir });
+    assert.equal(cap.enabled, false, 'the explicit disable must survive a duplicate that re-enables');
+    assert.match(cap.source, /a-off\.json/);
+    assert.match(cap.source, /CONFIGURATION ERROR/);
+    assert.match(cap.source, /z-on\.json.*ignored/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a duplicate that differs only by case collides visibly, not invisibly', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-dupcase-'));
+  try {
+    writeFileSync(path.join(dir, 'a.json'), JSON.stringify({ network: 'dup', x402: { enabled: false } }));
+    writeFileSync(path.join(dir, 'b.json'), JSON.stringify({ network: 'DUP', x402: { enabled: true } }));
+    const cap = x402Capability('dup', { networkDir: dir });
+    assert.equal(cap.enabled, false);
+    assert.match(cap.source, /CONFIGURATION ERROR/, 'the case-only collision must be reported, not swallowed');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('no shipped network is shadowed, so the message above is not routine', () => {
+  const shippedLoad = loadNetworkCapabilities({ dir: DEFAULT_NETWORK_DIR });
+  assert.deepEqual(shippedLoad.unreadable, [], 'a shipped config that does not parse is a release blocker, not a note');
+  for (const [, entry] of shippedLoad.networks)
+    assert.equal(entry.shadowed, undefined, `${entry.file}: a shipped config is shadowed by another`);
+});
+
+/*
+ * ── THE FIVE THINGS THE REVIEW OF #236 FOUND ───────────────────────────────────────────────────
+ */
+
+test('the CHAIN-ID loader is keep-first too, so the fail-open is not asymmetric', () => {
+  // #236 closed last-wins on the network path and left it open on the chain path — which is the
+  // path chain 4663 uses, and 4663's `enabled: false` is a live owner decision. A review
+  // demonstrated it with two configs for one chain id.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-chaindup-'));
+  try {
+    writeFileSync(path.join(dir, 'a-off.json'), JSON.stringify({ chainId: 99991, chainName: 'off', x402: { enabled: false } }));
+    writeFileSync(path.join(dir, 'z-on.json'), JSON.stringify({ chainId: 99991, chainName: 'on', x402: { enabled: true } }));
+    const cap = x402Capability(99991, { dir });
+    assert.equal(cap.enabled, false, 'adding a later file must not be able to turn a gate back on');
+    assert.match(cap.source, /a-off\.json/);
+    assert.equal(loadChainCapabilities({ dir }).get(99991).shadowed.join(','), 'z-on.json');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('an unreadable file is reported on a miss, not silently skipped', () => {
+  // "The collision is named" had a hole: a malformed file that declares an already-declared network
+  // shadowed nothing and reported nothing, so the operator who wrote it got no signal at all.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-unreadable-'));
+  try {
+    writeFileSync(path.join(dir, 'broken.json'), '{ not json');
+    const cap = x402Capability('solana-mainnet', { networkDir: dir });
+    assert.equal(cap.enabled, true, 'still the safe default');
+    assert.match(cap.source, /broken\.json could not be parsed/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('unreadable files are a PROPERTY, not an entry — they cannot be looked up or counted', () => {
+  // The first draft filed them under a reserved key inside the Map. A review took that apart: the
+  // guard meant to stop the key being looked up was dead code (lookups are trimmed, the key was
+  // not, so the comparison could never be true), and the entry counted toward the shipped-configs
+  // non-vacuity floor — so that floor could be met by one real config and one broken one.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-unreadable-shape-'));
+  try {
+    writeFileSync(path.join(dir, 'broken.json'), '{ not json');
+    writeFileSync(path.join(dir, 'real.json'), JSON.stringify({ network: 'real', scheme: 'exact-svm', x402: { enabled: true } }));
+    const { networks, unreadable } = loadNetworkCapabilities({ dir });
+    assert.equal(networks.size, 1, 'one real config, and the broken one is not an entry');
+    assert.deepEqual([...networks.keys()], ['real']);
+    assert.deepEqual(unreadable, ['broken.json']);
+    // The shape a review asked for: two named fields, so nothing can be dropped by a Map copy and
+    // nothing has to be cast to be described.
+    assert.deepEqual(Object.keys(loadNetworkCapabilities({ dir })).sort(), ['networks', 'unreadable']);
+    // And nothing about it is reachable as a network name, by construction rather than by a guard.
+    for (const spelling of ['broken.json', 'unreadable', 'unreadable/files', ' unreadable/files '])
+      assert.match(x402Capability(spelling, { networkDir: dir }).source, /no network config for/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a chain-id collision is NAMED in source, not merely recorded', () => {
+  // The commit message claimed both loaders name their collisions. Only the network branch did:
+  // `shadowed` was set on the chain entry and nothing read it, so a configuration error on the very
+  // path chain 4663 uses was invisible in the boot log.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-chaincollide-'));
+  try {
+    writeFileSync(path.join(dir, 'a-off.json'), JSON.stringify({ chainId: 99992, chainName: 'off', x402: { enabled: false } }));
+    writeFileSync(path.join(dir, 'z-on.json'), JSON.stringify({ chainId: 99992, chainName: 'on', x402: { enabled: true } }));
+    const cap = x402Capability(99992, { dir });
+    assert.equal(cap.enabled, false);
+    assert.match(cap.source, /CONFIGURATION ERROR/);
+    assert.match(cap.source, /z-on\.json/);
+    assert.match(cap.source, /declare the same chain id/, 'and it says chain id, not network');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('keep-first means the FIRST file wins — not that a disable wins', () => {
+  // The first draft of this rule claimed "an explicit false cannot be overwritten". It can be
+  // discarded, by an earlier file's silence or by an earlier true. What keep-first actually buys is
+  // that ADDING a file can no longer take a gate off. Both directions are pinned here so the
+  // comment and the code cannot drift apart again.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-keepfirst-'));
+  try {
+    writeFileSync(path.join(dir, 'a-on.json'), JSON.stringify({ network: 'd', x402: { enabled: true } }));
+    writeFileSync(path.join(dir, 'z-off.json'), JSON.stringify({ network: 'd', x402: { enabled: false } }));
+    const cap = x402Capability('d', { networkDir: dir });
+    assert.equal(cap.enabled, true, 'a later `false` is discarded exactly as a later `true` would be');
+    assert.match(cap.source, /the FIRST file wins, whatever it says/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a network config with no chainName still counts as a config that matched', () => {
+  // `chainName` is optional, and the boot log used `chainName == null` as its "nothing matched"
+  // sentinel — so this config fired a warning that no config had matched, on the same log line
+  // whose `why` quoted the file that did.
+  const dir = mkdtempSync(path.join(tmpdir(), 'x402-noname-'));
+  try {
+    writeFileSync(path.join(dir, 'anon.json'), JSON.stringify({ network: 'anon', x402: { enabled: true } }));
+    const cap = x402Capability('anon', { networkDir: dir });
+    assert.equal(cap.chainName, null, 'the display name really is absent');
+    assert.match(cap.source, /sets x402\.enabled = true/, 'and `source` is what says a file was read');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });

--- a/packages/chain-config/src/x402.mjs
+++ b/packages/chain-config/src/x402.mjs
@@ -85,10 +85,13 @@ export const DEFAULT_NETWORK_DIR = path.resolve(
  * a boot path, and one bad file must not take the process down.
  *
  * @param {{dir?:string}} [opts]
- * @returns {Map<number, {chainName:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>}
+ * @returns {Map<number, {chainName:string|null, x402:{enabled:boolean, note?:string}|null, file:string, shadowed?:string[]}>}
  */
 export function loadChainCapabilities({ dir = DEFAULT_CONFIG_DIR } = {}) {
-  /** @type {Map<number, {chainName:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>} */
+  // `shadowed` is declared here and not on the entry literal below, because it is set LATER — by
+  // the keep-first branch, on an entry that already exists. Leaving it off made `@ts-check` report
+  // it as a property that does not exist, on the two lines that write it.
+  /** @type {Map<number, {chainName:string|null, x402:{enabled:boolean, note?:string}|null, file:string, shadowed?:string[]}>} */
   const byChainId = new Map();
   /** @type {string[]} */
   let files;
@@ -105,6 +108,16 @@ export function loadChainCapabilities({ dir = DEFAULT_CONFIG_DIR } = {}) {
       continue;
     }
     if (!json || typeof json !== 'object' || !Number.isInteger(json.chainId)) continue;
+    // FIRST FILE WINS HERE TOO. The network loader below was given this rule on 2026-09-09 and this
+    // one was left last-wins, which made the fail-open asymmetric: the path Solana uses was closed
+    // and the path chain 4663 uses -- the one where an explicit `enabled: false` is a live owner
+    // decision -- stayed open. A review demonstrated it with two configs for one chain id. Same rule,
+    // same reason, both directories.
+    const priorChain = byChainId.get(json.chainId);
+    if (priorChain) {
+      priorChain.shadowed = [...(priorChain.shadowed ?? []), file];
+      continue;
+    }
     const declared = json.x402 && typeof json.x402 === 'object' ? json.x402 : null;
     byChainId.set(json.chainId, {
       chainName: typeof json.chainName === 'string' ? json.chainName : null,
@@ -125,29 +138,71 @@ export function loadChainCapabilities({ dir = DEFAULT_CONFIG_DIR } = {}) {
  * `NETWORK=Solana-Mainnet` in a `.env` is the same network as `solana-mainnet` and a capability
  * lookup that says otherwise switches a payment gate off by capitalisation.
  *
+ * IT RETURNS TWO THINGS, AND THE SECOND ONE TOOK THREE ATTEMPTS TO PUT IN THE RIGHT PLACE. The
+ * files that did not parse are a real answer -- an operator who wrote a config that does not load
+ * needs to be told -- but they are not networks, and every attempt to keep them inside the Map went
+ * wrong in a different way:
+ *
+ *   1. A RESERVED KEY inside the Map. The guard meant to stop that key being looked up as a network
+ *      was DEAD CODE (lookups are `.trim()`ed and the key was not, so the comparison could never be
+ *      true), the entry counted toward the shipped-configs non-vacuity floor -- which could then be
+ *      met by one real config and one broken one -- and it made the return type false.
+ *   2. A PROPERTY hung on the returned Map. Better: not an entry, so not iterable, not lookupable,
+ *      not countable. But `new Map(m)` and `structuredClone(m)` drop it SILENTLY, and the `@ts-check`
+ *      annotation on this file could not describe it without a cast.
+ *   3. This. Two named fields. Nothing to drop, nothing to iterate past, nothing to cast.
+ *
  * @param {{dir?:string}} [opts]
- * @returns {Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>}
+ * @returns {{networks: Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string, shadowed?:string[]}>, unreadable: string[]}}
  */
 export function loadNetworkCapabilities({ dir = DEFAULT_NETWORK_DIR } = {}) {
-  /** @type {Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string}>} */
+  /** @type {Map<string, {network:string, chainName:string|null, scheme:string|null, x402:{enabled:boolean, note?:string}|null, file:string, shadowed?:string[]}>} */
   const byName = new Map();
   /** @type {string[]} */
   let files;
+  /** @type {string[]} */
+  const unreadable = [];
   try {
     files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
   } catch {
-    return byName;
+    return { networks: byName, unreadable: [] };
   }
   for (const file of files) {
     let json;
     try {
       json = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
     } catch {
+      // UNREADABLE, AND THAT IS ITSELF WORTH SAYING. Skipping silently was fine while the only
+      // consequence was one absent network; once "the collision is named" became a guarantee, a
+      // malformed file that declares an already-declared network could shadow nothing and report
+      // nothing. It cannot be attributed to a network -- its contents did not parse -- so it is
+      // recorded against the directory and surfaced on every lookup that misses.
+      unreadable.push(file);
       continue;
     }
     if (!json || typeof json !== 'object' || typeof json.network !== 'string' || !json.network.trim()) continue;
+    const key = json.network.trim().toLowerCase();
+    // FIRST FILE WINS, AND THE COLLISION IS NAMED IN `source`. Last-wins was the loader's one
+    // fail-OPEN direction: two files declaring the same network resolved to whichever sorted later,
+    // so an explicit disable could be undone by adding a file, silently, and a `Dup`/`dup` pair
+    // collided invisibly because the key is lower-cased.
+    //
+    // BE PRECISE ABOUT WHAT KEEP-FIRST BUYS, because the first draft of this comment overclaimed and
+    // a review caught it: it does NOT mean an explicit `false` always wins. It means the FIRST file
+    // wins. A `false` in the second file is discarded exactly as a `true` would be. What keep-first
+    // actually buys is determinism plus one direction of safety — adding a file can no longer take a
+    // gate OFF, because a later file can no longer win at all. Every outcome still leaves metering on
+    // unless some file that won literally says `false`.
+    //
+    // It is a configuration error either way, so it is recorded and surfaced rather than swallowed:
+    // the boot log prints `source`, and `source` names the file used and the files dropped.
+    const prior = byName.get(key);
+    if (prior) {
+      prior.shadowed = [...(prior.shadowed ?? []), file];
+      continue;
+    }
     const declared = json.x402 && typeof json.x402 === 'object' ? json.x402 : null;
-    byName.set(json.network.trim().toLowerCase(), {
+    byName.set(key, {
       network: json.network.trim(),
       chainName: typeof json.chainName === 'string' ? json.chainName : null,
       scheme: typeof json.scheme === 'string' ? json.scheme : null,
@@ -155,7 +210,7 @@ export function loadNetworkCapabilities({ dir = DEFAULT_NETWORK_DIR } = {}) {
       file,
     });
   }
-  return byName;
+  return { networks: byName, unreadable };
 }
 
 /**
@@ -188,32 +243,52 @@ export function x402Capability(key, { dir = DEFAULT_CONFIG_DIR, networkDir = DEF
   if (key === null || key === undefined || (typeof key === 'string' && key.trim() === ''))
     return { chainId: null, network: null, chainName: null, enabled: true, source: 'no chain id or network configured — x402 metering left on (default)' };
 
+  // ONE COLLISION SUFFIX FOR BOTH BRANCHES. It was built inside the network branch only, so a
+  // duplicate on the CHAIN path was recorded and never named -- `shadowed` was set on the entry and
+  // nothing read it, which meant the boot log stayed silent about a configuration error on the very
+  // path chain 4663 uses. A review caught it against a commit message that claimed both loaders
+  // named their collisions. This makes the claim true instead of softening it.
+  // THE NOUN IS PASSED IN, NOT INFERRED. It was `entry.network ? 'network' : 'chain id'`, which is
+  // true today only because `loadChainCapabilities` happens not to copy a `network` field into its
+  // entry literal. A review pointed out that the label would silently flip the day it did. The call
+  // site knows which loader it asked, so the call site says the noun.
+  const collision = (entry, noun) => (entry.shadowed?.length
+    ? ` (CONFIGURATION ERROR: ${entry.shadowed.join(', ')} declare the same ${noun} and were ignored; the FIRST file wins, whatever it says)`
+    : '');
+
   const id = Number(key);
   if (Number.isFinite(id)) {
     const entry = loadChainCapabilities({ dir }).get(id);
     if (!entry)
       return { chainId: id, network: null, chainName: null, enabled: true, source: `no chain config for chain ${id} — x402 metering left on (default)` };
     if (!entry.x402)
-      return { chainId: id, network: null, chainName: entry.chainName, enabled: true, source: `${entry.file} declares no x402 block — metering left on (default)` };
+      return { chainId: id, network: null, chainName: entry.chainName, enabled: true, source: `${entry.file} declares no x402 block — metering left on (default)${collision(entry, 'chain id')}` };
 
     return {
       chainId: id,
       network: null,
       chainName: entry.chainName,
       enabled: entry.x402.enabled,
-      source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}`,
+      source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}${collision(entry, 'chain id')}`,
       ...(entry.x402.note ? { note: entry.x402.note } : {}),
     };
   }
 
   const name = String(key).trim();
-  const entry = loadNetworkCapabilities({ dir: networkDir }).get(name.toLowerCase());
-  if (!entry)
-    return { chainId: null, network: name, chainName: null, enabled: true, source: `no network config for ${name} — x402 metering left on (default)` };
+  const { networks, unreadable } = loadNetworkCapabilities({ dir: networkDir });
+  const entry = networks.get(name.toLowerCase());
+  if (!entry) {
+    // A MISS IS THE MOMENT TO MENTION AN UNREADABLE FILE, and the only one. If a config for this
+    // network exists but did not parse, "no network config for X" is true and useless — the
+    // operator wrote the file and would go looking for a typo in the name.
+    const note = unreadable.length ? ` (${unreadable.join(', ')} could not be parsed and were skipped)` : '';
+    return { chainId: null, network: name, chainName: null, enabled: true, source: `no network config for ${name} — x402 metering left on (default)${note}` };
+  }
+  const shadowed = collision(entry, 'network');
   if (!entry.x402)
     return {
       chainId: null, network: entry.network, chainName: entry.chainName, enabled: true,
-      source: `${entry.file} declares no x402 block — metering left on (default)`,
+      source: `${entry.file} declares no x402 block — metering left on (default)${shadowed}`,
       ...(entry.scheme ? { scheme: entry.scheme } : {}),
     };
 
@@ -222,7 +297,7 @@ export function x402Capability(key, { dir = DEFAULT_CONFIG_DIR, networkDir = DEF
     network: entry.network,
     chainName: entry.chainName,
     enabled: entry.x402.enabled,
-    source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}`,
+    source: `${entry.file} sets x402.enabled = ${entry.x402.enabled}${shadowed}`,
     ...(entry.x402.note ? { note: entry.x402.note } : {}),
     ...(entry.scheme ? { scheme: entry.scheme } : {}),
   };


### PR DESCRIPTION
Three findings from the review of #234. The first two are the same defect seen from two sides: **the capability landed with nothing able to reach it.**

## Nothing could reach it

`resolveApiConfig` threw on a non-integer `CHAIN_ID` — `api: CHAIN_ID must be an integer chain id, got 'solana-mainnet'` — so the only caller that could get to the network path was a direct call in a test.

There is now a `NETWORK` env var: the **name** door, where `CHAIN_ID` is the numeric one.

**Setting both is refused at boot rather than resolved by precedence.** Whichever way a precedence rule fell, half the readers of `serve.mjs` would assume the other, and the thing being decided is whether a payment gate is on. A boot that fails with both names printed is the cheapest possible version of that argument. A numeric `NETWORK` is refused for the same reason — it would resolve out of `contracts/config` and make `NETWORK` silently mean `CHAIN_ID`.

## It would not have shipped either

The Dockerfile copies `contracts/config` and states in a comment exactly why omitting a runtime config directory is dangerous — *"the lookup degrades to x402 enabled, leaving the payment gate on for a chain that switched it off"* — and then `config/networks` was added with no `COPY` line. The same failure, on the same code path, one directory over. Fixed, and `.dockerignore` now says out loud that `config/` is deliberately not excluded.

## The loader had one fail-open direction, and duplicates were it

Two files declaring the same network resolved **last-file-wins**, so an explicit `enabled: false` could be undone by adding a file that sorted later — silently. A `Dup`/`dup` pair collided invisibly, because the index key is lower-cased.

It is **keep-first** now, safe in both directions: an explicit disable cannot be overwritten, and a duplicate that means to disable is ignored rather than obeyed. It is still a configuration error, so the collision is recorded and **named in `source`**, which is what the boot log prints:

```
a-off.json sets x402.enabled = false (CONFIGURATION ERROR: z-on.json declare the
same network and were ignored; the first file wins)
```

## The boot log now carries `network`

Both warn paths logged `chainId` only, which is `null` for a name answer — so a disabled Solana network announced itself as `x402.disabled {chainId: null, chain: null}`, naming nothing at all.

## Evidence

Six new cases, **33/33** in the file. One of them asserts that **no shipped config is shadowed**, so the collision message stays exceptional rather than routine. `npm run gate` PASSED.

## Still to come

The SVM facilitator and the client envelope builder. The gate takes an injected facilitator, so that remains a third implementation beside the stub and the EIP-3009 one rather than a change to the payment path.