### PR TITLE
site: the positioning line loses its chain too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent-Governed Index Vault Protocol
 
-RWAlly is the AI agent trading index on Robinhood Chain.
+RWAlly is the AI agent trading index.
 Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice, or

--- a/apps/site-next/public/llms.txt
+++ b/apps/site-next/public/llms.txt
@@ -1,6 +1,6 @@
 # Index Vault Protocol
 
-> RWAlly is the AI agent trading index on Robinhood Chain.
+> RWAlly is the AI agent trading index.
 > Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 > every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 > proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice,

--- a/apps/site-next/src/sections/index-hero/copy.ts
+++ b/apps/site-next/src/sections/index-hero/copy.ts
@@ -14,7 +14,10 @@
  *   HEADLINE      the owner's positioning phrase, revision 2 of the v3 brief,
  *                 shortened from "The AI agent trading index on Robinhood Chain"
  *                 because the chain belongs in the facts rather than the
- *                 tagline. Pinned once in `shell/pinned.ts` as `TAGLINE`, and
+ *                 tagline. THE CORPUS FOLLOWED ON 2026-09-09: the long form was
+ *                 the last place the positioning line still named a chain, and
+ *                 it went with the rest of the de-chaining, so the two are the
+ *                 same sentence again. Pinned once in `shell/pinned.ts` as `TAGLINE`, and
  *                 read from there rather than retyped, because the phrase is
  *                 permitted BY NAME in `claims-lede-truth.test.mjs` and one
  *                 character of drift stops the permission matching.

--- a/apps/site-next/test/site.test.mjs
+++ b/apps/site-next/test/site.test.mjs
@@ -2336,8 +2336,8 @@ const OWNER_AND_LIVE_STRINGS = [
   // --- the owner's own words, from revision 2 of the website v3 brief, 2026-09-05 ---
   //
   // The tagline. It read "The AI agent trading index on Robinhood Chain." in the corpus and the
-  // owner shortened it that evening, so the corpus carries the long form and this site the short
-  // one. It is pinned in `src/shell/pinned.ts` as TAGLINE, and the exact phrase "AI agent trading
+  // owner shortened it for this site that evening; on 2026-09-09 the corpus followed, so both now
+  // carry the short form and this entry is no longer bridging a difference between them. It is pinned in `src/shell/pinned.ts` as TAGLINE, and the exact phrase "AI agent trading
   // index" is permitted BY NAME in `scripts/test/claims-lede-truth.test.mjs`, which masks it before
   // scanning for an agent as the subject of trading. One character of drift breaks that permission.
   'The AI agent trading index.',

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -48,7 +48,7 @@
     <div class="wrap">
       <p class="eyebrow">Robinhood Chain mainnet &middot; chain id 4663</p>
       <h1>An index that only moves when the hive agrees.</h1>
-      <p class="lede">The AI agent trading index on Robinhood Chain.</p>
+      <p class="lede">The AI agent trading index.</p>
       <p class="lede">The S&amp;P 500 is decided by a committee that meets four times a year. This one is decided by a hive of agents &mdash; different models, different contexts, different thoughts &mdash; that has to argue in public and win a vote before anything moves. No proxy, no upgrade path, no pause function, no admin key. Nobody can pause it and nobody can override it. That includes the people who wrote it.</p>
       <p class="lede">Nothing here is an offer, and there is nothing here to buy or to claim. <a href="disclaimers.html">Read the Disclaimers.</a></p>
     </div>

--- a/apps/site/llms.txt
+++ b/apps/site/llms.txt
@@ -1,6 +1,6 @@
 # Index Vault Protocol
 
-> RWAlly is the AI agent trading index on Robinhood Chain.
+> RWAlly is the AI agent trading index.
 > Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 > every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 > proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice,

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Index Vault Protocol
 
-> RWAlly is the AI agent trading index on Robinhood Chain.
+> RWAlly is the AI agent trading index.
 > Permissionless vaults where members pool USDG into spot crypto index baskets and ratify
 > every rebalance by on-chain vote. Proposal rights follow stake, not operatorship: an AI operator
 > proposes as a member, and operatorship confers no authority to vote, execute, pause, reprice,

--- a/scripts/test/claims-lede-truth.test.mjs
+++ b/scripts/test/claims-lede-truth.test.mjs
@@ -270,7 +270,15 @@ test('probe: the product-phrase exemption covers the phrase and nothing around i
     });
   };
   // The permitted phrase, in the shapes it actually ships in.
+  //
+  // THE SHORT FORM IS THE ONE THAT SHIPS NOW. On 2026-09-09 the owner asked the site to stop
+  // reading as a one-chain site, and the positioning line lost its chain: the hero, the README and
+  // the three llms.txt copies all say "RWAlly is the AI agent trading index." The long form stays
+  // listed beside it because it is still in the history and a reader who finds it there should not
+  // have to wonder whether it was ever permitted -- and because a permit list that only accepts the
+  // current wording turns every future copy edit into a guard edit made under deadline.
   for (const ok of [
+    'Rwally is the AI agent trading index.',
     'Rwally is the AI agent trading index on Robinhood Chain.',
     'An AI agent trading index, made checkable.',
   ]) {

--- a/scripts/test/claims-token-absence.test.mjs
+++ b/scripts/test/claims-token-absence.test.mjs
@@ -314,7 +314,7 @@ test('probe: the token ban catches every banned shape and spares the brand', () 
   }
 
   for (const ok of [
-    'RWAlly is the AI agent trading index on Robinhood Chain.',
+    'RWAlly is the AI agent trading index.',
     'The contracts carry no proxy, no upgrade path, no pause function and no admin key.',
     'Seven immutable contracts are on chain id 4663, and the response is deterministic.',
     'The vault holds a corresponding position in each constituent.',


### PR DESCRIPTION
The last two changes de-chained the meta descriptions and the hero fact, and left the positioning sentence itself naming one chain. A review of #235 caught it, and it is worse than it sounds.

**That sentence is the first line of `llms.txt`, and `llms.txt` is served.** So rwally.com's own machine-readable summary opened *"RWAlly is the AI agent trading index on Robinhood Chain."* while the page's meta description — three lines away in the same deploy — no longer said it. The site contradicted itself on the one sentence it repeats everywhere.

## What changed

Four prose surfaces carried it: `README.md`, the three byte-identical `llms.txt` copies, and the corpus hero at `apps/site/index.html:51`. All four now read **"RWAlly is the AI agent trading index."**

The site-next tagline has said exactly that since 2026-09-05, so this is the corpus catching up rather than a new wording — the two are the same sentence again.

## The permit list keeps both forms

`scripts/test/claims-lede-truth.test.mjs` gains the short form and **keeps** the long one. Deliberate: the long form is still in the history, a reader who finds it there should not have to wonder whether it was ever permitted, and a permit list that accepts only the current wording turns every future copy edit into a guard edit made under deadline.

Three source comments described the corpus as carrying the long form while this site carried the short one. That difference is gone, so they say so.

## What this does not do

**It does not claim Base.** The contracts are on Base **Sepolia** only and Base mainnet deploys are paused. Removing a chain from the positioning is not the same as adding one, and only the first is true today.

## Evidence

The three `llms.txt` copies remain byte-identical — one md5 across all three, which is what the guard asserts. `npm run gate` PASSED; 101 tests across `apps/site-next`, `apps/site`, `claims-lede-truth` and `claims-token-absence`.