### PR TITLE
test(gate): run apps/app's claims guard, and guard the wiring that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,20 @@ jobs:
       # moved back after the next one. scripts/gate.mjs mirrors this order.
       - name: Build the redesign (apps/site-next) so the claims guards can walk dist/
         run: npm run build --workspace apps/site-next
+      # app.rwally.com (apps/app) keeps its own step instead of a glob inside `npm run
+      # test:backend`, and the reason is a measured race rather than a preference.
+      # apps/app/test/claims.test.mjs runs apps/app/build.mjs at module load, which is
+      # `rm -rf dist` then `cp -r src dist`. The repository-wide walks inside test:backend
+      # (claims-lede-truth, config-doc-truth, claims-token-absence) enumerate files first and
+      # read them after, and deliberately do not skip `dist`. In one `node --test` batch the
+      # build deletes a path an unrelated guard has listed but not yet opened, and that guard
+      # throws ENOENT. Measured at 1 failure in 25 batched runs — the rate that gets filed as
+      # flakiness. claims-token-absence.test.mjs records the same finding and dropped its own
+      # build for it. Ordered BEFORE test:backend so those walks read a dist matching src.
+      # scripts/gate.mjs mirrors this order, and
+      # scripts/test/test-wiring-truth.test.mjs fails if either file stops invoking this script.
+      - name: app.rwally.com claims guard (apps/app) against its own build
+        run: npm run test:app
       - name: Backend + frontend logic tests
         run: npm run test:backend
       # The live site under apps/site keeps its own suite inside npm run test:backend above.

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -17,8 +17,15 @@
  * test:app` at the repository root, which `.github/workflows/ci.yml` and
  * `scripts/gate.mjs` each invoke as a step of their own, ordered immediately
  * before `npm run test:backend`. `scripts/test/test-wiring-truth.test.mjs`
- * fails if either of them stops invoking it, and fails if any `*.test.mjs` in
- * the repository stops being covered by a wired script.
+ * fails if any `*.test.mjs` in the repository stops being covered by a wired
+ * script, and fails if either pipeline stops invoking this one -- where
+ * "invoking" is read narrowly and on purpose: it searches the value of ci.yml's
+ * `run:` keys with comments removed, and gate.mjs's `args:` array literals with
+ * comments removed. Deleting a step and leaving its `name:`, its `title:` or
+ * the paragraph explaining it behind is therefore caught. What that guard
+ * cannot establish is that the step it found is reachable -- an `if:`, a
+ * `--quick` skip or a job outside the required set would all still satisfy it.
+ * Only a green CI run and a green `npm run gate` show this file executing.
  *
  * IT IS DELIBERATELY NOT A GLOB INSIDE `test:backend`, and the reason is a
  * measured race. The `execFileSync` below is `rm -rf dist` followed by

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -13,17 +13,27 @@
  * guard's own header relies on, and it is stated here so nobody moves these
  * strings into a `.json` fixture and discovers the consequence in CI.
  *
+ * HOW THIS FILE RUNS, because for its first weeks it did not. It is `npm run
+ * test:app` at the repository root, which `.github/workflows/ci.yml` and
+ * `scripts/gate.mjs` each invoke as a step of their own, ordered immediately
+ * before `npm run test:backend`. `scripts/test/test-wiring-truth.test.mjs`
+ * fails if either of them stops invoking it, and fails if any `*.test.mjs` in
+ * the repository stops being covered by a wired script.
+ *
+ * IT IS DELIBERATELY NOT A GLOB INSIDE `test:backend`, and the reason is a
+ * measured race. The `execFileSync` below is `rm -rf dist` followed by
+ * `cp -r src dist`. The repository-wide walks that `test:backend` runs
+ * enumerate files first and read them after, and they deliberately do not skip
+ * `dist`. Batched into one `node --test` invocation with them, this build
+ * deletes a path an unrelated guard has already listed and not yet opened, and
+ * that guard throws ENOENT: 1 failure in 25 batched runs, which is the rate
+ * that gets dismissed as flakiness rather than diagnosed.
+ * `scripts/test/claims-token-absence.test.mjs` carries the same finding at its
+ * `apps/app` group, and dropped its own build because of it.
+ *
  * WHAT THIS FILE DOES NOT COVER, said plainly rather than left to be inferred:
  *
- *   1. IT IS NOT WIRED INTO `npm run test:backend`. That script enumerates
- *      `apps/web/test/*`, `apps/site/test/*` and `scripts/test/*` by name and
- *      does not glob `apps/app/test/*`. Wiring it in means editing the root
- *      package.json, which is outside this change's paths. Until someone does,
- *      run it directly:
- *
- *          node --test --test-reporter=tap apps/app/test/claims.test.mjs
- *
- *   2. IT IS A SHAPE CHECK, NOT A TRUTH CHECK. It can tell that a banned string
+ *   1. IT IS A SHAPE CHECK, NOT A TRUTH CHECK. It can tell that a banned string
  *      is absent and that a required sentence is present. It cannot tell that a
  *      new sentence is true. The repository guard has the same limit and says
  *      so; no guard here is a proof of absence.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cc:web": "node scripts/dashboard.mjs",
     "build:contracts": "cd contracts && forge build",
     "test:contracts": "cd contracts && forge test -vv",
+    "test:app": "node --test --test-reporter=tap apps/app/test/*.test.mjs",
     "test:backend": "node --test packages/oplog/test/*.test.mjs packages/indexer/test/*.test.mjs packages/canary/test/*.test.mjs packages/agent-sdk/test/*.test.mjs packages/reference-agent/test/*.test.mjs apps/api/test/*.test.mjs apps/web/test/*.test.mjs apps/site/test/*.test.mjs scripts/test/*.test.mjs",
     "start:indexer": "node packages/indexer/src/index-runner.mjs",
     "start:api": "node apps/api/src/serve.mjs",

--- a/scripts/gate.mjs
+++ b/scripts/gate.mjs
@@ -126,12 +126,33 @@ const STEPS = [
     why: 'Must precede `backend` AND `site-test`: without dist/ the claims guards walk zero redesign pages.',
   },
   {
+    id: 'app-test',
+    title: 'npm run test:app',
+    cmd: WIN ? 'npm.cmd' : 'npm',
+    args: ['run', 'test:app'],
+    cwd: REPO,
+    // IT IS ITS OWN STEP RATHER THAN A GLOB IN `test:backend`, AND THE REASON IS A MEASURED RACE,
+    // not a preference. `apps/app/test/claims.test.mjs` runs `apps/app/build.mjs` at module load,
+    // which is `rm -rf dist` followed by `cp -r src dist`. The repository-wide walks in
+    // `backend` -- claims-lede-truth, config-doc-truth, claims-token-absence -- enumerate files
+    // first and read them after, and deliberately do not skip `dist`. Put this file in the same
+    // `node --test` batch and the build deletes a path an unrelated guard has already listed but
+    // not yet opened: an ENOENT thrown inside whatever test happened to be running. Measured at
+    // 1 failure in 25 batched runs, which is exactly the rate that gets dismissed as flakiness.
+    // `scripts/test/claims-token-absence.test.mjs` carries the same finding at its APP group and
+    // dropped its own build for it.
+    //
+    // ORDERED BEFORE `backend` so the walks that follow read a dist that matches src. Behind it,
+    // they would read whatever a previous run left.
+    why: 'Runs on its own: it builds apps/app/dist, which would race the repository walks in `backend`.',
+  },
+  {
     id: 'backend',
     title: 'npm run test:backend',
     cmd: WIN ? 'npm.cmd' : 'npm',
     args: ['run', 'test:backend'],
     cwd: REPO,
-    why: 'Backend + frontend logic suite. Needs `build` and `site-build` first (see both above).',
+    why: 'Backend + frontend logic suite. Needs `build`, `site-build` and `app-test` first (see above).',
   },
   {
     id: 'site-test',

--- a/scripts/test/test-wiring-truth.test.mjs
+++ b/scripts/test/test-wiring-truth.test.mjs
@@ -18,10 +18,21 @@
  *      wired npm scripts actually run, and assert the first set is a subset of the second.
  *   2. INVOCATION. Assert every wired script is invoked by BOTH `.github/workflows/ci.yml` and
  *      `scripts/gate.mjs`. A script that exists but nothing calls is the same defect one level up.
- *      It matches the INVOCATION and not the script's name: searching gate.mjs for the string
- *      `test:app` is satisfied by the step's own `title`, and by the comment explaining why the
- *      step exists, so the step could be deleted and the prose alone would read as wired. See
- *      `invokedIn` below.
+ *      IT MATCHES ONLY WHAT EACH FILE EXECUTES, never the prose around it, because both files
+ *      are heavily commented and every one of those comments names the scripts it is explaining.
+ *      In ci.yml the corpus is the value of each `run:` key and nothing else, with YAML and shell
+ *      comments removed; in gate.mjs it is the source with line and block comments removed, and
+ *      the match is anchored to the `args:` array literal rather than floating over the step.
+ *      Without both halves a deleted step whose `name:`, `title:` or explanatory comment survived
+ *      would still read as wired -- which is precisely the state ci.yml was in when this file
+ *      first landed. See `invokedIn` and `executableText` below.
+ *
+ * WHAT LEG 2 STILL CANNOT PROVE, stated because the first version of this header claimed a
+ * property the code did not have. It is a text match over two files. It does not prove either
+ * pipeline ran, nor that the step it found is reachable: an `if:` condition, `continue-on-error`,
+ * a job outside the required set, a `quickSkip` dropped by `npm run gate -- --quick`, or an
+ * `args:` literal sitting in a STEPS entry no filter selects would all satisfy it. `scripts/
+ * gate.mjs` proves its own half the only way that can be proven, by running.
  *
  * THE COVERED SET IS DERIVED, NEVER RESTATED. It is read out of the `scripts` block of
  * package.json and of each workspace package.json. Hardcoding the nine directories here would
@@ -82,6 +93,124 @@ const discoverTestFiles = () => {
 const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
+ * Cut a line at the comment that opens on it, quote-aware.
+ *
+ * `#` opens a comment in YAML and in POSIX shell under the same condition -- it has to open a
+ * word, so it is either the first character or preceded by whitespace -- and in neither language
+ * does it open one inside a quoted scalar or a quoted shell word. That single rule serves both
+ * halves of `ciRunCommands` below.
+ */
+const stripHashComment = (line) => {
+  let quote = null;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (quote) {
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") quote = c;
+    else if (c === '#' && (i === 0 || /\s/.test(line[i - 1]))) return line.slice(0, i);
+  }
+  return line;
+};
+
+/** `|`, `>`, `|-`, `>+2`: a block scalar header, so the value is on the lines below it. */
+const BLOCK_SCALAR = /^[|>][+-]?\d*$/;
+
+/**
+ * THE SHELL THE WORKFLOW ACTUALLY RUNS: the value of every `run:` key, and nothing else.
+ *
+ * THIS IS THE HOLE THIS FILE SHIPPED WITH, and it is recorded here rather than in a commit
+ * message because the next person to widen leg 2 needs it. Leg 2 matched `npm run <name>` against
+ * the whole text of ci.yml, and ci.yml explains itself at length: `npm run test:backend` occurs
+ * there four times, three of them inside comments. Deleting the real step stops all 79 of the 81
+ * test files that script runs -- THIS FILE AMONG THEM, since it lives under `scripts/test/` --
+ * leaving CI with the one file under `test:app` and the one under `apps/site-next`. All three
+ * legs stayed green, and `npm run gate` stayed green with them, because leg 2 requires BOTH
+ * files and gate.mjs's own step was untouched. The header claimed that could not happen. Reading
+ * only `run:` values closes it, and closes the neighbouring case of a `name:` that quotes the
+ * script it is naming.
+ */
+const ciRunCommands = (yaml) => {
+  const lines = yaml.split(/\r?\n/);
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^\s*(?:-\s+)?run:(.*)$/.exec(lines[i]);
+    if (!m) continue;
+    const value = m[1].trim();
+    if (value !== '' && !BLOCK_SCALAR.test(value)) {
+      out.push(stripHashComment(value));
+      continue;
+    }
+    // A block scalar (`run: |`) and a plain scalar wrapped onto the next line (`run:`, then the
+    // command indented under it) both continue below, over every line indented deeper than the
+    // key. The one bare `run:` GitHub Actions defines for itself is `defaults.run`, whose
+    // children are `shell:` and `working-directory:` and cannot hold an npm invocation -- so
+    // reading those two lines costs nothing, while SKIPPING a bare `run:` would make a legal
+    // reflow of a real step read as a deleted one.
+    const keyIndent = lines[i].search(/\S/);
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue;
+      if (lines[j].search(/\S/) <= keyIndent) break;
+      out.push(stripHashComment(lines[j]));
+    }
+  }
+  return out.join('\n');
+};
+
+/**
+ * `scripts/gate.mjs` with its comments removed, so an `args:` vector quoted inside one cannot
+ * stand in for the step it describes. That is not hypothetical either: it is how the ci.yml hole
+ * above was found, by writing exactly such a comment and watching this file stay green.
+ *
+ * LINE-ORIENTED ON PURPOSE. A scanner run over the whole file has to tell a regex literal from a
+ * division to know whether a quote inside it opens a string, and gate.mjs contains
+ * `/[&|<>^()"%!]/`. Get that wrong once and the rest of the file is swallowed as a string, and
+ * this guard goes red for a reason that has nothing to do with wiring. Per line, the worst case
+ * is one line left uncut, and every `args:` vector in gate.mjs is written on one line.
+ */
+const stripJsComments = (src) => {
+  const out = [];
+  let inBlock = false;
+  for (const raw of src.split(/\r?\n/)) {
+    let kept = '';
+    let quote = null;
+    for (let i = 0; i < raw.length; i++) {
+      const c = raw[i];
+      if (inBlock) {
+        if (c === '*' && raw[i + 1] === '/') {
+          inBlock = false;
+          i++;
+        }
+        continue;
+      }
+      if (quote) {
+        kept += c;
+        if (c === '\\') kept += raw[++i] ?? '';
+        else if (c === quote) quote = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') quote = c;
+      else if (c === '/' && raw[i + 1] === '/') break;
+      else if (c === '/' && raw[i + 1] === '*') {
+        inBlock = true;
+        i++;
+        continue;
+      }
+      kept += c;
+    }
+    out.push(kept);
+  }
+  return out.join('\n');
+};
+
+/** What each pipeline file EXECUTES, which is the only text leg 2 is allowed to look at. */
+const executableText = () => ({
+  'scripts/gate.mjs': stripJsComments(readFileSync(path.join(REPO, 'scripts', 'gate.mjs'), 'utf8')),
+  '.github/workflows/ci.yml': ciRunCommands(readFileSync(path.join(REPO, '.github', 'workflows', 'ci.yml'), 'utf8')),
+});
+
+/**
  * The npm scripts that run `node --test`, each with the directory its paths are relative to and
  * the shape its invocation takes in each pipeline.
  *
@@ -95,12 +224,18 @@ const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
  * runner that happens to use the test runner". If you want one, do not give it a root `test:*`
  * script; call the file directly, as `scripts/smoke-test.mjs` and the soak drills do.
  *
- * `invokedIn` IS A SHAPE, NOT A NAME, and that distinction is the whole value of leg 2. A
- * `.includes('test:app')` over gate.mjs is satisfied by the step's own `title`, and by the comment
- * that explains why the step exists -- so deleting the step and leaving the prose behind would read
- * as wired. Matching the argument vector (`'run', 'test:app'`) and the shell line
- * (`npm run test:app`) means the thing being matched is the invocation itself. It is still a text
- * match over a file and cannot prove execution; `scripts/gate.mjs` proves that by running.
+ * `invokedIn` IS A SHAPE MATCHED AGAINST A NARROWED CORPUS, and it needs both halves to be worth
+ * anything. The shape: the argument vector under its `args:` key (`args: ['run', 'test:app']`),
+ * and the shell line (`npm run test:app`), rather than the script's name, which the `title:`, the
+ * `name:` and the surrounding prose all repeat. The corpus: `executableText()` above, which is
+ * gate.mjs without its comments and ONLY the `run:` values of ci.yml. Either half alone is
+ * defeated by a comment -- the shape by quoting an `args:` line inside one, the corpus by a
+ * `title:` string that happens to contain the invocation.
+ *
+ * WHAT IT STILL DOES NOT ESTABLISH: that anything ran. It is a text match. A step behind an `if:`,
+ * a job outside the required set, `continue-on-error: true`, or a STEPS entry that `--quick` or
+ * `--only` filters out all satisfy it. `scripts/gate.mjs` establishes its own half by running,
+ * which is why a green gate and a green CI are the merge bar and this file is only the tripwire.
  */
 const wiredScripts = () => {
   const out = [];
@@ -115,7 +250,9 @@ const wiredScripts = () => {
         base: REPO,
         invokedAs: `npm run ${name}`,
         invokedIn: {
-          'scripts/gate.mjs': new RegExp(`'run'\\s*,\\s*'${esc(name)}'`),
+          // `args:` anchors the match to the vector the step is BUILT from. Without it a `why:`
+          // or a `title:` string carrying the same two tokens would answer for the step.
+          'scripts/gate.mjs': new RegExp(`args:\\s*\\[\\s*'run'\\s*,\\s*'${esc(name)}'\\s*\\]`),
           '.github/workflows/ci.yml': new RegExp(`npm[ \\t]+run[ \\t]+${esc(name)}(?![\\w:.-])`),
         },
       });
@@ -143,8 +280,9 @@ const wiredScripts = () => {
         invokedAs: `npm test --workspace ${ws}`,
         invokedIn: {
           // The `'test',` prefix matters: without it a `build --workspace apps/site-next` step
-          // would satisfy this, and the test step could be deleted with nothing going red.
-          'scripts/gate.mjs': new RegExp(`'test'\\s*,\\s*'--workspace'\\s*,\\s*'${esc(ws)}'`),
+          // would satisfy this, and the test step could be deleted with nothing going red. Both
+          // steps exist here, so this is the pair the mutation table has to discriminate.
+          'scripts/gate.mjs': new RegExp(`args:\\s*\\[\\s*'test'\\s*,\\s*'--workspace'\\s*,\\s*'${esc(ws)}'\\s*\\]`),
           '.github/workflows/ci.yml': new RegExp(`npm[ \\t]+test[ \\t]+--workspace[ \\t]+${esc(ws)}(?![\\w/.-])`),
         },
       });
@@ -175,7 +313,26 @@ const expand = (script, files) => {
   return matched;
 };
 
-const FILE_FLOOR = 70; // 79 today. A floor, not a count: adding tests must not red this file.
+/**
+ * 81 test files today. Deliberately loose, and deliberately NOT sold as more than it is.
+ *
+ * WHAT A COUNT FLOOR PROVES: that the walk did not collapse -- that `discoverTestFiles` returned
+ * a real set rather than the empty one that would make the subset check above pass over nothing.
+ * That is the failure this repository actually shipped twice, and it is the only thing this
+ * number is here for.
+ *
+ * WHAT IT DOES NOT PROVE, at 70 or at any number a deletion would not trip: that no directory
+ * went missing. A `SKIP_DIRS` entry that swallowed one package's tests would take 81 to 75 and
+ * this assertion would not notice. The check that DOES notice is `dead` below -- a swallowed
+ * directory that a wired script still globs makes that glob match zero files, and that is
+ * reported. The residual gap is a directory that is both swallowed and unwired, which is
+ * invisible to every leg here; nothing short of comparing against `git ls-files` would see it.
+ *
+ * The floor is loose on purpose: tightening it to 79 or 80 would turn every legitimate test
+ * deletion into an unrelated red in an unrelated PR, and buy no property the paragraph above
+ * does not already say it lacks.
+ */
+const FILE_FLOOR = 70;
 
 test('every test file in the repository is run by a wired npm script', () => {
   const files = discoverTestFiles();
@@ -200,10 +357,7 @@ test('every test file in the repository is run by a wired npm script', () => {
 });
 
 test('every wired script is invoked by both scripts/gate.mjs and .github/workflows/ci.yml', () => {
-  const text = {
-    'scripts/gate.mjs': readFileSync(path.join(REPO, 'scripts', 'gate.mjs'), 'utf8'),
-    '.github/workflows/ci.yml': readFileSync(path.join(REPO, '.github', 'workflows', 'ci.yml'), 'utf8'),
-  };
+  const text = executableText();
 
   const missing = [];
   for (const s of wiredScripts()) {
@@ -217,8 +371,13 @@ test('every wired script is invoked by both scripts/gate.mjs and .github/workflo
     [],
     'A script that runs tests but that no pipeline calls is the same defect as an unwired test file,\n' +
       'one level up. gate.mjs states its own contract: it must mirror ci.yml, not a subset of it.\n\n' +
-      'What is matched is the INVOCATION and not the script name, so a step deleted while its title\n' +
-      'or its explanatory comment stays behind is caught rather than read as still wired.\n\n' +
+      'WHAT WAS SEARCHED, so a false red here is diagnosable: not the two files, but what they\n' +
+      'execute. For ci.yml that is the value of every `run:` key with YAML and shell comments cut;\n' +
+      'for gate.mjs it is the source with comments cut, and the match is anchored to `args:`. A step\n' +
+      "deleted while its `name:`, its `title:` or its explanatory comment survives is therefore\n" +
+      'reported here rather than read as still wired. If you believe the step IS present, check that\n' +
+      'it sits under a `run:` (ci.yml) or in an `args:` array literal (gate.mjs) -- prose naming the\n' +
+      'script deliberately does not count.\n\n' +
       `${missing.join('\n')}`,
   );
 });
@@ -230,8 +389,10 @@ test('the enumeration and the globs are non-empty, so neither check above is vac
   assert.ok(
     files.length >= FILE_FLOOR,
     `Walked ${files.length} test files, expected at least ${FILE_FLOOR}. A subset check over an empty\n` +
-      'set passes and proves nothing. Either the walk broke, or SKIP_DIRS grew an entry that swallows\n' +
-      'real test directories.',
+      'set passes and proves nothing, so this asserts the walk still returns a real set -- and that is\n' +
+      'ALL it asserts. It is a collapse detector, not a census: with 81 files today it cannot tell you\n' +
+      'that one directory stopped being walked. Reaching this line means the walk broke outright, or\n' +
+      'SKIP_DIRS grew an entry that swallows most of the repository.',
   );
 
   assert.ok(scripts.length >= 3, `Found ${scripts.length} wired script(s), expected at least 3 (test:app, test:backend, apps/site-next#test).`);

--- a/scripts/test/test-wiring-truth.test.mjs
+++ b/scripts/test/test-wiring-truth.test.mjs
@@ -1,0 +1,253 @@
+/**
+ * Every test file in this repository is actually executed by CI and by `npm run gate`.
+ *
+ * WHY THIS EXISTS. `apps/app/test/claims.test.mjs` was written, reviewed and merged, and then
+ * ran in no pipeline for weeks. `npm run test:backend` enumerates its directories by hand --
+ * `packages/oplog/test/*.test.mjs packages/indexer/test/*.test.mjs ...` -- and `apps/app` was
+ * simply not among them. Nothing was red. A claims guard that never runs is worse than an absent
+ * one, because the discipline it is supposed to enforce is assumed to be enforced.
+ *
+ * That is the second inert guard this repository has shipped. The first was the soak's
+ * freeze-safety leg, which read a `SOAK_VAULTS` environment variable nothing ever set, so it
+ * mapped over an empty array and reported all clear. Both have the same shape: a check whose
+ * INPUT is empty, reporting a pass over nothing that reads exactly like a pass over everything.
+ *
+ * SO THIS FILE CHECKS THE WIRING, NOT THE CODE. Two independent legs:
+ *
+ *   1. COVERAGE. Enumerate every `*.test.mjs` from the filesystem, then enumerate the files the
+ *      wired npm scripts actually run, and assert the first set is a subset of the second.
+ *   2. INVOCATION. Assert every wired script is invoked by BOTH `.github/workflows/ci.yml` and
+ *      `scripts/gate.mjs`. A script that exists but nothing calls is the same defect one level up.
+ *      It matches the INVOCATION and not the script's name: searching gate.mjs for the string
+ *      `test:app` is satisfied by the step's own `title`, and by the comment explaining why the
+ *      step exists, so the step could be deleted and the prose alone would read as wired. See
+ *      `invokedIn` below.
+ *
+ * THE COVERED SET IS DERIVED, NEVER RESTATED. It is read out of the `scripts` block of
+ * package.json and of each workspace package.json. Hardcoding the nine directories here would
+ * rebuild, in a guard, exactly the hand-maintained list the guard exists to police.
+ *
+ * NON-VACUITY IS ASSERTED, because that is the failure mode being guarded against. A walk that
+ * finds nothing and a glob that matches nothing both produce an empty difference, and an empty
+ * difference is green.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Directories this walk does not enter. `.claude` is the load-bearing one: around ten agent
+ * sessions keep worktrees under `.claude/worktrees/`, each a full copy of this repository, and a
+ * walk that descended into them would find every test file several times over and blame the
+ * change under test. `claims-lede-truth.test.mjs` and `config-doc-truth.test.mjs` carry the same
+ * entry for the same reason.
+ */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.claude',
+  'lib',
+  'out',
+  'dist',
+  'dist-ssr',
+  'cache',
+  'broadcast',
+  'coverage',
+  'artifacts',
+]);
+
+/** A repo-relative, slash-separated path, so comparisons do not depend on the platform. */
+const rel = (abs) => path.relative(REPO, abs).split(path.sep).join('/');
+
+/** Every `*.test.mjs` in the repository, enumerated from the filesystem -- never from a list. */
+const discoverTestFiles = () => {
+  const found = [];
+  (function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(path.join(dir, entry.name));
+      } else if (entry.name.endsWith('.test.mjs')) {
+        found.push(rel(path.join(dir, entry.name)));
+      }
+    }
+  })(REPO);
+  return found.sort();
+};
+
+/** Escape a literal for embedding in a RegExp. */
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * The npm scripts that run `node --test`, each with the directory its paths are relative to and
+ * the shape its invocation takes in each pipeline.
+ *
+ * Root scripts are matched on their COMMAND (`node --test`), not on their name, so a new
+ * `test:whatever` is picked up the day it is written rather than the day someone remembers this
+ * file. Workspace scripts are the `test` script of any workspace package.json -- that is how
+ * `apps/site-next` runs, as its own CI and gate step.
+ *
+ * THE CONTRACT THAT SELECTOR CREATES, stated rather than left as a trap: a root script that runs
+ * `node --test` MUST be a step of both pipelines. There is no third category here, no "manual
+ * runner that happens to use the test runner". If you want one, do not give it a root `test:*`
+ * script; call the file directly, as `scripts/smoke-test.mjs` and the soak drills do.
+ *
+ * `invokedIn` IS A SHAPE, NOT A NAME, and that distinction is the whole value of leg 2. A
+ * `.includes('test:app')` over gate.mjs is satisfied by the step's own `title`, and by the comment
+ * that explains why the step exists -- so deleting the step and leaving the prose behind would read
+ * as wired. Matching the argument vector (`'run', 'test:app'`) and the shell line
+ * (`npm run test:app`) means the thing being matched is the invocation itself. It is still a text
+ * match over a file and cannot prove execution; `scripts/gate.mjs` proves that by running.
+ */
+const wiredScripts = () => {
+  const out = [];
+  const rootPkg = JSON.parse(readFileSync(path.join(REPO, 'package.json'), 'utf8'));
+
+  for (const [name, cmd] of Object.entries(rootPkg.scripts ?? {})) {
+    if (typeof cmd === 'string' && cmd.includes('node --test')) {
+      out.push({
+        id: name,
+        kind: 'root',
+        cmd,
+        base: REPO,
+        invokedAs: `npm run ${name}`,
+        invokedIn: {
+          'scripts/gate.mjs': new RegExp(`'run'\\s*,\\s*'${esc(name)}'`),
+          '.github/workflows/ci.yml': new RegExp(`npm[ \\t]+run[ \\t]+${esc(name)}(?![\\w:.-])`),
+        },
+      });
+    }
+  }
+
+  // The workspace globs are `packages/*` and `apps/*`; expand them off the filesystem so a new
+  // workspace is covered without editing this file.
+  for (const glob of rootPkg.workspaces ?? []) {
+    const parent = path.join(REPO, glob.replace(/\/\*$/, ''));
+    if (!existsSync(parent)) continue;
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(parent, entry.name);
+      const pkgFile = path.join(dir, 'package.json');
+      if (!existsSync(pkgFile)) continue; // apps/app and apps/site carry none, by design
+      const cmd = JSON.parse(readFileSync(pkgFile, 'utf8')).scripts?.test;
+      if (typeof cmd !== 'string' || !cmd.includes('node --test')) continue;
+      const ws = rel(dir);
+      out.push({
+        id: `${ws}#test`,
+        kind: 'workspace',
+        cmd,
+        base: dir,
+        invokedAs: `npm test --workspace ${ws}`,
+        invokedIn: {
+          // The `'test',` prefix matters: without it a `build --workspace apps/site-next` step
+          // would satisfy this, and the test step could be deleted with nothing going red.
+          'scripts/gate.mjs': new RegExp(`'test'\\s*,\\s*'--workspace'\\s*,\\s*'${esc(ws)}'`),
+          '.github/workflows/ci.yml': new RegExp(`npm[ \\t]+test[ \\t]+--workspace[ \\t]+${esc(ws)}(?![\\w/.-])`),
+        },
+      });
+    }
+  }
+
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+};
+
+/**
+ * The path arguments of a `node --test` command: every token that ends in `.test.mjs`. Flags
+ * (`--test-reporter=tap`) do not, and neither does `node`, so no allowlist of flags is needed --
+ * one that existed would go stale the first time Node grew an option.
+ */
+const globTokens = (cmd) => cmd.split(/\s+/).filter((t) => t.endsWith('.test.mjs'));
+
+/** `apps/*/test/*.test.mjs` semantics: `*` matches within one path segment and nothing else. */
+const globToRegExp = (glob) =>
+  new RegExp(`^${glob.split('*').map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('[^/]*')}$`);
+
+const expand = (script, files) => {
+  const prefix = script.base === REPO ? '' : `${rel(script.base)}/`;
+  const matched = new Map();
+  for (const token of globTokens(script.cmd)) {
+    const re = globToRegExp(prefix + token);
+    matched.set(token, files.filter((f) => re.test(f)));
+  }
+  return matched;
+};
+
+const FILE_FLOOR = 70; // 79 today. A floor, not a count: adding tests must not red this file.
+
+test('every test file in the repository is run by a wired npm script', () => {
+  const files = discoverTestFiles();
+  const scripts = wiredScripts();
+
+  const covered = new Set();
+  for (const s of scripts) for (const hits of expand(s, files).values()) for (const f of hits) covered.add(f);
+
+  const orphans = files.filter((f) => !covered.has(f));
+  assert.deepEqual(
+    orphans,
+    [],
+    'These test files are executed by nothing. They are not failing -- they are not running, which\n' +
+      'is the state `apps/app/test/claims.test.mjs` was in for weeks while the repository treated its\n' +
+      'assertions as enforced.\n\n' +
+      `Not run anywhere:\n  ${orphans.join('\n  ')}\n\n` +
+      'Fix by adding the directory to `test:backend` in the root package.json, or -- when the file\n' +
+      'must not share a `node --test` batch with the repository-wide walks, as apps/app must not --\n' +
+      'by giving it its own root script plus the matching step in BOTH scripts/gate.mjs and\n' +
+      '.github/workflows/ci.yml. The next test in this file checks that second half.',
+  );
+});
+
+test('every wired script is invoked by both scripts/gate.mjs and .github/workflows/ci.yml', () => {
+  const text = {
+    'scripts/gate.mjs': readFileSync(path.join(REPO, 'scripts', 'gate.mjs'), 'utf8'),
+    '.github/workflows/ci.yml': readFileSync(path.join(REPO, '.github', 'workflows', 'ci.yml'), 'utf8'),
+  };
+
+  const missing = [];
+  for (const s of wiredScripts()) {
+    for (const [file, re] of Object.entries(s.invokedIn)) {
+      if (!re.test(text[file])) missing.push(`  ${file} does not invoke \`${s.invokedAs}\` (${s.id}); looked for ${re}`);
+    }
+  }
+
+  assert.deepEqual(
+    missing,
+    [],
+    'A script that runs tests but that no pipeline calls is the same defect as an unwired test file,\n' +
+      'one level up. gate.mjs states its own contract: it must mirror ci.yml, not a subset of it.\n\n' +
+      'What is matched is the INVOCATION and not the script name, so a step deleted while its title\n' +
+      'or its explanatory comment stays behind is caught rather than read as still wired.\n\n' +
+      `${missing.join('\n')}`,
+  );
+});
+
+test('the enumeration and the globs are non-empty, so neither check above is vacuous', () => {
+  const files = discoverTestFiles();
+  const scripts = wiredScripts();
+
+  assert.ok(
+    files.length >= FILE_FLOOR,
+    `Walked ${files.length} test files, expected at least ${FILE_FLOOR}. A subset check over an empty\n` +
+      'set passes and proves nothing. Either the walk broke, or SKIP_DIRS grew an entry that swallows\n' +
+      'real test directories.',
+  );
+
+  assert.ok(scripts.length >= 3, `Found ${scripts.length} wired script(s), expected at least 3 (test:app, test:backend, apps/site-next#test).`);
+
+  const dead = [];
+  for (const s of scripts) {
+    for (const [token, hits] of expand(s, files)) {
+      if (hits.length === 0) dead.push(`  ${s.id}: "${token}" matches no file`);
+    }
+  }
+  assert.deepEqual(
+    dead,
+    [],
+    'A glob that matches nothing is the drift the first test guards, running the other way: a\n' +
+      'workspace was renamed or removed and the script kept pointing at where it used to be. It costs\n' +
+      'no CI time and reports no error, so nothing else would ever say so.\n\n' +
+      `${dead.join('\n')}`,
+  );
+});


### PR DESCRIPTION
## The defect

`apps/app/test/claims.test.mjs` has existed on `protocol/main` since #222 and has run in no
pipeline. `npm run test:backend` enumerates its directories by hand:

```
packages/oplog packages/indexer packages/canary packages/agent-sdk packages/reference-agent
apps/api apps/web apps/site scripts/test
```

`apps/app` is not among them, and `npm run gate` and CI both reach that suite only through
`test:backend`. The file's own header said so and told the reader to run it by hand.

Six assertions were therefore inert: the verbatim empty-state sentence, the factory address on the
page, the five banned claim shapes (x402, airdrop, presale, coming soon, em-dash), the CSP
`_headers` file, the no-inline-script/style rule, and the no-third-party-fetch rule. This is the
second inert guard here. The first was the soak's freeze-safety leg reading a `SOAK_VAULTS` that
nothing set, and both have the same shape: an empty input producing a pass that reads like a pass
over everything.

**It is green on `protocol/main` when run by hand.** Nothing was being hidden, so nothing in
`apps/app/src` needed fixing. The wiring was the whole defect.

## Why it is its own step and not one more glob

Adding `apps/app/test/*.test.mjs` to `test:backend` looks like the one-word fix and introduces a
race. `claims.test.mjs` runs `apps/app/build.mjs` at module load, which is `rm -rf dist` then
`cp -r src dist`. The repository-wide walks inside `test:backend` (`claims-lede-truth`,
`config-doc-truth`, `claims-token-absence`) enumerate files first and read them after, and
deliberately do not skip `dist`. In one `node --test` batch, the build deletes a path an unrelated
guard has already listed and not yet opened.

Measured, not assumed: 25 batched runs of the three files together, **1 ENOENT failure**, thrown
inside `claims-lede-truth.test.mjs`'s "no public surface says an AI agent pools capital" test on
`apps/app/dist/index.html`. One in 25 is the rate that gets filed as flakiness.

`scripts/test/claims-token-absence.test.mjs` already carries this exact finding at its `apps/app`
group. It ran the build in its first draft, hit the same ENOENT, and dropped it, recording that
"the build does not belong in a guard that shares a process batch with a repository walk" and that
`claims.test.mjs` "runs on its own". This PR makes that last clause true.

So: a root `test:app` script, invoked as its own step by both `scripts/gate.mjs` and `ci.yml`,
ordered immediately before `test:backend` so the walks that follow read a `dist` matching `src`.

## The sweep, and the guard that keeps it swept

Every `*.test.mjs` in the repository, 79 files, diffed against what the pipelines execute.
`apps/app/test/claims.test.mjs` was the only orphan. `apps/site-next/test/site.test.mjs` is not one:
it runs as the separate `site-test` step. No other test file shape exists here, no `.test.js`,
no `.spec.*`, tracked or untracked.

A one-word glob fix would drift again the next time a workspace gains tests, so
`scripts/test/test-wiring-truth.test.mjs` now asserts the wiring itself:

1. **Coverage.** Every `*.test.mjs` walked off the filesystem is matched by a glob in some wired
   script. The wired set is *derived*, read out of the root `scripts` block (any script containing
   `node --test`) and each workspace's `test` script, never restated here. Hardcoding the nine
   directories would rebuild the same hand-maintained list inside the guard meant to police it.
2. **Invocation.** Every wired script is invoked by both `scripts/gate.mjs` and
   `.github/workflows/ci.yml`. A script nothing calls is the same defect one level up. What is
   matched is the invocation and *not* the script's name: a `.includes('test:app')` over
   `gate.mjs` is satisfied by the step's own `title` and by the comment explaining why the step
   exists, so the step could be deleted and the leftover prose would read as wired. The first
   draft of this file had exactly that hole, and it is the shape of the defect being guarded, a
   check whose input can be satisfied by something that is not the thing. It now matches the
   argument vector (`'run', 'test:app'`) and the shell line (`npm run test:app`).
3. **Non-vacuity.** At least 70 files walked (79 today, a floor and not a count), at least 3 wired
   scripts, and every glob token matches at least one file. A dead glob is the same drift running
   the other way, and it reports nothing.

`.claude` is in `SKIP_DIRS` alongside `node_modules` and `.git`, matching the other two walkers:
around ten sessions keep full worktrees under `.claude/worktrees/`, and a walk that descended into
them would find every test file many times over.

## Mutation evidence

A wiring change that cannot be shown to fail is the same defect again. Five mutations, each applied
and reverted:

| mutation | result |
|---|---|
| `FACTORY` set to a wrong address in `claims.test.mjs` | full `npm run gate` **FAILED on `app-test`**, `not ok 2 - the built page names the factory address` |
| the same, reverted | `GATE PASSED` |
| `test:app` deleted from package.json, that is the exact `protocol/main` state | `npm run gate -- --only backend` **FAILED**, meta-guard names `apps/app/test/claims.test.mjs` under "Not run anywhere" |
| `apps/web/test/*.test.mjs` dropped from `test:backend` | meta-guard red, all 10 `apps/web` files listed |
| **only** the `args: ['run', 'test:app']` line deleted from `gate.mjs`, `title` and comment left intact | meta-guard red: "scripts/gate.mjs does not invoke `npm run test:app`" |
| **only** the `run: npm run test:app` line deleted from `ci.yml`, comment left intact | meta-guard red on `ci.yml` |
| **only** the `args: ['test', '--workspace', 'apps/site-next']` line deleted, the `site-build` `--workspace` step left intact | meta-guard red, so a `build` step cannot stand in for the `test` step |

The third one matters most: the new guard turns red on the tree as it stands today on
`protocol/main`, so it would have caught the original defect rather than being written after it.

## Gate

`npm run gate` from the repo root, full, in a scratchpad worktree:

```
  pass  fmt 0.1s        pass  syntax 0.3s    pass  build 1.1s     pass  opscheck 0.1s
  pass  site-build 2.4s pass  app-test 0.5s  pass  backend 2.9s   pass  site-test 0.6s
  pass  test 9.5s       pass  snapshot 9.7s  pass  sizes 1.1s     warn  slither (advisory)
GATE PASSED (39.7s) 1 advisory warning(s)
```

`app-test` is the new step, between `site-build` and `backend`.

No contract source changed, so no gas regeneration and no EIP-170 measurement applies. No assertion
was weakened: the six existing assertions in `claims.test.mjs` are byte-identical, and the only edit
to that file is its header, which claimed in prose that it was unwired.
