### PR TITLE
feat(web): say on the page that a queued exit stripped the vote

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -185,6 +185,8 @@
   .panel .row.total{background:var(--surface-2);font-weight:600}
   .panel .row small{display:block;font-family:var(--sans);font-weight:400;font-size:11.5px;color:var(--muted);margin-top:2px;max-width:40ch}
   .panel .row .v{font-family:var(--mono);font-variant-numeric:tabular-nums;white-space:nowrap}
+  /* Never the only carrier of the fact: the row's own `small` always states it in words. */
+  .panel .row .v[data-sev="warn"]{color:var(--warn)}
 
   /* basket + oracle feeds */
   .basket{display:flex;flex-direction:column;gap:9px}
@@ -619,6 +621,29 @@ function renderActionBar(x) {
   </div>`;
 }
 
+/**
+ * Why the voting-eligible number differs from the share balance, in the contract's own terms.
+ * A queued exit strips the vote silently: the shares are still held, still valued, and still
+ * shown — and a strip that stopped at "Shares held" said nothing about the vote they no longer
+ * carry. The derivation is in `vault-view.mjs`; this is only its copy.
+ */
+function votingNote(vt) {
+  if (vt.reason === 'parent') {
+    return 'Zero: a registered parent vault holds shares in its child but is excluded from ' +
+      'voting-eligible stake and from the holder count. Its members vote in the parent instead.';
+  }
+  if (vt.reason === 'queued') {
+    return `${wadExact(vt.lockedShares, { maxFrac: 6 })} of your shares left voting-eligible ` +
+      'stake the moment you queued your exit. They stay outstanding and keep gaining and losing ' +
+      'with the vault. Nothing un-queues them: the lock ends only when settleQueuedExit(you) is ' +
+      'called, a separate call anyone can make once no execution is pending, and that settlement ' +
+      'burns exactly the locked shares, so the vote does not come back with them.';
+  }
+  return 'Your whole balance, because nothing here is locked. Queueing an exit subtracts from ' +
+    'this number the moment you queue, and vote weight and quorum stake are read from ' +
+    'voting-eligible shares, never from the share count above.';
+}
+
 function renderPositionStrip(x) {
   const p = x.position;
   const pend = x.pendingDeposit;
@@ -627,6 +652,8 @@ function renderPositionStrip(x) {
   if (p && p.shares > 0n) {
     html += `<div class="row"><div>Shares held<small>Non-transferable: exiting is the only way out.</small></div>
       <div class="v">${esc(wadExact(p.shares, { maxFrac: 6 }))}</div></div>
+      <div class="row"><div>Voting-eligible shares<small>${esc(votingNote(p.voting))}</small></div>
+        <div class="v"${p.voting.eligibleShares < p.shares ? ' data-sev="warn"' : ''}>${esc(wadExact(p.voting.eligibleShares, { maxFrac: 6 }))}</div></div>
       <div class="row"><div>Value today</div><div class="v">${p.valueUsdc !== null ? esc(usdcExact(p.valueUsdc)) : 'Unknown while frozen'}</div></div>
       <div class="row"><div>Cost basis</div><div class="v">${p.costBasisUsdc !== null ? esc(usdcExact(p.costBasisUsdc)) : '—'}</div></div>
       <div class="row"><div>Exit fee today<small>${esc(duration(p.tenureSec))} of tenure. ${p.isSoleHolder ? 'Waived: you are the only member, and the fee accrues to remaining members.' : 'Paid to the members who stay, never to the operator.'}</small></div>

--- a/apps/web/src/vault-view.mjs
+++ b/apps/web/src/vault-view.mjs
@@ -56,12 +56,55 @@ export function oracleHealth(basket, nowSec) {
 }
 
 /**
+ * Voting-eligible stake, mirroring `VaultCore.votingEligibleShares` (VaultCore.sol:1025-1028):
+ * the parent vault reads 0, everyone else reads `sharesOf[member] - queuedExitShares[member]`.
+ *
+ * It is its own derivation because both subtractions are invisible on a page that shows only a
+ * share balance. A Mode-F exit locks shares the instant it is QUEUED — `requestExit` writes
+ * `queuedExitShares` and calls `_snapshot` in the same transaction (VaultCore.sol:551-556) — and
+ * `requestExit(shares)` takes any amount up to the balance, so a PARTIAL queue leaves a real
+ * voting remainder that "queued / not queued" alone cannot express.
+ *
+ * `eligibleShares` is not the same claim as "shares you can vote with today": `commitVote` weighs
+ * `min(pastVotingEligibleShares(createdAt-1), votingEligibleShares(now))` (Governance.sol:352-356),
+ * so stake minted after a proposal was created is eligible here and still carries no weight in
+ * that proposal. This is the eligibility term, and nothing more.
+ *
+ * @param {{shares:bigint, queuedExitShares:bigint, isParentVault:boolean}} p
+ * @returns {{shares:bigint, lockedShares:bigint, eligibleShares:bigint, isParentVault:boolean,
+ *            reason:'parent'|'queued'|'full'}}
+ */
+export function votingEligibility({ shares, queuedExitShares, isParentVault }) {
+  // The carve-out is the contract's FIRST branch and never reads `queuedExitShares`, so a parent
+  // vault reports its zero for the reason the contract gives, queued exit or not.
+  if (isParentVault) {
+    return { shares, lockedShares: 0n, eligibleShares: 0n, isParentVault: true, reason: 'parent' };
+  }
+  // Clamped defensively only: `requestExit` requires `sharesOf >= shares`, shares are
+  // non-transferable, and a member with a queued exit cannot queue again, so the contract cannot
+  // reach queued > held. Incoherent input renders as zero, never as a negative share count.
+  const locked = queuedExitShares > shares ? shares : queuedExitShares;
+  return {
+    shares,
+    lockedShares: locked,
+    eligibleShares: shares - locked,
+    isParentVault: false,
+    reason: locked > 0n ? 'queued' : 'full',
+  };
+}
+
+/**
  * The viewer's position in one vault, valued at the vault's NAV/share.
+ * @param {object} vault
+ * @param {object|null} holding
+ * @param {number} nowSec
+ * @param {string|null} [viewerAddress] whose position this is — compared against the vault's
+ *   registered parent, to mirror the contract's parent-vault carve-out
  * @returns {{shares:bigint, valueUsdc:bigint|null, costBasisUsdc:bigint|null,
  *            pnlUsdc:bigint|null, tenureSec:number, feeBpsNow:bigint, isSoleHolder:boolean,
- *            queuedExitShares:bigint}|null}
+ *            queuedExitShares:bigint, voting:ReturnType<typeof votingEligibility>}|null}
  */
-export function position(vault, holding, nowSec) {
+export function position(vault, holding, nowSec, viewerAddress) {
   if (!vault || !holding) return null;
   const shares = toBig(holding.shares) ?? 0n;
   const totalShares = toBig(vault.totalShares) ?? 0n;
@@ -77,6 +120,12 @@ export function position(vault, holding, nowSec) {
 
   const tenureSec = Math.max(0, nowSec - Number(holding.lastDepositTime ?? nowSec));
   const isSoleHolder = totalShares > 0n && shares === totalShares;
+  const queuedExitShares = toBig(holding.queuedExitShares) ?? 0n;
+
+  // A ROOT vault carries `parent: null`, and `parentVault()` returns address(0) there — never a
+  // member — so the carve-out cannot bite, and a record missing the field reads as root. Both
+  // record producers set it: `fixtures.mjs` verbatim, `mapVaultRecords` as `v.parent ?? null`.
+  const parent = vault.parent ?? null;
 
   return {
     shares,
@@ -91,7 +140,12 @@ export function position(vault, holding, nowSec) {
       isSoleHolder,
     }),
     isSoleHolder,
-    queuedExitShares: toBig(holding.queuedExitShares) ?? 0n,
+    queuedExitShares,
+    voting: votingEligibility({
+      shares,
+      queuedExitShares,
+      isParentVault: parent !== null && eqAddr(viewerAddress, parent),
+    }),
   };
 }
 
@@ -128,7 +182,7 @@ export function vaultView(vault, wallet, nowSec) {
 
   // The derived freeze state, not the record's own flag, decides whether the position can be
   // valued — so a card and the detail page cannot disagree about it.
-  const pos = position({ ...vault, frozen }, holding, nowSec);
+  const pos = position({ ...vault, frozen }, holding, nowSec, wallet?.address ?? null);
 
   const mode = resolveExitMode(vault.proposal ?? null, nowSec);
 

--- a/apps/web/test/vault-view.test.mjs
+++ b/apps/web/test/vault-view.test.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { oracleHealth, position, vaultView, SORTS } from '../src/vault-view.mjs';
+import { oracleHealth, position, votingEligibility, vaultView, SORTS } from '../src/vault-view.mjs';
 import { VAULTS, WALLET, NOW, vaultByAddress } from '../src/fixtures.mjs';
 import { mapVaultRecords } from '../src/live-adapter.mjs';
 import { PROPOSAL_UNKNOWN } from '../src/governance.mjs';
@@ -192,4 +192,71 @@ test('sorts rank on the named signal, and tolerate a missing one', () => {
   }
   const byFee = [...views].sort(SORTS.fee.fn);
   assert.equal(byFee[0].fees.exitFeeMaxBps, 0, 'lowest exit fee first');
+});
+
+test('votingEligibility mirrors votingEligibleShares, including a partial queue', () => {
+  // VaultCore.sol:1025-1028 — `if (member == parentVault()) return 0; return sharesOf[member] -
+  // queuedExitShares[member]`. `requestExit(shares)` takes any amount up to the balance
+  // (VaultCore.sol:545-547), so a partial queue leaves a voting remainder, and a strip that only
+  // knew "queued / not queued" would report that remainder as nothing.
+  const partial = votingEligibility({ shares: 100n * WAD, queuedExitShares: 30n * WAD, isParentVault: false });
+  assert.equal(partial.eligibleShares, 70n * WAD);
+  assert.equal(partial.lockedShares, 30n * WAD);
+  assert.equal(partial.reason, 'queued');
+
+  const whole = votingEligibility({ shares: 100n * WAD, queuedExitShares: 100n * WAD, isParentVault: false });
+  assert.equal(whole.eligibleShares, 0n, 'a queue for the whole balance leaves no vote at all');
+  assert.equal(whole.reason, 'queued');
+
+  const none = votingEligibility({ shares: 100n * WAD, queuedExitShares: 0n, isParentVault: false });
+  assert.equal(none.eligibleShares, 100n * WAD);
+  assert.equal(none.lockedShares, 0n);
+  assert.equal(none.reason, 'full');
+});
+
+test('votingEligibility carves out the parent vault, queued exit or not', () => {
+  // The carve-out is the FIRST branch in the contract and does not read queuedExitShares at all:
+  // a registered parent holds shares in its child and is excluded from eligible stake and from
+  // the holder count (`_snapshot` pushes 0 for it — VaultCore.sol:509-517).
+  const p = votingEligibility({ shares: 500n * WAD, queuedExitShares: 0n, isParentVault: true });
+  assert.equal(p.eligibleShares, 0n);
+  assert.equal(p.lockedShares, 0n, 'zero because it is the parent, not because anything is queued');
+  assert.equal(p.reason, 'parent');
+});
+
+test('position states the voting-eligible amount, so a queued exit does not silently strip the vote', () => {
+  // The soak case: a member holding ~20% of a vault whose votingEligibleShares reads 0, with
+  // nothing on the page saying so. 0x2222's holder has queued their whole balance.
+  const view = vaultView(vaultByAddress('0x2222000000000000000000000000000000002222'), WALLET, NOW);
+  assert.equal(view.facts.hasQueuedExit, true);
+  assert.ok(view.position.shares > 0n, 'still holds shares — they are locked, not burned');
+  assert.equal(view.position.voting.eligibleShares, 0n);
+  assert.equal(view.position.voting.lockedShares, view.position.shares);
+  assert.equal(view.position.voting.reason, 'queued');
+
+  // A vault the same wallet holds with nothing queued keeps its whole vote.
+  const open = vaultView(vaultByAddress('0x1111000000000000000000000000000000001111'), WALLET, NOW);
+  assert.equal(open.position.voting.eligibleShares, open.position.shares);
+  assert.equal(open.position.voting.reason, 'full');
+});
+
+test('position resolves the parent-vault carve-out from the record, not from a guess', () => {
+  // 0x3333 is a sub-vault whose `parent` is 0x1111. Viewed AS that parent, the position holds
+  // shares and carries no vote; viewed as anyone else, the same holding votes in full.
+  const sub = vaultByAddress('0x3333000000000000000000000000000000003333');
+  const holding = { vault: sub.address, shares: 245n * WAD, costBasisUsdc: 0n, lastDepositTime: NOW };
+
+  const asParent = position(sub, holding, NOW, sub.parent);
+  assert.equal(asParent.voting.eligibleShares, 0n);
+  assert.equal(asParent.voting.reason, 'parent');
+
+  const asMember = position(sub, holding, NOW, WALLET.address);
+  assert.equal(asMember.voting.eligibleShares, 245n * WAD);
+  assert.equal(asMember.voting.reason, 'full');
+
+  // A ROOT vault carries `parent: null`, so the carve-out can never bite: address(0) is not a
+  // member. Reading a root record must not turn a wallet with no address into the parent.
+  const root = vaultByAddress('0x1111000000000000000000000000000000001111');
+  assert.equal(root.parent, null);
+  assert.equal(position(root, { ...holding, vault: root.address }, NOW, null).voting.reason, 'full');
 });


### PR DESCRIPTION
## What this closes

A Base Sepolia soak found a member holding ~20% of a vault whose `votingEligibleShares` read `0`,
with nothing telling them. The machine-facing half was closed on the indexer projection and the
metered API (`memberPosition` now returns `queuedExitShares`, `votingEligibleShares` and
`votingEligibleNote`). `apps/web` was still silent.

It already warns at QUEUE time (`index.html:1082-1083`, `:1116`) and renders a "Settle my queued
exit" button afterwards. But `renderPositionStrip` showed only Shares held, Value today, Cost basis
and Exit fee today — so **after** queueing, the page showed the shares and said nothing about the
vote they no longer carry. This is a separate change from the API one because it is a separate data
path: `apps/web` reads its position from the record set, never from the projection.

## The change

`votingEligibility()` in `apps/web/src/vault-view.mjs`, mirroring `VaultCore.votingEligibleShares`
(`VaultCore.sol:1025-1028`) including the parent-vault carve-out, surfaced through `position()` and
rendered as one row in the position strip. The derivation is in the module because `index.html` has
no DOM test; only the row's copy lives in the page.

Three branches: `parent` (0), `queued` (balance minus the locked amount), `full`.

## Read from the contracts, not paraphrased

- `requestExit(shares)` takes any amount up to the balance (`VaultCore.sol:545-547`), so a
  **partial** queue leaves a real voting remainder. "queued / not queued" cannot express it; the row
  names the amount.
- The lock lands at QUEUE time — `requestExit` writes `queuedExitShares` and calls `_snapshot` in
  the same transaction (`VaultCore.sol:551-556`).
- It does **not** clear on Defeated / Executed / expiry. Those only make settlement *possible*.
  `settleQueuedExit(member)` is a separate call anyone can make once no execution is pending
  (`VaultCore.sol:583-593`), and it zeroes `queuedExitShares` and burns exactly those shares in
  `_settleExit` (`VaultCore.sol:639-640`) — so the eligible number does not come back with them.
- Locked shares stay outstanding and keep gaining and losing with the vault.
- The parent-vault branch is the contract's **first**, and never reads `queuedExitShares`;
  `_snapshot` pushes 0 for the parent and excludes it from the holder count
  (`VaultCore.sol:509-517`). The web side resolves it from the record's `parent` field against the
  viewer's address; a root vault carries `parent: null` and `parentVault()` is `address(0)` there,
  never a member, so the carve-out cannot bite.
- The row is **not** labelled as votable weight. `commitVote` weighs
  `min(pastVotingEligibleShares(createdAt-1), votingEligibleShares(now))` (`Governance.sol:352-356`),
  so eligibility is one term of two; that caveat is recorded in the module doc, not on screen.
  `grep -c sharesOf contracts/src/Governance.sol` is **0**, which is what the `full` note's "never
  from the share count above" rests on — narrowed from an earlier draft that said "every quorum
  read", because the sub-five regime's member-majority branch reads `pastHolderCount`, a head count.

## Test that failed first

`apps/web/test/vault-view.test.mjs` gains four tests. Against the pre-change tree:

```
# import { oracleHealth, position, votingEligibility, vaultView, SORTS } from '../src/vault-view.mjs';
#                                  ^^^^^^^^^^^^^^^^^
# SyntaxError: The requested module '../src/vault-view.mjs' does not provide an export named 'votingEligibility'
# tests 1
# pass 0
# fail 1
```

and, behind that import error, the fact the row exists to fix:

```
hasQueuedExit: true
position keys: shares, valueUsdc, costBasisUsdc, pnlUsdc, tenureSec, feeBpsNow, isSoleHolder, queuedExitShares
position.voting: undefined
```

After: 21/21 in that file, 173/173 across the claims guard + web + site suites.

## Gate

`npm run gate` from the repo root of my own worktree, on a clean tree at the committed SHA:

```
GATE PASSED (385.7s) 1 advisory warning(s)
  pass fmt / syntax / build / opscheck / site-build / backend / site-test / test / snapshot / sizes
  warn slither  -- advisory, 236 results, the pre-existing untriaged count SWARM §2 records
```

No Solidity changed, so no gas snapshot regeneration and no EIP-170 delta to report.

## Found, and deliberately not changed

- **The partial-queue branch is unreachable from the shipped fixture set.** `0x2222` queues its
  whole balance, which is the soak scenario and should stay that way — repointing it to a partial
  queue would just make the full-queue branch unreachable instead. The remainder branch is tested
  directly on the derivation rather than by adding a fixture.
- **`vault-state.mjs:112-120`'s `queued-exit` notice omits Defeated** from its resolution list
  ("when the proposal executes or expires"). `index.html:1079` gets all three. `Governance.sol:29-30`
  says `hasPendingExecution` turns false on Defeated / Executed / expiry. It is adjacent copy, not
  this row, so it is named here rather than folded into this commit.

## Uncertain

`index.html` has no DOM test, and the gate's `syntax` step covers six operational entrypoints, not
this file — so nothing in CI parses its inline module or renders this row. My verification was a
scratch harness that `node --check`ed the extracted module (80,411 chars, passes) and rendered the
strip for all three branches with stubbed formatters. **That coverage does not persist**: it lives
in my session scratchpad, not in the repo. The queued branch renders as:

> Shares held **18,400** · Voting-eligible shares **0** — "18,400 of your shares left
> voting-eligible stake the moment you queued your exit. They stay outstanding and keep gaining and
> losing with the vault. Nothing un-queues them: the lock ends only when settleQueuedExit(you) is
> called, a separate call anyone can make once no execution is pending, and that settlement burns
> exactly the locked shares, so the vote does not come back with them."
