### PR TITLE
fix(api): a member with a Mode-F lock could not see that their stake does not vote

### DIFF
--- a/apps/api/test/openapi-vaultview.test.mjs
+++ b/apps/api/test/openapi-vaultview.test.mjs
@@ -23,7 +23,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { applyAll, vaultView } from '../../../packages/indexer/src/projections.mjs';
+import { applyAll, vaultView, memberPosition } from '../../../packages/indexer/src/projections.mjs';
 
 const V = '0x' + '1'.repeat(40);
 const A = '0x' + 'a'.repeat(40);
@@ -139,5 +139,38 @@ test('the OpenAPI VaultView schema declares nothing the route does not return', 
   const state = applyAll([ev('VaultCreated', 1, 0, { creator: A, usdc: A, capacityCapUsdc: 0n })]);
   const returned = new Set(Object.keys(vaultView(state, V)));
   const phantom = (await vaultViewSchemaKeys()).filter((k) => !returned.has(k));
+  assert.deepEqual(phantom, [], `declared in openapi.yaml but never returned: ${phantom.join(', ')}`);
+});
+
+/**
+ * `GET /vaults/{addr}/members/{addr}` is the same asymmetry as the vault route — its body is
+ * whatever `memberPosition` returns — and it was WORSE off: the path was served by server.mjs and
+ * did not appear in openapi.yaml at all, so no schema existed for a field to drift from. The same
+ * derived check therefore applies here, in both directions.
+ */
+async function memberPositionSchemaKeys() {
+  const lines = await schemaLines();
+  return propertyKeysAt(lines, schemaStart(lines, 'MemberPosition'), 4);
+}
+
+test('every field GET /vaults/{addr}/members/{addr} returns is declared in the OpenAPI MemberPosition schema', async () => {
+  // A member with a queued Mode-F exit, so the fields that only appear on a locked position are
+  // exercised rather than skipped.
+  const state = applyAll([
+    ev('VaultCreated', 1, 0, { creator: A, usdc: A, capacityCapUsdc: 0n }),
+    ev('DepositActivated', 2, 0, { member: A, sharesMinted: 100n }),
+    ev('ExitQueued', 3, 0, { member: A, shares: 50n }),
+  ]);
+  const returned = Object.keys(memberPosition(state, V, A));
+  const declared = new Set(await memberPositionSchemaKeys());
+  const undocumented = returned.filter((k) => !declared.has(k));
+  assert.deepEqual(undocumented, [],
+    `served by the paid /vaults/{addr}/members/{addr} route but not declared in docs/api/openapi.yaml: ${undocumented.join(', ')}`);
+});
+
+test('the OpenAPI MemberPosition schema declares nothing the route does not return', async () => {
+  const state = applyAll([ev('VaultCreated', 1, 0, { creator: A, usdc: A, capacityCapUsdc: 0n })]);
+  const returned = new Set(Object.keys(memberPosition(state, V, A)));
+  const phantom = (await memberPositionSchemaKeys()).filter((k) => !returned.has(k));
   assert.deepEqual(phantom, [], `declared in openapi.yaml but never returned: ${phantom.join(', ')}`);
 });

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -295,29 +295,39 @@ components:
             fraction — it is denominated in total supply, which includes locked and non-voting
             stake.
         queuedExitShares:
-          type: string
+          type: [string, 'null']
           description: >-
             decimal string — shares locked by an outstanding queued Mode-F exit, 0 when there is
             none. Mode-F queues an exit instead of settling it when the vault has a pending
             execution; the shares stay outstanding and still gain and lose with the vault, and are
             excluded from voting-eligible stake until the exit settles. Settlement is a separate
             settleQueuedExit(member) call that anyone can make once no execution is pending, and a
-            queued exit cannot be cancelled.
+            queued exit cannot be cancelled. null in the one case where the amount is UNKNOWN
+            rather than zero — the indexer knows this member has an outstanding queued exit but
+            not its size, which happens after resuming a state snapshot written before queued-exit
+            sizes were recorded. Do not read that null as 0; votingEligibleNote always says so, and
+            votingEligibleShares is null alongside it.
         votingEligibleShares:
-          type: string
+          type: [string, 'null']
           description: >-
             decimal string — the live voting weight, mirroring VaultCore.votingEligibleShares:
             zero when the member is the vault's registered parent vault (a non-voting member), and
             otherwise shares minus queuedExitShares. This is the LIVE term only. Governance bounds a
             vote by min(snapshot weight at proposal creation, this), so a non-zero value here does
             not on its own establish that a vote would carry weight; a zero does establish that it
-            would not.
+            would not. null when queuedExitShares is null, i.e. when the withheld amount is unknown
+            — some non-zero part of the holding is locked and the exact remainder is not derivable
+            here, so no number is served rather than one that would over-report the weight that
+            votes. Read VaultCore.votingEligibleShares(member) on the vault for the exact figure.
+            The parent-vault zero is still exact in that state, because the contract returns 0 for
+            the parent before any subtraction.
         votingEligibleNote:
           type: [string, 'null']
           description: >-
-            null when nothing is withheld. Otherwise a human-readable sentence naming what is
-            withheld, why, and how it resolves — so a zero voting weight beside a material holding
-            is explained rather than merely reported.
+            null when nothing is withheld and nothing is unknown. Otherwise a human-readable
+            sentence naming what is withheld or unknown, why, and how it resolves — so a zero or
+            absent voting weight beside a material holding is explained rather than merely
+            reported. It is never null while votingEligibleShares is null.
     LeaderboardRow:
       type: object
       properties:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -118,6 +118,32 @@ paths:
               schema: { $ref: '#/components/schemas/VaultView' }
         '402': { $ref: '#/components/responses/PaymentRequired' }
         '404': { description: Unknown vault }
+  /vaults/{address}/members/{member}:
+    get:
+      summary: One member's position in one vault, and the weight of it that can vote (metered)
+      operationId: getMemberPosition
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema: { type: string, pattern: '^0x[0-9a-fA-F]{40}$' }
+        - name: member
+          in: path
+          required: true
+          schema: { type: string, pattern: '^0x[0-9a-fA-F]{40}$' }
+      responses:
+        '200':
+          description: >-
+            Member position. A member with no shares in the vault is not an error: the route
+            returns zeros rather than a 404.
+          headers:
+            payment-response:
+              schema: { type: string }
+              description: JSON receipt of the settled x402 payment.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/MemberPosition' }
+        '402': { $ref: '#/components/responses/PaymentRequired' }
   /operators/leaderboard:
     get:
       summary: Operator leaderboard — all attested vaults, no cherry-picking (metered)
@@ -247,6 +273,51 @@ components:
             againstWeight: { type: string }
             revealedWeight: { type: string }
             revealedVoters: { type: integer }
+    MemberPosition:
+      type: object
+      description: >-
+        A member's holding in one vault, and separately the part of it that carries a vote. The two
+        are different numbers and the difference is silent on-chain, which is what this schema
+        exists to make legible: a member can hold a fifth of a vault and have a voting-eligible
+        weight of zero.
+      properties:
+        vault: { type: string }
+        member: { type: string }
+        shares:
+          type: string
+          description: >-
+            WAD, decimal string. Shares held, INCLUDING any locked by a queued exit: shares burn at
+            settlement, never at request.
+        shareOfVaultBps:
+          type: integer
+          description: >-
+            shares as a fraction of totalShares, in basis points. A holding fraction, NOT a voting
+            fraction — it is denominated in total supply, which includes locked and non-voting
+            stake.
+        queuedExitShares:
+          type: string
+          description: >-
+            decimal string — shares locked by an outstanding queued Mode-F exit, 0 when there is
+            none. Mode-F queues an exit instead of settling it when the vault has a pending
+            execution; the shares stay outstanding and still gain and lose with the vault, and are
+            excluded from voting-eligible stake until the exit settles. Settlement is a separate
+            settleQueuedExit(member) call that anyone can make once no execution is pending, and a
+            queued exit cannot be cancelled.
+        votingEligibleShares:
+          type: string
+          description: >-
+            decimal string — the live voting weight, mirroring VaultCore.votingEligibleShares:
+            zero when the member is the vault's registered parent vault (a non-voting member), and
+            otherwise shares minus queuedExitShares. This is the LIVE term only. Governance bounds a
+            vote by min(snapshot weight at proposal creation, this), so a non-zero value here does
+            not on its own establish that a vote would carry weight; a zero does establish that it
+            would not.
+        votingEligibleNote:
+          type: [string, 'null']
+          description: >-
+            null when nothing is withheld. Otherwise a human-readable sentence naming what is
+            withheld, why, and how it resolves — so a zero voting weight beside a material holding
+            is explained rather than merely reported.
     LeaderboardRow:
       type: object
       properties:

--- a/packages/indexer/src/projections.mjs
+++ b/packages/indexer/src/projections.mjs
@@ -122,6 +122,13 @@ export function emptyState() {
     /** @type {Set<string>} */ adapters: new Set(), // execution-adapter addresses, learned from RebalanceExecuted
     /** @type {Map<string, Set<string>>} */
     queuedExits: new Map(), // vault -> members with an OUTSTANDING queued Mode-F exit (see `apply`)
+    /** @type {Map<string, Map<string, bigint>>} */
+    // vault -> member -> the SIZE of that outstanding queue entry. Deliberately a second structure
+    // rather than a `Map<member,bigint>` replacing the Set above: `queuedExits` is serialized as a
+    // flat array of members (store.mjs) and store.test.mjs pins that on-disk shape, so widening it
+    // would turn an observability fix into a snapshot-format migration. The two are written and
+    // cleared in the same two `apply` cases, and store.test.mjs pins both round-trips.
+    queuedExitShares: new Map(),
     lastBlock: 0,
     lastLogIndex: -1,
   };
@@ -176,6 +183,16 @@ function queuedExitSet(state, vault) {
     state.queuedExits.set(vault, q);
   }
   return q;
+}
+
+/** Member -> outstanding queued-exit size for `vault` (created on demand). */
+function queuedExitShareBook(state, vault) {
+  let b = state.queuedExitShares.get(vault);
+  if (!b) {
+    b = new Map();
+    state.queuedExitShares.set(vault, b);
+  }
+  return b;
 }
 
 function shareBook(state, vault) {
@@ -275,9 +292,13 @@ export function apply(state, e) {
     case 'ExitQueued':
       // VaultCore.requestExit allows ONE queued exit per member at a time
       // (`queuedExitShares[msg.sender] == 0`, ExitAlreadyQueued) and a queued exit is
-      // irrevocable, so this set holds at most one entry per member and never needs a size.
+      // irrevocable, so this set holds at most one entry per member and needs no per-member count.
       ensureVault(state, e.vault).exitQueuedCount += 1;
       queuedExitSet(state, e.vault).add(a.member);
+      // The SIZE of the entry, not only its existence: `requestExit(shares)` accepts any amount up
+      // to the balance, so a queued exit subtracts from voting-eligible stake rather than zeroing
+      // it, and `memberPosition` cannot state the withheld weight without this.
+      queuedExitShareBook(state, e.vault).set(a.member, big(a.shares ?? 0n));
       break;
     case 'ExitSettled': {
       const v = ensureVault(state, e.vault);
@@ -287,6 +308,7 @@ export function apply(state, e) {
       // path that clears `queuedExitShares` — so the next ExitSettled for a queued member is
       // necessarily the settlement of that queued exit, and every other ExitSettled is Mode I.
       if (queuedExitSet(state, e.vault).delete(a.member)) v.modeFSettledCount += 1;
+      queuedExitShareBook(state, e.vault).delete(a.member); // the lock ends with the settlement
       creditShares(state, e.vault, a.member, -big(a.sharesBurned));
       break;
     }
@@ -468,16 +490,68 @@ export function queuedExitBacklog(state, vault) {
   return state.queuedExits.get(vault)?.size ?? 0;
 }
 
-/** A member's share position in a vault (0 if none). */
+/**
+ * A member's share position in a vault (0 if none), INCLUDING the weight it can actually vote.
+ *
+ * `shares` and `votingEligibleShares` are different quantities and the difference is silent
+ * on-chain. The Base Sepolia soak found a member holding roughly a fifth of a vault whose
+ * `votingEligibleShares` read 0, with nothing off-chain saying so — this projection carried no
+ * eligibility field at all, so the number a member sees and the number that carries a vote could
+ * disagree by their whole position and nothing here reconciled them.
+ *
+ * `votingEligibleShares` mirrors `VaultCore.votingEligibleShares` (VaultCore.sol:1025-1028) term
+ * for term, INCLUDING the branch that is not about exits at all:
+ *
+ *     if (member == parentVault()) return 0;
+ *     return sharesOf[member] - queuedExitShares[member];
+ *
+ * So there are TWO ways a material position votes with nothing, and a field carrying only the
+ * queued-exit lock would report the second one wrongly. `votingEligibleNote` names whichever
+ * applies, the amount it withholds, and how it resolves; it is `null` when nothing is withheld,
+ * so a consumer can treat its presence as the whole signal.
+ *
+ * What this is NOT: the weight a vote would actually carry. `Governance._boundedWeight`
+ * (Governance.sol:352-356) takes `min(pastVotingEligibleShares(member, createdAt - 1),
+ * votingEligibleShares(member))` and `commitVote` requires that minimum to be non-zero
+ * (Governance.sol:365). The snapshot term is a chain read of a checkpoint this fold does not keep,
+ * so a non-zero value here is the LIVE term only and promises nothing about the snapshot term. A
+ * zero is the stronger statement: zero is the smaller term whatever the snapshot holds.
+ */
 export function memberPosition(state, vault, member) {
   const shares = shareBook(state, vault).get(member) ?? 0n;
   const v = state.vaults.get(vault);
   const totalShares = v ? v.totalShares : 0n;
+  const queued = state.queuedExitShares.get(vault)?.get(member) ?? 0n;
+
+  const parent = v?.parent ?? null;
+  const isParent = parent !== null && String(parent).toLowerCase() === String(member).toLowerCase();
+  const eligible = isParent ? 0n : shares > queued ? shares - queued : 0n;
+
+  const notes = [];
+  if (isParent) {
+    notes.push(
+      `This position belongs to ${parent}, the vault's registered parent vault, which is a ` +
+      'non-voting member: VaultCore.votingEligibleShares returns 0 for the parent whatever it holds.',
+    );
+  }
+  if (queued > 0n) {
+    notes.push(
+      `${queued} of ${shares} shares are locked by a queued Mode-F exit and are excluded from ` +
+      'voting-eligible stake. Locked shares stay outstanding and still gain and lose with the ' +
+      'vault, and a queued exit cannot be cancelled: the lock ends when the exit settles, which is ' +
+      'a separate settleQueuedExit(member) call that anyone can make once the vault has no pending ' +
+      'execution.',
+    );
+  }
+
   return {
     vault,
     member,
     shares,
     // fraction in basis points (integer) — NAV-denominated value is chain-read enrichment.
     shareOfVaultBps: totalShares > 0n ? Number((shares * 10000n) / totalShares) : 0,
+    queuedExitShares: queued,
+    votingEligibleShares: eligible,
+    votingEligibleNote: notes.length ? notes.join(' ') : null,
   };
 }

--- a/packages/indexer/src/projections.mjs
+++ b/packages/indexer/src/projections.mjs
@@ -298,7 +298,19 @@ export function apply(state, e) {
       // The SIZE of the entry, not only its existence: `requestExit(shares)` accepts any amount up
       // to the balance, so a queued exit subtracts from voting-eligible stake rather than zeroing
       // it, and `memberPosition` cannot state the withheld weight without this.
-      queuedExitShareBook(state, e.vault).set(a.member, big(a.shares ?? 0n));
+      //
+      // An ABSENT amount is recorded as absent, not as 0n. `abis.mjs` decodes `shares` from a
+      // non-indexed, non-optional event field, so this branch is unreachable from a well-formed
+      // log — but `0n` is the wrong failure direction whatever produces it: the size book would
+      // then say "nothing is locked" about a member `queuedExits` says IS locked, and
+      // `memberPosition` would report the member's whole position as voting-eligible when
+      // `VaultCore.votingEligibleShares` returns strictly less. Leaving the entry out instead puts
+      // the member in the one state that is honest, "locked, amount unknown", which is the same
+      // state a snapshot predating this book resumes into and which `memberPosition` reports as
+      // null with a note rather than as a number.
+      if (a.shares !== undefined && a.shares !== null) {
+        queuedExitShareBook(state, e.vault).set(a.member, big(a.shares));
+      }
       break;
     case 'ExitSettled': {
       const v = ensureVault(state, e.vault);
@@ -510,22 +522,46 @@ export function queuedExitBacklog(state, vault) {
  * applies, the amount it withholds, and how it resolves; it is `null` when nothing is withheld,
  * so a consumer can treat its presence as the whole signal.
  *
+ * There is a THIRD state, and it is a state of this projection rather than of the chain: the fold
+ * can know that a member is locked without knowing by how much. `queuedExits` (who) and
+ * `queuedExitShares` (how much) are separate structures, and `store.mjs` keeps `VERSION = 1` so a
+ * snapshot written before the second existed LOADS rather than being rejected — `buildIndexer`
+ * calls `loadSnapshot` on every restart, so that is the ordinary upgrade path and not an edge
+ * case. Across such a resume `queuedExits` still names the member and the size book does not, and
+ * the honest report is `null`: unknown, not zero. Defaulting the amount to `0n` would make
+ * `votingEligibleShares` equal `shares` — the member's WHOLE position reported as votable, with a
+ * `null` note affirming nothing is withheld, for a member whose on-chain eligible weight is
+ * strictly less. Clamping to `0n` instead would be wrong in the other direction and would falsify
+ * the paragraph below: the member may have queued one share of two thousand, so a zero here would
+ * no longer establish that a vote carries nothing. `null` is the only value that claims what is
+ * actually known, and it never over-reports; the note always says so, and names the chain read
+ * that answers exactly.
+ *
  * What this is NOT: the weight a vote would actually carry. `Governance._boundedWeight`
  * (Governance.sol:352-356) takes `min(pastVotingEligibleShares(member, createdAt - 1),
  * votingEligibleShares(member))` and `commitVote` requires that minimum to be non-zero
  * (Governance.sol:365). The snapshot term is a chain read of a checkpoint this fold does not keep,
  * so a non-zero value here is the LIVE term only and promises nothing about the snapshot term. A
- * zero is the stronger statement: zero is the smaller term whatever the snapshot holds.
+ * zero is the stronger statement: zero is the smaller term whatever the snapshot holds. A `null`
+ * is neither statement — it is the absence of one, which is why it may never be read as a number.
  */
 export function memberPosition(state, vault, member) {
   const shares = shareBook(state, vault).get(member) ?? 0n;
   const v = state.vaults.get(vault);
   const totalShares = v ? v.totalShares : 0n;
-  const queued = state.queuedExitShares.get(vault)?.get(member) ?? 0n;
+  // "Locked, amount unknown" is a state the fold can be in and must not round off: `queuedExits`
+  // names the member and the size book has no entry for them. The two structures are written and
+  // cleared together in `apply`, so within a single run this cannot happen; it is reached by
+  // resuming a snapshot written before the size book existed, which `store.mjs` still loads.
+  const sizeBook = state.queuedExitShares.get(vault);
+  const lockedAmountUnknown = (state.queuedExits.get(vault)?.has(member) ?? false) && !sizeBook?.has(member);
+  const queued = lockedAmountUnknown ? null : sizeBook?.get(member) ?? 0n;
 
   const parent = v?.parent ?? null;
   const isParent = parent !== null && String(parent).toLowerCase() === String(member).toLowerCase();
-  const eligible = isParent ? 0n : shares > queued ? shares - queued : 0n;
+  // The parent branch is unconditional on chain — `if (member == parentVault()) return 0` runs
+  // before the subtraction — so it stays exact even when the withheld amount is unknown.
+  const eligible = isParent ? 0n : lockedAmountUnknown ? null : shares > queued ? shares - queued : 0n;
 
   const notes = [];
   if (isParent) {
@@ -534,7 +570,20 @@ export function memberPosition(state, vault, member) {
       'non-voting member: VaultCore.votingEligibleShares returns 0 for the parent whatever it holds.',
     );
   }
-  if (queued > 0n) {
+  if (lockedAmountUnknown) {
+    notes.push(
+      `This position of ${shares} shares carries an outstanding queued Mode-F exit whose size ` +
+      'this projection does not know, so queuedExitShares and votingEligibleShares are null ' +
+      'rather than numbers that would over-report the weight that votes. Some part of the ' +
+      'holding is locked and excluded from voting-eligible stake: VaultCore.votingEligibleShares ' +
+      'returns sharesOf(member) minus queuedExitShares(member), and a queued exit is for a ' +
+      'non-zero amount, so the votable weight is strictly less than the holding shown here. Read ' +
+      'votingEligibleShares(member) on the vault for the exact figure. The lock ends when the ' +
+      'exit settles, which is a separate settleQueuedExit(member) call that anyone can make once ' +
+      'the vault has no pending execution.',
+    );
+  }
+  if (queued !== null && queued > 0n) {
     notes.push(
       `${queued} of ${shares} shares are locked by a queued Mode-F exit and are excluded from ` +
       'voting-eligible stake. Locked shares stay outstanding and still gain and lose with the ' +

--- a/packages/indexer/src/store.mjs
+++ b/packages/indexer/src/store.mjs
@@ -105,16 +105,27 @@ export function deserializeState(obj) {
   for (const [k, pid] of obj.activeProposal) s.activeProposal.set(k, pid);
   // Absent on a snapshot written before these fields existed — default to empty rather than
   // throwing, so an older snapshot still resumes cleanly. VERSION deliberately stays at 1: the
-  // guard on line 53 rejects any snapshot whose version is not exactly VERSION, so bumping it
-  // would make every existing snapshot UNLOADABLE (loadSnapshot rethrows, the daemon dies on
-  // restart, verifySnapshot reports UNUSABLE) — the opposite of a migration. These defaults ARE
-  // the migration; the added fields are all additive and zero-valued.
+  // guard above rejects any snapshot whose version is not exactly VERSION (`!==`, not `<`), so
+  // bumping it would make every existing snapshot UNLOADABLE — `loadSnapshot` catches only ENOENT
+  // and rethrows this, so `buildIndexer` dies at startup; `verifySnapshot` stamps `version: VERSION`
+  // and would report every existing file UNUSABLE, which the docs/RUNTIME.md §8 troubleshooting
+  // table routes to "restore from .1 per §8.3" — a backup written by the same older build, so it
+  // would fail identically. That is an outage, not a migration. These
+  // defaults ARE the migration; the added fields are all additive and zero-valued.
   for (const [k, stat] of obj.eventStats ?? []) s.eventStats.set(k, stat);
   for (const a of obj.adapters ?? []) s.adapters.add(a);
   for (const [k, members] of obj.queuedExits ?? []) s.queuedExits.set(k, new Set(members));
   // Absent on a snapshot written before the queued-exit SIZES were folded. `queuedExits` above
   // still restores WHICH members are queued, so the Mode-F discriminator and the backlog survive
   // such a resume intact; only the per-member amount is unknown until that member's next event.
+  //
+  // "Unknown" is where it stops. This is the one added field whose empty default is not harmless,
+  // because a missing per-member entry is indistinguishable from a zero one to anything that reads
+  // the map alone — and a zero here means "nothing is locked" about a member `queuedExits` says IS
+  // locked. So the absence is not filled in: `memberPosition` reads the pair (queued in the set,
+  // no entry in this book) as "locked, amount unknown" and reports null with a note, rather than a
+  // number it cannot support. That is why the missing map still does not need a VERSION bump — the
+  // gap is DETECTABLE in place, so the in-place upgrade is graceful rather than merely quiet.
   for (const [k, book] of obj.queuedExitShares ?? []) {
     s.queuedExitShares.set(k, new Map(book.map(([m, b]) => [m, BigInt(b)])));
   }

--- a/packages/indexer/src/store.mjs
+++ b/packages/indexer/src/store.mjs
@@ -46,6 +46,8 @@ export function serializeState(state) {
     eventStats: mapEntries(state.eventStats),
     adapters: [...state.adapters],
     queuedExits: mapEntries(state.queuedExits, (members) => [...members]),
+    // Same nested shape as `shares`, bigints as strings: vault -> [[member, "amount"], ...].
+    queuedExitShares: mapEntries(state.queuedExitShares, (book) => mapEntries(book, (b) => b.toString())),
   };
 }
 
@@ -110,6 +112,12 @@ export function deserializeState(obj) {
   for (const [k, stat] of obj.eventStats ?? []) s.eventStats.set(k, stat);
   for (const a of obj.adapters ?? []) s.adapters.add(a);
   for (const [k, members] of obj.queuedExits ?? []) s.queuedExits.set(k, new Set(members));
+  // Absent on a snapshot written before the queued-exit SIZES were folded. `queuedExits` above
+  // still restores WHICH members are queued, so the Mode-F discriminator and the backlog survive
+  // such a resume intact; only the per-member amount is unknown until that member's next event.
+  for (const [k, book] of obj.queuedExitShares ?? []) {
+    s.queuedExitShares.set(k, new Map(book.map(([m, b]) => [m, BigInt(b)])));
+  }
   return s;
 }
 

--- a/packages/indexer/test/projections.test.mjs
+++ b/packages/indexer/test/projections.test.mjs
@@ -347,3 +347,33 @@ test('a registered parent vault holds shares in its child and votes with none of
   assert.ok(pos.votingEligibleNote, 'and the reason must be the parent carve-out, not a queued exit');
   assert.match(pos.votingEligibleNote, /parent/i);
 });
+
+/**
+ * The same over-report reachable without a snapshot at all: an ExitQueued whose `shares` argument
+ * is missing. `abis.mjs` decodes `shares` from a non-indexed field of a two-field event, so a
+ * well-formed log always carries it and this is unreachable in production — but it is the identical
+ * class to the resumed-snapshot gap, and the old `?? 0n` default failed the same way: the size book
+ * would record "nothing locked" for a member the queued set says IS locked. The entry is left out
+ * instead, which puts the member in the honest "locked, amount unknown" state.
+ */
+test('an ExitQueued with no amount records the lock as unknown, never as zero', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 2_000n }),
+    ev('DepositActivated', 1, 1, V, { member: B, sharesMinted: 8_000n }),
+    ev('ExitQueued', 2, 0, V, { member: A }), // no `shares`
+  ]);
+  assert.equal(queuedExitBacklog(s, V), 1, 'the member is queued either way');
+  assert.equal(s.queuedExitShares.get(V)?.has(A) ?? false, false, 'and no size was invented for them');
+
+  const pos = memberPosition(s, V, A);
+  assert.equal(pos.shares, 2_000n);
+  assert.equal(pos.queuedExitShares, null, 'unknown, not 0n');
+  assert.equal(pos.votingEligibleShares, null, 'so no eligible number is served');
+  assert.notEqual(pos.votingEligibleNote, null);
+  assert.match(pos.votingEligibleNote, /does not know/);
+
+  // And the discriminator still resolves at settlement, exactly as it does with a known size.
+  apply(s, ev('ExitSettled', 3, 0, V, { member: A, sharesBurned: 2_000n }));
+  assert.equal(s.vaults.get(V).modeFSettledCount, 1, 'an unknown size is still a Mode-F settlement');
+  assert.equal(memberPosition(s, V, A).votingEligibleNote, null, 'and the lock is gone from the report');
+});

--- a/packages/indexer/test/projections.test.mjs
+++ b/packages/indexer/test/projections.test.mjs
@@ -268,3 +268,82 @@ test('the persisted adapter set is bounded at exactly 64, at and above the bound
   assert.equal(over.adapters.size, 64, 'the persisted set must not grow past the ceiling');
   assert.ok(!over.adapters.has(adapterAt(65)), 'the 65th must not be persisted');
 });
+
+/**
+ * THE SOAK FINDING. During the Base Sepolia soak a member holding roughly a fifth of a vault read
+ * `votingEligibleShares` 0 on-chain and nothing off-chain said so: `memberPosition` returned
+ * `shares` and `shareOfVaultBps` only, so the member's own position page could show 20% of the
+ * vault beside a weight the contract treats as nothing.
+ *
+ * The two assertions belong in one block deliberately. A material `shareOfVaultBps` alone is not
+ * the finding, and a zero eligible weight alone is not either — the finding is the two coexisting
+ * with no third field reconciling them.
+ */
+test('a member holding a fifth of the vault with a queued Mode-F exit reads zero voting weight, and the projection says so', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 2_000n }),
+    ev('DepositActivated', 1, 1, V, { member: B, sharesMinted: 8_000n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 2_000n }),
+  ]);
+  const pos = memberPosition(s, V, A);
+
+  assert.equal(pos.shares, 2_000n, 'queued shares stay outstanding until settlement');
+  assert.equal(pos.shareOfVaultBps, 2000, 'a fifth of the vault');
+  assert.equal(pos.queuedExitShares, 2_000n);
+  assert.equal(pos.votingEligibleShares, 0n, 'VaultCore.votingEligibleShares: sharesOf - queuedExitShares');
+  assert.ok(pos.votingEligibleNote, 'the zero must be explained, not merely reported');
+  assert.match(pos.votingEligibleNote, /2000/, 'the note names the locked amount');
+  assert.match(pos.votingEligibleNote, /settleQueuedExit/, 'and how it resolves');
+
+  // B queued nothing, so B keeps a full weight and gets no note.
+  const other = memberPosition(s, V, B);
+  assert.equal(other.queuedExitShares, 0n);
+  assert.equal(other.votingEligibleShares, 8_000n);
+  assert.equal(other.votingEligibleNote, null);
+});
+
+test('a PARTIAL queued exit subtracts rather than zeroing', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 1_000n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 400n }),
+  ]);
+  const pos = memberPosition(s, V, A);
+  assert.equal(pos.queuedExitShares, 400n);
+  assert.equal(pos.votingEligibleShares, 600n);
+  assert.ok(pos.votingEligibleNote, 'a partial lock is still withheld weight and still needs saying');
+});
+
+test('settling the queued exit clears the lock from the projection', () => {
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: A, sharesMinted: 1_000n }),
+    ev('ExitQueued', 2, 0, V, { member: A, shares: 400n }),
+    ev('ExitSettled', 3, 0, V, { member: A, sharesBurned: 400n }),
+  ]);
+  const pos = memberPosition(s, V, A);
+  assert.equal(pos.shares, 600n);
+  assert.equal(pos.queuedExitShares, 0n);
+  assert.equal(pos.votingEligibleShares, 600n);
+  assert.equal(pos.votingEligibleNote, null);
+});
+
+/**
+ * The second way `votingEligibleShares` returns zero on material stake, and the one a lock-only
+ * field would report wrongly: `VaultCore.votingEligibleShares` opens with
+ * `if (member == parentVault()) return 0` (VaultCore.sol:1025-1027), so a registered parent's
+ * position in its child carries no weight at all, queued exit or not.
+ */
+test('a registered parent vault holds shares in its child and votes with none of them', () => {
+  const P = '0x' + 'p'.replace('p', '2').repeat(40);
+  const s = applyAll([
+    ev('DepositActivated', 1, 0, V, { member: P, sharesMinted: 5_000n }),
+    ev('DepositActivated', 1, 1, V, { member: B, sharesMinted: 5_000n }),
+    ev('ChildRegistered', 2, 0, V, { child: V, parent: P, depth: 1 }),
+  ]);
+  const pos = memberPosition(s, V, P);
+  assert.equal(pos.shares, 5_000n);
+  assert.equal(pos.shareOfVaultBps, 5000);
+  assert.equal(pos.queuedExitShares, 0n, 'nothing is queued: the lock is not why this reads zero');
+  assert.equal(pos.votingEligibleShares, 0n);
+  assert.ok(pos.votingEligibleNote, 'and the reason must be the parent carve-out, not a queued exit');
+  assert.match(pos.votingEligibleNote, /parent/i);
+});

--- a/packages/indexer/test/store.test.mjs
+++ b/packages/indexer/test/store.test.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
-import { applyAll, apply, vaultView, leaderboard, queuedExitBacklog, modeFExitRateBps, memberPosition } from '../src/projections.mjs';
+import { applyAll, apply, vaultView, leaderboard, queuedExitBacklog, modeFExitRateBps, memberPosition, emptyState } from '../src/projections.mjs';
 import { serializeState, deserializeState, saveSnapshot, loadSnapshot, resumeCursor } from '../src/store.mjs';
 import { createIndexerDaemon } from '../src/daemon.mjs';
 
@@ -215,5 +215,69 @@ test('queuedExitShares round-trips through JSON, and an older snapshot without i
   delete json.queuedExitShares;
   const s2 = deserializeState(json);
   assert.equal(queuedExitBacklog(s2, V), 1, 'who is queued survives even when how much does not');
-  assert.equal(memberPosition(s2, V, A).queuedExitShares, 0n);
+
+  // "How much does not" is a MISSING number, not a zero, and the two are different claims to a
+  // member. `queuedExitShares: 0n` here would read as "nothing is locked" for a member the same
+  // state knows is locked, and `votingEligibleShares` would then be `shares` — the whole position
+  // reported as votable when the contract returns strictly less. Both come back null instead.
+  const unknown = memberPosition(s2, V, A);
+  assert.equal(unknown.queuedExitShares, null, 'an unknown locked amount is null, never 0');
+  assert.equal(unknown.votingEligibleShares, null, 'and the eligible weight it feeds is null too');
+  assert.match(unknown.votingEligibleNote ?? '', /queued Mode-F exit/,
+    'and the note says so — null there is the schema\'s "nothing is withheld"');
+});
+
+/**
+ * The same absence, reached the way an operator actually reaches it: NOT by deleting a key from a
+ * snapshot this build wrote, but by loading a file this build never wrote. `store.mjs` keeps
+ * `VERSION = 1`, so a snapshot from before the size book was folded LOADS rather than being
+ * rejected, and `buildIndexer` calls `loadSnapshot` on every restart — so this is the default
+ * upgrade path, not an edge case, and it runs on the paid /vaults/{addr}/members/{addr} route.
+ *
+ * The fixture is written out literally rather than derived from `serializeState`, because deriving
+ * it from today's serializer is exactly the assumption under test. It is pinned against the current
+ * key set below so it cannot quietly stop resembling a real snapshot.
+ */
+test('a snapshot written by pre-size-book code never tells a locked member their whole stake votes', () => {
+  // Byte-for-byte what `serializeState` emitted before `queuedExitShares` existed: version 1, the
+  // membership set present, the size book absent entirely.
+  const preUpgrade = {
+    version: 1,
+    lastBlock: 3,
+    lastLogIndex: 0,
+    vaults: [[V, {
+      vault: V, creator: A, usdc: A, operatorId: 0, totalShares: '10000', idleUsdc: '0',
+      memberCount: 2, pendingCount: 0, capacityCapUsdc: '0', parent: null, depth: 0,
+      exitQueuedCount: 1, exitSettledCount: 0, modeFSettledCount: 0,
+    }]],
+    operators: [],
+    shares: [[V, [[A, '2000'], [B, '8000']]]],
+    proposals: [],
+    activeProposal: [],
+    eventStats: [],
+    adapters: [],
+    queuedExits: [[V, [A]]],
+  };
+  // A file that no longer resembles what this build writes would stop testing the upgrade path and
+  // start testing a museum piece. Today's keys, minus the one the old writer did not have.
+  const writtenToday = Object.keys(serializeState(emptyState())).filter((k) => k !== 'queuedExitShares');
+  assert.deepEqual(Object.keys(preUpgrade).sort(), writtenToday.sort(),
+    'the pre-upgrade fixture is one field behind the current serializer, no more and no less — a ' +
+    'field added since needs its own absent-means-unknown decision here');
+
+  const resumed = deserializeState(preUpgrade);
+  const pos = memberPosition(resumed, V, A);
+
+  assert.equal(pos.shares, 2_000n, 'the holding is known: it comes from the shares book');
+  assert.equal(pos.shareOfVaultBps, 2000);
+  assert.equal(queuedExitBacklog(resumed, V), 1, 'and the state still knows this member is queued');
+
+  // The blocker: before this fix these read 0n and 2000n with a null note, i.e. "your whole
+  // position votes and nothing is withheld", on a member for whom VaultCore.votingEligibleShares
+  // returns strictly less. Never over-report; say unknown instead.
+  assert.equal(pos.queuedExitShares, null);
+  assert.equal(pos.votingEligibleShares, null);
+  assert.notEqual(pos.votingEligibleNote, null, 'a null note means nothing is withheld — it is not');
+  assert.match(pos.votingEligibleNote, /queued Mode-F exit/);
+  assert.match(pos.votingEligibleNote, /settleQueuedExit/, 'and how the lock ends');
 });

--- a/packages/indexer/test/store.test.mjs
+++ b/packages/indexer/test/store.test.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
-import { applyAll, apply, vaultView, leaderboard, queuedExitBacklog, modeFExitRateBps } from '../src/projections.mjs';
+import { applyAll, apply, vaultView, leaderboard, queuedExitBacklog, modeFExitRateBps, memberPosition } from '../src/projections.mjs';
 import { serializeState, deserializeState, saveSnapshot, loadSnapshot, resumeCursor } from '../src/store.mjs';
 import { createIndexerDaemon } from '../src/daemon.mjs';
 
@@ -184,4 +184,36 @@ test('queuedExits survives a serialize -> deserialize -> settle cycle', () => {
   assert.equal(s1.vaults.get(V).modeFSettledCount, 1, 'a second settle for the same member is Mode-I');
   assert.equal(s1.vaults.get(V).exitSettledCount, 2);
   assert.equal(modeFExitRateBps(s1, V), 5000);
+});
+
+/**
+ * The SIZE of each queue entry is durable state too, and it fails differently from the membership
+ * set above. `queuedExits` losing an entry misclassifies a settlement; `queuedExitShares` losing
+ * one restores a member whose voting weight the projection then over-reports by the whole locked
+ * amount -- which is the exact silence this field was added to end. A bigint that reached disk as
+ * `{}` or as a number would be lost or rounded, so this goes through JSON, not just through the
+ * two functions.
+ */
+test('queuedExitShares round-trips through JSON, and an older snapshot without it still loads', () => {
+  const s0 = applyAll([
+    ev('VaultCreated', 1, 0, V, { creator: A, usdc: A, capacityCapUsdc: 0n }),
+    ev('DepositActivated', 2, 0, V, { member: A, sharesMinted: 2_000n }),
+    ev('DepositActivated', 2, 1, V, { member: B, sharesMinted: 8_000n }),
+    ev('ExitQueued', 3, 0, V, { member: A, shares: 2_000n }),
+  ]);
+  const json = JSON.parse(JSON.stringify(serializeState(s0)));
+  assert.deepEqual(json.queuedExitShares, [[V, [[A, '2000']]]], 'bigints reach disk as decimal strings');
+
+  const s1 = deserializeState(json);
+  const pos = memberPosition(s1, V, A);
+  assert.equal(pos.shares, 2_000n);
+  assert.equal(pos.queuedExitShares, 2_000n, 'the locked amount survived the restart');
+  assert.equal(pos.votingEligibleShares, 0n);
+
+  // A snapshot written before this field existed: absent, not empty. It must still load, and the
+  // membership set must still carry the Mode-F discriminator across the resume.
+  delete json.queuedExitShares;
+  const s2 = deserializeState(json);
+  assert.equal(queuedExitBacklog(s2, V), 1, 'who is queued survives even when how much does not');
+  assert.equal(memberPosition(s2, V, A).queuedExitShares, 0n);
 });


### PR DESCRIPTION
## The finding

During the Base Sepolia soak a member held roughly 20% of a vault and their
`votingEligibleShares` read 0, with nothing off-chain saying so. The mechanism is Mode-F: once a
member requests an exit while the vault has a pending execution, their shares stay outstanding but
are excluded from voting-eligible stake. That is correct protocol behaviour. It was also silent — a
member could hold a fifth of a vault, believe they could carry a vote, and find out only when a
round failed to reach quorum.

## The gap was real. Where it was, and where it was not

- `VaultCore` already exposes `votingEligibleShares(member)` (VaultCore.sol:1025-1028). The contract
  is fine; **nothing here touches Solidity.**
- `packages/indexer/src/projections.mjs` — `memberPosition` returned `vault`, `member`, `shares`,
  `shareOfVaultBps`. No eligibility field of any kind.
- `apps/api` — `GET /vaults/{addr}/members/{addr}` serves exactly that object (server.mjs:181), and
  the path was **absent from `docs/api/openapi.yaml` altogether**, so no schema existed for a field
  to be missing from.
- `packages/canary/src/signals/governance-watch.mjs` — already rich, and **not** coverage: it is
  per-vault phase narration keyed `signal|vault|key`, with no member dimension. It also pages
  `PAGE_WEBHOOK_URL`, which reaches the operator, not the member holding the stake. No signal added.
- `apps/web` — warns at *queue time* (index.html:1082-1083) and offers a Settle button afterwards,
  but `renderPositionStrip` shows shares/value/basis/fee only. Left for a follow-up: its
  `queuedExitShares` comes from a chain read via `live-adapter`, an independent data path from this
  one.

## What changed

`memberPosition` now also returns:

- `queuedExitShares` — the amount locked by an outstanding queued Mode-F exit, folded from
  `ExitQueued`'s `shares` argument.
- `votingEligibleShares` — mirroring `VaultCore.votingEligibleShares` term for term, **including**
  `if (member == parentVault()) return 0`. That second branch is why this is not a boolean: a
  registered parent vault's position in its child votes with nothing and has no queued exit at all,
  so a lock-only flag would have reported it wrongly.
- `votingEligibleNote` — `null` when nothing is withheld; otherwise a sentence naming the amount,
  the reason, and how it resolves.

`requestExit(shares)` accepts any amount up to the balance, so the lock subtracts rather than
zeroes, and the amount had to be folded rather than inferred. `state.queuedExits` stays a `Set` and
`state.queuedExitShares` is a second map beside it: `queuedExits` serializes as a flat array of
members and `store.test.mjs` pins that on-disk shape, so widening it would have turned this into a
snapshot-format migration. The new map serializes in the same style as `shares` (bigints as decimal
strings) and its absence from an older snapshot loads cleanly.

`docs/api/openapi.yaml` gains the `/vaults/{address}/members/{member}` path and a `MemberPosition`
schema, and `openapi-vaultview.test.mjs` gains the same derived both-directions check it already
applies to `VaultView`, so a field added to this route tomorrow fails until it is documented.

Wording checked against source, not against other prose. The note says the lock ends when the exit
*settles*, and that settlement is a separate `settleQueuedExit(member)` call anyone can make once
no execution is pending (VaultCore.sol:586-593) — not that it clears on Defeated/Executed/expiry,
which would be false. It says locked shares stay outstanding and still gain and lose with the vault
(`docs/vault/two-mode-exits.md`). The schema says a non-zero `votingEligibleShares` is the live term
only, because `Governance._boundedWeight` takes `min(snapshot, live)` (Governance.sol:352-356) and
the snapshot term is a chain read this fold does not keep.

## Failing-test-first

Four new tests in `packages/indexer/test/projections.test.mjs`, run against the unmodified fold:

```
not ok 19 - a member holding a fifth of the vault with a queued Mode-F exit reads zero voting weight, and the projection says so
not ok 20 - a PARTIAL queued exit subtracts rather than zeroing
not ok 21 - settling the queued exit clears the lock from the projection
not ok 22 - a registered parent vault holds shares in its child and votes with none of them
# pass 18
# fail 4
```

The first is the soak scenario exactly: 2,000 of 10,000 shares, `shareOfVaultBps` 2000 and
`votingEligibleShares` 0 asserted in one block, because neither number alone is the finding.

The two new OpenAPI tests were also shown to fail first, with the `MemberPosition` schema block
renamed out of the file:

```
not ok 4 - every field GET /vaults/{addr}/members/{addr} returns is declared in the OpenAPI MemberPosition schema
  error: 'MemberPosition schema not found in docs/api/openapi.yaml'
not ok 5 - the OpenAPI MemberPosition schema declares nothing the route does not return
```
