### PR TITLE
fix(rpc): stop recommending an endpoint that prunes logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,20 @@
 # Copy to `.env` and fill in. Never commit a real .env. Neither process holds a private key.
 
 # ── Chain / indexer ──
-RPC_URL=https://base-sepolia-rpc.publicnode.com   # Base (or Base Sepolia) HTTP RPC (sepolia.base.org 503s; publicnode is reliable)
+RPC_URL=https://sepolia.base.org          # Base (or Base Sepolia) HTTP RPC.
+# THIS SAID publicnode, AND "publicnode is reliable", UNTIL 2026-09-09. It is reliable for state
+# reads and it PRUNES LOGS AND RECEIPTS: `eth_call` and `eth_getBlockByNumber` answer correctly, so
+# it looks entirely healthy, while `eth_getLogs` over an older range returns [] and
+# `eth_getTransactionReceipt` returns null for transactions that certainly landed. Measured over
+# blocks 46,307,100-46,307,300 on the Base Sepolia VaultFactory: sepolia.base.org and
+# base-sepolia.drpc.org each returned the VaultCreated event, publicnode returned none -- while all
+# three agreed on `vaultCount()` and `allVaults(0)`. An absent log there is indistinguishable from
+# an event that never happened, and reading it as the latter cost a round of wrong conclusions
+# written into this repository as fact. The indexer reads logs for a living, so it is the process
+# this matters most for.
+#
+# sepolia.base.org does intermittently 503 -- that part of the old note was true, and it is why
+# publicnode was chosen. A flaky endpoint fails loudly and you retry; a pruning one does not.
 CHAIN_ID=84532                            # 8453 = Base mainnet, 84532 = Base Sepolia
 # NETWORK=solana-devnet                  # instead of CHAIN_ID, for a network with no chain id.
 #                                        # Set one or the other, never both -- the API refuses to

--- a/docs/TESTNET-CHECKLIST.md
+++ b/docs/TESTNET-CHECKLIST.md
@@ -37,14 +37,29 @@ too: replace the account flags with `--ledger` everywhere.
 ## 2. Environment
 
 ```bash
-export BASE_SEPOLIA_RPC="https://base-sepolia-rpc.publicnode.com"   # or your own endpoint
+export BASE_SEPOLIA_RPC="https://sepolia.base.org"                 # or your own FULL-HISTORY endpoint
 export ETHERSCAN_API_KEY="<your key>"                               # only needed for --verify
 export SMOKE_SIGNER_ARGS="--account deployer --password-file $HOME/.secrets/deployer.pw"
 ```
 
-The official `https://sepolia.base.org` endpoint intermittently returns 503s; publicnode has
-been reliable. Any Base Sepolia RPC works — the scripts assert `chainId == 84532` before
-sending anything.
+**Do not use `base-sepolia-rpc.publicnode.com`, which this section recommended until
+2026-09-09.** It is reliable for state reads and it **prunes logs and receipts**: `eth_call` and
+`eth_getBlockByNumber` answer correctly, so it looks healthy, while `eth_getLogs` over an older
+range returns `[]` and `eth_getTransactionReceipt` returns `null` for transactions that certainly
+landed. Measured across blocks 46,307,100–46,307,300 on the VaultFactory, `sepolia.base.org` and
+`base-sepolia.drpc.org` each returned the `VaultCreated` event and publicnode returned none — while
+all three agreed on `vaultCount()` and `allVaults(0)`. An absent log there cannot be told apart from
+an event that never happened, and reading it as the latter cost a round of wrong conclusions
+committed to this repository as chain readings.
+
+`sepolia.base.org` does intermittently 503, which is why publicnode was recommended in the first
+place, and that trade is the wrong way round: a flaky endpoint fails loudly and you retry, a pruning
+one answers confidently and wrong. If you need a fallback, use `base-sepolia.drpc.org` — it served
+the same event, with an occasional `code 19` retry.
+
+Any FULL-HISTORY Base Sepolia RPC works — the scripts assert `chainId == 84532` before sending
+anything, and `scripts/soak/lib.mjs`'s `assertLogsServed()` refuses to run a drill against an
+endpoint that cannot produce a log it can prove exists.
 
 ## 3. Deploy (one command)
 
@@ -159,9 +174,9 @@ Then check on [sepolia.basescan.org](https://sepolia.basescan.org): each address
 
 ## 6. Troubleshooting
 
-- **RPC 503 / “no backend healthy”** — the default `sepolia.base.org` endpoint is flaky; use
-  publicnode (§2) or a provider key. The smoke runner is resumable, so a mid-run RPC outage
-  costs nothing: re-run the same command.
+- **RPC 503 / “no backend healthy”** — `sepolia.base.org` is flaky. Retry, or use
+  `base-sepolia.drpc.org` or a provider key — **not publicnode, which prunes logs** (§2). The
+  smoke runner is resumable, so a mid-run RPC outage costs nothing: re-run the same command.
 - **`StaleOracle` warning in preflight** — the asset's single Chainlink feed idled past its
   configured heartbeat (86,400 s on this testnet). The breaker is working as designed (K-4), and
   with one feed per asset there is no second source to fall back to. The no-op lifecycle never prices a non-zero basket balance, so

--- a/scripts/live-x402-run.mjs
+++ b/scripts/live-x402-run.mjs
@@ -50,7 +50,9 @@ import { createProtocolClient } from '../packages/agent-sdk/src/index.mjs';
 import { seed } from '../packages/reference-agent/fixtures/seed-snapshot.mjs';
 
 const TESTNET_CHAIN_IDS = new Set([84532, 11155111, 31337, 1337]);
-const DEFAULT_RPC = 'https://base-sepolia-rpc.publicnode.com';
+// NOT publicnode: it prunes logs and receipts, and this runner reads receipts for its own fee
+// accounting. See the note in `.env.example` for the measurement.
+const DEFAULT_RPC = 'https://sepolia.base.org';
 const BASE_SEPOLIA_USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
 
 /** Hard ceilings. This script exists to move a few cents; anything larger is a mistake. */

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -20,7 +20,8 @@
  * none is supplied via --password-file, cast prompts on YOUR terminal (stdin is inherited).
  *
  * Environment:
- *   BASE_SEPOLIA_RPC   RPC url            (default: https://base-sepolia-rpc.publicnode.com)
+ *   BASE_SEPOLIA_RPC   RPC url            (default: https://sepolia.base.org -- publicnode
+ *                                          prunes logs and receipts, see .env.example)
  *   SMOKE_SIGNER_ARGS  cast signer flags  (required; e.g. "--account deployer --password-file .pw")
  *   DEPLOY_JSON        forge broadcast output
  *                      (default: contracts/broadcast/DeployTestnet.s.sol/84532/run-latest.json)
@@ -38,7 +39,9 @@ import { PROPOSAL_SIG, decodeProposal } from './lib/proposal-decode.mjs';
 import { classifyProposal } from './proposal-recovery.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://base-sepolia-rpc.publicnode.com';
+// NOT publicnode: it prunes logs and receipts, and this script decodes phase results FROM
+// RECEIPTS. See the note in `.env.example` for the measurement.
+const RPC = process.env.BASE_SEPOLIA_RPC ?? 'https://sepolia.base.org';
 const CAST = process.env.CAST ?? 'cast';
 const DEPLOY_JSON = process.env.DEPLOY_JSON
   ?? path.join(ROOT, 'contracts', 'broadcast', 'DeployTestnet.s.sol', '84532', 'run-latest.json');

--- a/scripts/soak/agent-policy.mjs
+++ b/scripts/soak/agent-policy.mjs
@@ -26,7 +26,9 @@ export const TESTNET_CHAIN_IDS = new Set([84532, 11155111, 31337, 1337]);
  * @param {Record<string, string|undefined>} env
  * @returns {{keystore:string, password:string, apiBaseUrl:string, rpcUrl:string}}
  */
-export function resolveAgentRunConfig(env, { defaultRpc = 'https://base-sepolia-rpc.publicnode.com' } = {}) {
+// The default matches `lib.mjs`'s deliberately -- publicnode prunes logs, and the two names
+// resolve with the same `||` precedence, so a split default is a split view of the chain.
+export function resolveAgentRunConfig(env, { defaultRpc = 'https://sepolia.base.org' } = {}) {
   const problems = [];
   if (env[EXECUTE_ENV_VAR] !== 'yes') problems.push(`${EXECUTE_ENV_VAR} is not set to "yes"`);
   if (!env.SOAK_AGENT_KEYSTORE) problems.push('SOAK_AGENT_KEYSTORE (path to the throwaway keystore) is not set');

--- a/scripts/soak/oracle-sampler.mjs
+++ b/scripts/soak/oracle-sampler.mjs
@@ -63,7 +63,9 @@ import { fileURLToPath } from 'node:url';
 import { assertLiveChainId, deploymentPath, loadDeployment } from './deployment.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const RPC = process.env.SOAK_RPC || process.env.BASE_SEPOLIA_RPC || 'https://base-sepolia-rpc.publicnode.com';
+// Same default as `lib.mjs`: publicnode prunes logs, and a sampler on a different endpoint
+// from the drills it feeds is a second opinion nobody asked for.
+const RPC = process.env.SOAK_RPC || process.env.BASE_SEPOLIA_RPC || 'https://sepolia.base.org';
 const CAST = process.env.CAST ?? 'cast';
 const SERIES = process.env.SOAK_SERIES ?? path.join(ROOT, 'data', 'oracle-series.jsonl');
 const SAMPLE_MS = Number(process.env.SOAK_SAMPLE_MS ?? 120_000);


### PR DESCRIPTION
fix(rpc): stop recommending an endpoint that prunes logs

`base-sepolia-rpc.publicnode.com` **prunes logs and receipts.** `eth_call` and
`eth_getBlockByNumber` answer correctly, so it looks entirely healthy, while
`eth_getLogs` over an older range returns `[]` and `eth_getTransactionReceipt`
returns `null` for transactions that certainly landed.

Measured 2026-09-09 across blocks 46,307,100-46,307,300 on the Base Sepolia
VaultFactory 0xc1cb7824…9743:

    sepolia.base.org        -> 1 log  (VaultCreated, topics[1] = 0xb940d71b…)
    base-sepolia.drpc.org   -> 1 log  (the same one)
    publicnode              -> 0 logs

while `vaultCount()` returned 7 and `allVaults(0)` returned that vault on ALL
THREE. State reads agree; log reads do not.

An empty `eth_getLogs` is exactly what a range with no events returns, so there
is no tell. Reading one as the other produced three sentences of invented chain
history in `scripts/soak/` and shipped them in a pull request as readings.
PR #240 retracts those and adds `assertLogsServed()`, a positive control that
refuses to run a drill against an endpoint that cannot produce a log the factory
proves exists. This is the other half: the places that TOLD people to use it.

  - `.env.example` — the line every operator copies. It said "sepolia.base.org
    503s; publicnode is reliable". The 503s are real, and that trade is the wrong
    way round: a flaky endpoint fails loudly and you retry; a pruning one answers
    confidently and wrong. The indexer reads logs for a living.
  - `docs/TESTNET-CHECKLIST.md` §2 and §6 — same recommendation, twice.
  - `scripts/smoke-test.mjs` — which decodes phase results FROM RECEIPTS.
  - `scripts/live-x402-run.mjs` — which reads receipts for its own fee accounting.
  - `scripts/soak/agent-policy.mjs` and `scripts/soak/oracle-sampler.mjs` — these
    only `eth_call`, so they were not exposed, but they resolve the same two env
    names with the same precedence as `lib.mjs`. A split default is a split view
    of the chain, and the next reader cannot tell which parts were safe.

`base-sepolia.drpc.org` is the fallback where one is wanted: it served the same
event, with an occasional `code 19` retry.

LEFT ALONE DELIBERATELY: `docs/TESTNET-REPORT.md`, `docs/SOAK-REPORT.md`,
`docs/RESTORE-DRILL.md` and `docs/X402-LIVE-REPORT.md`. Those are past-tense
records of runs that did use publicnode, and they are true. Rewriting a record to
match today's advice is how a record stops being one.

The only live default still pointing at publicnode after this is
`scripts/soak/lib.mjs:41`, which PR #240 changes in the same direction; whichever
lands second rebases through it.

Gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)