### PR TITLE
fix(api): four OpenAPI descriptions were being truncated by an unquoted comma

### DIFF
--- a/apps/api/test/openapi-flow-scalars.test.mjs
+++ b/apps/api/test/openapi-flow-scalars.test.mjs
@@ -1,0 +1,273 @@
+// @ts-check
+/**
+ * `docs/api/openapi.yaml` writes most short property schemas as YAML FLOW mappings, one per line:
+ *
+ *     totalShares: { type: string, description: WAD, decimal string }
+ *
+ * Inside `{ }` an unquoted comma is a SEPARATOR, not text. So that line does not mean what it
+ * reads as. It parses to `{type: string, description: WAD, "decimal string": null}` — the
+ * description is truncated to its first word, and a junk key with a null value is injected into
+ * the schema. Four lines were written that way and every one of them had been read, reviewed and
+ * shipped, because the damage is invisible until something actually parses the file: the API
+ * server never does, and the sibling `openapi-vaultview.test.mjs` reads it by indentation.
+ *
+ * This guard closes that. It does not check a list of known-bad lines — it validates the SHAPE, so
+ * a flow mapping written tomorrow is covered without anyone remembering this file exists.
+ *
+ * WHY IT PARSES BY HAND. The repo ships no YAML dependency, and `scripts/gate.mjs` says outright
+ * that the gate does not run `npm ci` — "the one case where a green gate can still meet a red CI"
+ * is a lockfile change. Adding `js-yaml` to catch a punctuation bug would put this change into
+ * exactly that hole. So the scan implements the one piece of YAML that matters here: splitting a
+ * flow mapping into entries.
+ *
+ * WHY IT SELF-TESTS. Once the four lines are fixed, a detector that finds nothing passes forever,
+ * including when it has silently stopped matching anything at all. So there is a floor on the
+ * number of mappings scanned (85 of them when this was written), an unbalanced brace is a failure
+ * rather than a skip, and the three shapes that break naive tokenizers — an apostrophe inside a
+ * plain scalar, braces inside a quoted one, and an OpenAPI path template — are asserted CLEAN
+ * against inline fixtures.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const SPEC = fileURLToPath(new URL('../../../docs/api/openapi.yaml', import.meta.url));
+
+/**
+ * Is `text[i]` at a position where a NODE may begin?
+ *
+ * This is the whole subtlety of the format. `'`, `"`, `{` and `[` are indicators only at the start
+ * of a node; inside a plain scalar they are ordinary characters. Two shapes in this very file turn
+ * on it:
+ *
+ *   - `description: the vault's USDC token address` — an apostrophe, not a quote. A tokenizer that
+ *     flips a flag on every `'` swallows the rest of the line and never finds the closing brace.
+ *   - `/vaults/{address}:` — an OpenAPI path template. The `{` is the fourth character of a plain
+ *     scalar that started at `/`, so it opens nothing. Treating it as a flow mapping reports a
+ *     perfectly good path as malformed.
+ *
+ * A node begins at the start of a line, or after `{`, `[`, `,`, `:`, or a `-` that is itself a
+ * block-sequence dash rather than a hyphen inside a word.
+ * @param {string} text
+ * @param {number} i
+ */
+function atNodeStart(text, i) {
+  for (let j = i - 1; j >= 0; j--) {
+    const c = text[j];
+    if (c === ' ') continue;
+    if (c === '-') return j === 0 || text[j - 1] === ' '; // `- { … }`, not `Mode-{…}`
+    return c === '{' || c === '[' || c === ',' || c === ':';
+  }
+  return true; // nothing but space to the left: the node starts here
+}
+
+/**
+ * Index of the `}` closing the flow mapping that opens at `open`, or -1 if it does not close in
+ * `text`. Quoted scalars are skipped whole, so `pattern: '^0x[0-9a-fA-F]{40}$'` cannot move the
+ * depth — that one balances by luck, which is worse than not balancing.
+ * @param {string} text
+ * @param {number} open  index of the opening `{`
+ */
+function matchBrace(text, open) {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if ((c === "'" || c === '"') && atNodeStart(text, i)) {
+      const end = text.indexOf(c, i + 1);
+      if (end === -1) return -1; // unterminated quote: refuse to guess
+      i = end;
+      continue;
+    }
+    if ((c === '{' || c === '[') && atNodeStart(text, i)) depth++;
+    else if ((c === '}' || c === ']') && depth > 0) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * The top-level entries of a flow mapping `{ ... }`, split on the commas that actually separate —
+ * not the ones inside a nested collection or a quoted scalar.
+ * @param {string} mapping  including the outer braces
+ * @returns {string[]}
+ */
+function splitEntries(mapping) {
+  const body = mapping.slice(1, -1);
+  const out = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if ((c === "'" || c === '"') && atNodeStart(body, i)) {
+      const end = body.indexOf(c, i + 1);
+      assert.notEqual(end, -1, `unterminated quoted scalar in ${mapping}`);
+      i = end;
+      continue;
+    }
+    if ((c === '{' || c === '[') && atNodeStart(body, i)) depth++;
+    else if ((c === '}' || c === ']') && depth > 0) depth--;
+    else if (c === ',' && depth === 0) {
+      out.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  out.push(body.slice(start));
+  return out.map((e) => e.trim()).filter((e) => e !== '');
+}
+
+/**
+ * Entries of `mapping` that do not carry one whole scalar — what an unquoted comma or colon inside
+ * a flow scalar leaves behind. Recurses into nested flow mappings, so
+ * `payment-response: { schema: { type: string } }` is checked all the way down.
+ *
+ * Two shapes, because the two punctuation marks fail differently:
+ *
+ *   - A comma SPLITS, leaving a fragment with no value at all (`decimal string`). That is the bug
+ *     this file was written for, and it parses silently.
+ *   - A colon-space NESTS, so `description: see: this` is a mapping value inside a mapping value.
+ *     That is a hard parse error rather than silent truncation, which is why the file had none —
+ *     but the check is here so the message can name both, and so a `key: a: b` added tomorrow is
+ *     reported by name instead of as a stack trace from whatever tries to load the spec.
+ * @param {string} mapping  including the outer braces
+ * @returns {string[]}
+ */
+function malformedEntries(mapping) {
+  const bad = [];
+  for (const entry of splitEntries(mapping)) {
+    // `key: value`. The key may be quoted; the value must be non-empty. An entry with no `:` at all
+    // is the truncation artifact, and `key:` with nothing after it is a null value written out.
+    const m = /^(?:'[^']*'|"[^"]*"|[^:'"]+?)\s*:\s*(\S.*)$/.exec(entry);
+    if (!m) {
+      bad.push(entry);
+      continue;
+    }
+    const value = m[1].trim();
+    if (value.startsWith('{')) {
+      const close = matchBrace(value, 0);
+      assert.equal(close, value.length - 1, `nested flow mapping does not close cleanly: ${entry}`);
+      bad.push(...malformedEntries(value));
+      continue;
+    }
+    // A second `: ` in a PLAIN value. Quoting it is what makes it text, so a quoted value is fine
+    // however many colons it holds.
+    const quoted = /^'[^']*'$/.test(value) || /^"[^"]*"$/.test(value);
+    if (!quoted && /:\s/.test(value)) bad.push(entry);
+  }
+  return bad;
+}
+
+/**
+ * Every flow mapping in `text`, as `{ line, mapping }`. A `{` that does not close on its own line is
+ * a hard failure: every flow mapping in this file is single-line, and a multi-line one must not be
+ * able to slip past the scan by being unrecognised.
+ * @param {string} text
+ */
+function flowMappings(text) {
+  const found = [];
+  const lines = text.split(/\r?\n/);
+  let blockIndent = -1; // inside a `|` / `>` block scalar, where braces are literal text
+  for (let n = 0; n < lines.length; n++) {
+    const line = lines[n];
+    const indent = line.length - line.trimStart().length;
+    if (blockIndent >= 0) {
+      if (line.trim() === '' || indent > blockIndent) continue;
+      blockIndent = -1;
+    }
+    if (/:\s*[|>][-+]?\d*\s*$/.test(line)) {
+      blockIndent = indent;
+      continue;
+    }
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if ((c === "'" || c === '"') && atNodeStart(line, i)) {
+        const end = line.indexOf(c, i + 1);
+        if (end === -1) break; // plain scalar with an apostrophe; nothing structural left to find
+        i = end;
+        continue;
+      }
+      if (c !== '{' || !atNodeStart(line, i)) continue;
+      const close = matchBrace(line, i);
+      assert.notEqual(close, -1,
+        `docs/api/openapi.yaml:${n + 1} opens a flow mapping that does not close on its line, which this scan cannot check:\n  ${line}`);
+      found.push({ line: n + 1, mapping: line.slice(i, close + 1) });
+      i = close;
+    }
+  }
+  return found;
+}
+
+test('every flow-mapping entry in the OpenAPI spec carries one whole scalar', async () => {
+  const mappings = flowMappings(await readFile(SPEC, 'utf8'));
+
+  // A detector that has stopped matching anything reports the same green as a clean file. It does
+  // not here: the spec is written almost entirely in flow mappings — 85 of them when this was
+  // written — so a collapse of the scan is visible rather than silent.
+  assert.ok(mappings.length >= 70,
+    `scanned only ${mappings.length} flow mappings in docs/api/openapi.yaml — the scan has gone blind, not the file clean`);
+
+  const offences = [];
+  for (const { line, mapping } of mappings) {
+    for (const entry of malformedEntries(mapping)) {
+      offences.push(`docs/api/openapi.yaml:${line}: "${entry}" is not one whole scalar — an unquoted comma or colon ended the scalar before it early. Quote it.\n    ${mapping}`);
+    }
+  }
+  assert.deepEqual(offences, [], `\n${offences.join('\n')}\n`);
+});
+
+test('the flow-mapping scanner survives the shapes that break naive tokenizers', () => {
+  // Fixtures, not file lines: these keep meaning something after the file is clean.
+  assert.deepEqual(
+    malformedEntries('{ type: string, description: WAD, decimal string }'),
+    ['decimal string'],
+    'an unquoted comma inside a flow scalar must be reported',
+  );
+  assert.deepEqual(
+    malformedEntries('{ type: integer, description: 0 Rebalance, 1 RuleChange, 2 ChildAllocation }'),
+    ['1 RuleChange', '2 ChildAllocation'],
+    'every fragment after the first comma is a separate junk key',
+  );
+  assert.deepEqual(
+    malformedEntries("{ type: string, description: the vault's USDC token address }"),
+    [],
+    "an apostrophe inside a plain scalar is not a quote and must not be treated as one",
+  );
+  assert.deepEqual(
+    malformedEntries("{ type: string, pattern: '^0x[0-9a-fA-F]{40}$' }"),
+    [],
+    'braces inside a quoted scalar are text, not structure',
+  );
+  assert.deepEqual(
+    malformedEntries("{ type: [string, 'null'], description: \"max NAV in USDC base units; 0 = uncapped\" }"),
+    [],
+    'commas inside a nested sequence, and inside a quoted scalar, do not separate entries',
+  );
+  assert.deepEqual(
+    malformedEntries('{ schema: { type: string, description: WAD, decimal string } }'),
+    ['decimal string'],
+    'the scan must recurse into nested flow mappings',
+  );
+  assert.deepEqual(
+    malformedEntries('{ type: string, description: see: this }'),
+    ['description: see: this'],
+    'an unquoted colon-space nests instead of splitting, and is a parse error rather than silent truncation',
+  );
+  assert.deepEqual(
+    malformedEntries('{ type: string, description: "a note: with a colon in it" }'),
+    [],
+    'a quoted value may hold as many colons as it likes',
+  );
+
+  // And the scanner itself: it must find the mappings, skip what only looks like one, and refuse a
+  // shape it cannot check.
+  assert.equal(flowMappings("a: { b: c }\nd: |\n  { not: yaml, at all }\n").length, 1,
+    'a brace inside a block scalar is literal text, not a flow mapping');
+  assert.deepEqual(flowMappings('  /vaults/{address}:\n'), [],
+    'an OpenAPI path template is a plain scalar — its brace opens no flow mapping');
+  assert.equal(flowMappings('  - { name: address, in: path }\n').length, 1,
+    'a flow mapping as a block-sequence entry is still scanned');
+  assert.throws(() => flowMappings('a: { b: c\n'), /does not close on its line/,
+    'a multi-line flow mapping must fail loudly rather than be skipped');
+});

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -179,7 +179,7 @@ components:
         scheme: { type: string, enum: [exact] }
         x402Version: { type: integer, enum: [2] }
         asset: { type: string, description: USDC token address }
-        amount: { type: string, description: integer, USDC base units (6dp) }
+        amount: { type: string, description: "integer, USDC base units (6dp)" }
         payTo: { type: string }
         network: { type: string, example: base }
         nonce: { type: string }
@@ -209,12 +209,12 @@ components:
         creator: { type: string }
         usdc: { type: string, description: the vault's USDC token address }
         operatorId: { type: integer }
-        totalShares: { type: string, description: WAD, decimal string }
+        totalShares: { type: string, description: "WAD, decimal string" }
         idleUsdc: { type: string }
         memberCount: { type: integer }
         pendingCount: { type: integer, description: deposits in the 4h observation window }
         capacityCapUsdc: { type: string, description: "max NAV in USDC base units; 0 = uncapped" }
-        parent: { type: [string, 'null'], description: sub-vault parent, or null for a root }
+        parent: { type: [string, 'null'], description: "sub-vault parent, or null for a root" }
         depth: { type: integer, description: 0 root … 2 grandchild }
         holders: { type: integer }
         exitQueuedCount: { type: integer, description: lifetime ExitQueued events (Mode-F exit requests) }
@@ -240,7 +240,7 @@ components:
           properties:
             pid: { type: integer }
             vault: { type: string }
-            ptype: { type: integer, description: 0 Rebalance, 1 RuleChange, 2 ChildAllocation }
+            ptype: { type: integer, description: "0 Rebalance, 1 RuleChange, 2 ChildAllocation" }
             proposer: { type: string }
             status: { type: string, enum: [Active, Passed, Defeated, Executed, Expired] }
             forWeight: { type: string, description: decimal string — vote weights serialize as strings }


### PR DESCRIPTION
## The bug

Inside a YAML flow mapping a comma is a **separator**, not text. So this line in
`docs/api/openapi.yaml`:

```yaml
totalShares: { type: string, description: WAD, decimal string }
```

does not mean what it reads as. It parses to:

```json
{"type": "string", "description": "WAD", "decimal string": null}
```

The description is cut to its first word, and a junk key with a null value is injected into the
schema. Four properties were written that way, producing five null-valued keys between them:

| Property | Description as written | Description as parsed | Junk key(s) injected |
|---|---|---|---|
| `Challenge.amount` | `integer, USDC base units (6dp)` | `integer` | `USDC base units (6dp)` |
| `VaultView.totalShares` | `WAD, decimal string` | `WAD` | `decimal string` |
| `VaultView.parent` | `sub-vault parent, or null for a root` | `sub-vault parent` | `or null for a root` |
| `activeProposal.ptype` | `0 Rebalance, 1 RuleChange, 2 ChildAllocation` | `0 Rebalance` | `1 RuleChange`, `2 ChildAllocation` |

`ptype` is the worst of them: it loses two thirds of the enum it exists to document, and a client
generating types off this spec gets phantom optional members named `2 ChildAllocation`.

The damage is invisible until something actually parses the file. The API server never does — it
serves a hand-written JSON body — and the sibling guard `openapi-vaultview.test.mjs` reads the
file by indentation and says so. So four broken lines were read, reviewed and shipped.

## The fix

The four scalars are quoted. That is the form already used on the three longer descriptions in the
same file (`enabled`, `attested`, `capacityCapUsdc`), so it introduces no new convention, and it
keeps every property key at the same indent — which is what `openapi-vaultview.test.mjs` reads, so
that test is untouched and still green.

Verified independently with PyYAML, walking the parsed document for null-valued keys:

```
before:  5 null-valued keys
after:   0
```

and all four descriptions round-trip whole.

## The guard

`apps/api/test/openapi-flow-scalars.test.mjs` is the other half. Without it, this recurs the next
time someone writes a comma.

It validates the **shape**, not a list of known-bad lines: every entry of all 85 flow mappings in
the spec must carry one whole scalar, recursing into nested mappings. A flow mapping added tomorrow
is covered without anyone remembering the file exists.

Both punctuation marks the shape can involve are checked, because they fail differently. A comma
**splits**, leaving a valueless fragment, and parses silently — that is this bug. A colon-space
**nests**, which is a hard parse error rather than truncation, and is why the file contained no
instance of it (PyYAML loading the file at all is the proof). It is checked anyway, so a
`description: see: this` added tomorrow is reported by line and name rather than arriving as a
stack trace from whatever tries to load the spec.

**It parses by hand, and does not add a YAML dependency.** `scripts/gate.mjs` documents a lockfile
change as "the one case where a green gate can still meet a red CI", because the gate does not run
`npm ci`. Adding `js-yaml` to catch a punctuation bug would put this change into exactly that hole.
The scan implements the one piece of YAML that matters here — splitting a flow mapping into
entries — so the test is a flow-mapping entry validator, not a YAML loader.

**It self-tests, so it cannot go quietly inert.** Once the four lines are fixed a detector that
finds nothing passes forever, including when it has silently stopped matching anything at all.
Three things prevent that:

1. A floor on the number of mappings scanned — the file has exactly 85, the floor is 70. A scan
   that goes blind reads as red, not green.
2. A flow mapping that does not close on its own line is a hard failure, not a skip.
3. Inline fixtures for the three shapes that break naive tokenizers, each asserted **clean**:
   - an apostrophe inside a plain scalar — `description: the vault's USDC token address`. A
     tokenizer that flips a flag on every `'` swallows the rest of the line and never finds the
     closing brace.
   - braces inside a quoted scalar — `pattern: '^0x[0-9a-fA-F]{40}$'`. Depth counting happens to
     balance here by luck, which is worse than failing.
   - an OpenAPI path template — `/vaults/{address}:`. The `{` is the fourth character of a plain
     scalar that started at `/`, so it opens nothing. The first draft of this guard reported that
     path as malformed; the tokenizer now applies YAML's actual rule, that `'`, `"`, `{` and `[`
     are indicators only at the start of a node.

## Evidence

Red before the fix, naming every line. This is the guard as it ships, run against the file as it stands on `protocol/main` (`4f385db9`), with the middle repetition elided:

```
✖ every flow-mapping entry in the OpenAPI spec carries one whole scalar
  docs/api/openapi.yaml:182: "USDC base units (6dp)" is not one whole scalar — an unquoted comma or colon ended the scalar before it early. Quote it.
      { type: string, description: integer, USDC base units (6dp) }
  docs/api/openapi.yaml:212: "decimal string" is not one whole scalar — ...
      { type: string, description: WAD, decimal string }
  docs/api/openapi.yaml:217: "or null for a root" is not one whole scalar — ...
      { type: [string, 'null'], description: sub-vault parent, or null for a root }
  docs/api/openapi.yaml:243: "1 RuleChange" is not one whole scalar — ...
      { type: integer, description: 0 Rebalance, 1 RuleChange, 2 ChildAllocation }
  docs/api/openapi.yaml:243: "2 ChildAllocation" is not one whole scalar — ...
      { type: integer, description: 0 Rebalance, 1 RuleChange, 2 ChildAllocation }
```

Five offences, matching PyYAML's five null-valued keys exactly — no misses, no false positives.
Green after.

And it catches a **reintroduced** break, which is the part that matters after this merges:
un-quoting `totalShares` alone turns the guard red on line 212 and nothing else.

`npm run gate` from the repo root, on `5ddb4f86` (the head of this branch):

```
  pass             fmt        0.2s
  pass             syntax     0.3s
  pass             build      349.3s
  pass             opscheck   0.1s
  pass             site-build 4.1s
  pass             backend    4.8s
  pass             site-test  0.6s
  pass             test       10.4s
  pass             snapshot   10.4s
  pass             sizes      1.2s
  warn             slither    12.5s

GATE PASSED (394.0s) 1 advisory warning(s)
```

The Slither warning is the pre-existing advisory baseline (236 results, the figure recorded in
`docs/SWARM.md` §2), unchanged by this PR and `continue-on-error` in CI exactly as locally.

The guard is collected by the gate, not just runnable by hand — `npm run test:backend` matches it
through `apps/api/test/*.test.mjs`, confirmed by grepping its own test name out of that run.

## Scope

Docs and test only. No `src/` change, so no EIP-170 measurement applies; no gas change, so the
snapshot is untouched (it was regenerated by the gate and came back clean).

Deliberately **not** changed: the descriptions that contain a comma-free em dash, ellipsis or
parentheses (`depth`, `exitQueuedCount`, `exitSettledCount`, `forWeight`). Those are valid plain
scalars and round-trip whole — the guard confirms it. Rewriting them would be churn.

Also deliberately not done: extending the scan to other YAML in the repo. `.github/workflows/*.yml`
carries `${{ … }}` expressions that this tokenizer would have to special-case, and the payoff is a
class of bug that has not occurred there. Scoped to `docs/api/openapi.yaml`, which is the published
API contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
