### PR TITLE
test(claims): close the key-custody guard's two advertised gaps, and prove the patterns

### DIFF
--- a/scripts/test/claims-key-custody-truth.test.mjs
+++ b/scripts/test/claims-key-custody-truth.test.mjs
@@ -24,7 +24,8 @@
  *      required; adding to one half without the other reopens exactly this hole.
  *   2. **The SUBJECT is on a different line from the CLAIM.** "API" is on line 1, the claim on
  *      line 2. Every line-scoped grep misses it twice — once for the subject, once for the claim.
- *      So matching here is done against a WINDOW of ±`WINDOW` lines, flattened, never a line.
+ *      So the SUBJECT is looked for in a WINDOW of ±`WINDOW` lines, flattened, never a line, and
+ *      the CLAIM itself is matched over a forward join of `CLAIM_SPAN` lines (see "gap 2" below).
  *   3. **CI could not see the file at all.** `claims-lede-truth.test.mjs` walks `.md`, `.html`,
  *      `.txt` and `.json`. `.env.example` has no extension in that set — nor do `Dockerfile`,
  *      `.mjs` and `.yaml`, which between them hold most of this claim family. So this walk has NO
@@ -53,6 +54,60 @@
  * own tests. `SUBJECT` is therefore narrow on purpose: the window must name the API or its server.
  * Widening `SUBJECT` to "any process" would red a hundred true sentences, and the predictable next
  * move is relaxing the patterns until it goes quiet, which manufactures a green.
+ *
+ * ## The two completeness gaps an independent review found after this landed
+ *
+ * Both were demonstrated against synthetics and neither had a live instance in the tree. They are
+ * closed here, and the synthetics are kept as tests (`SYNTHETIC` below) because a pattern with no
+ * live instance is otherwise indistinguishable from a pattern that matches nothing.
+ *
+ *   **Gap 1 — `SVM_KEYPAIR` was advertised as a clearing token and could never match.** The
+ *   emphasis normaliser strips `*`, `_` and `` ` `` from every line before matching, so by the time
+ *   `MODE_TOKEN` saw the token it read `SVMKEYPAIR` and the `\bSVM_KEYPAIR\b` alternative was dead.
+ *   It failed SAFE — extra reds, never fewer — but the header and the assertion message both told a
+ *   reader that writing `SVM_KEYPAIR` next to a claim would clear it, and it would not. Fixed by
+ *   making the token tolerate the strip (`SVM_?KEYPAIR`) rather than by dropping `_` from the
+ *   normaliser: `_no key_` is live markdown emphasis in this repository, and a normaliser that
+ *   stopped folding it would fail UNSAFE on the claim half, which is the wrong direction for the
+ *   one character that decides whether a claim is seen at all.
+ *
+ *   **Gap 2 — the claim was matched single-line while only the subject was windowed.** This repo
+ *   hard-wraps prose at 100 columns, so `Neither the indexer nor the API process\nholds a private
+ *   key.` passed while the same sentence on one line redded. The docstring stated the windowing
+ *   property in general terms and so overstated what was implemented. Fixed by matching each claim
+ *   over `lines[i .. i + CLAIM_SPAN]` joined, and reporting the hit only when the match BEGINS
+ *   inside line `i` — which is also what keeps one wrapped claim from being reported `CLAIM_SPAN`
+ *   times. The `[^.!?]` bounds already in the negated-positive patterns stop a join at a sentence
+ *   boundary, so the join cannot weld two unrelated sentences into one claim.
+ *
+ *   Measured cost of gap 2 on the tree as it stands: zero true cross-line claims exist to catch
+ *   today (its whole value is prospective) and it produced exactly one new match, at
+ *   `apps/web/index.html:1556`, which is TRUE and is exempted below with its geometry written out.
+ *   That ratio is stated rather than buried: a reviewer will compute it.
+ *
+ * ## What was measured and DELIBERATELY NOT added
+ *
+ * The same review listed further phrasings. Widening a pattern set has a false-positive cost, and
+ * this family's value is that its reds are real, so each was measured against the tree first.
+ *
+ *   **`never signs` / `does not sign` / `cannot sign` — DECLINED.** Thirteen instances tree-wide,
+ *   every one of them TRUE, and none of them about the API: the indexer (`index-runner.mjs:5`), the
+ *   canary (`canary-runner.mjs:11`), the reference agent (`run.mjs:102`, `REFERENCE-AGENT.md:384`)
+ *   and the oracle sampler (`scripts/soak/oracle-sampler.mjs:4`) all say it about themselves. Ten
+ *   sit further than 12 lines from any API mention, but TWO do not: `docs/REFERENCE-AGENT.md:384`
+ *   at distance 5 and `docs/RUNTIME.md:432` at distance 6. A two-line edit to either paragraph
+ *   would red a true sentence. The shape is real — `FACILITATOR=svm` co-signs as fee payer, so "the
+ *   API never signs" IS false at this head — but catching it needs a subject test that requires the
+ *   API to be the SENTENCE's subject rather than merely present in the window, and that test does
+ *   not exist here. Build it, measure it against those two distances, and then add the pattern.
+ *
+ *   **`no key here` (`docs/RUNTIME.md:34`) — NOT CLOSED, and green for the wrong reason.** That
+ *   line is an ASCII-diagram annotation, `(no key here: stub/http)`, and it is true. It passes
+ *   because no pattern matches `no key here`, not because anything cleared it. Both halves of the
+ *   blindness matter: a bare `\bno keys?\b` would be wide enough to catch it, and it would then
+ *   RED, because `stub/http` is not a `MODE_TOKEN` — the token requires `FACILITATOR=stub`. So
+ *   closing the pattern alone converts a true line into a false red, and closing it properly means
+ *   rewriting the diagram annotation to carry the token. Recorded as a known limit, not fixed.
  *
  * ## This file exempts itself, and that is a real hole
  *
@@ -91,11 +146,18 @@ const SELF = path.relative(REPO, HERE).split(path.sep).join('/');
 // states that a skip list two guards disagree on is its own drift; this is the disagreement,
 // declared, with its reason. If a public page ever starts describing facilitator modes, delete
 // these two entries rather than reasoning from this paragraph.
+//
+// `lib` USED TO BE IN THIS SET AND IS NOT ANY MORE. Matching a bare directory NAME at any depth is
+// right for `node_modules` and wrong for `lib`: the entry was meant for `contracts/lib`, the forge
+// dependency checkout, but it also silenced `scripts/lib/` (6 files) and `contracts/src/lib/` (3),
+// both of which are this repository's own source. Nine files were outside the walk for no stated
+// reason. `contracts/lib` is now skipped by PATH, so the vendored checkout stays out and our source
+// comes in; `coverage:` below asserts both halves so neither can be lost to a later tidy-up.
+const SKIP_PATHS = new Set(['contracts/lib']);
 const SKIP_DIRS = new Set([
   'node_modules',
   '.git',
   '.claude',
-  'lib',
   'out',
   'cache',
   'broadcast',
@@ -121,6 +183,42 @@ const MAX_BYTES = 1024 * 1024;
 /** Lines either side of a match that count as "the same claim". See property 2 in the header. */
 const WINDOW = 3;
 
+/**
+ * Lines AFTER a line that a single claim may run into. Prose here hard-wraps at 100 columns, so a
+ * claim that starts near the end of a line finishes on the next one; two is enough for every
+ * phrasing in `CLAIM_PATTERNS` at that width and is deliberately smaller than `WINDOW`. Bigger is
+ * not free: the join is the haystack a claim is matched in, so every extra line is another chance
+ * for a pattern to weld two sentences together. The `[^.!?]` bounds inside the negated-positive
+ * patterns are the other half of that defence.
+ */
+const CLAIM_SPAN = 2;
+
+/**
+ * A line as a READER sees it, which is not how the plainest author happened to type it.
+ *
+ * 1. HTML inline emphasis. `holds <strong>no key</strong>` survives a markdown strip and did:
+ *    `apps/web/index.html` and `apps/site/*.html` are hand-written HTML, and this guard walks
+ *    them. The set is inline emphasis only — dropping BLOCK tags would fuse `<td>keyless</td>`
+ *    into the next cell and LOSE matches. Tags are dropped rather than spaced for the same reason
+ *    `**` is: the reader sees `holds no key`, one space, and the patterns are written with one.
+ * 2. Markdown emphasis. `holds **no key**` does not match /holds no key/, and bolding exactly
+ *    these words is this repository's dominant style — `**no key**`, `**Keyless by design**`,
+ *    `**non-custodial**`, `**no client for the indexed chain by design**`. Measured over the tree
+ *    when it was added: one true finding, zero new false positives. It is also the cause of gap 1,
+ *    which is fixed in `MODE_TOKEN` rather than here — see that comment for why this stays greedy.
+ * 3. Whitespace, collapsed and trimmed. Steps 1 and 2 leave double spaces behind wherever an
+ *    emphasis run sat between two words, and every pattern in this file is written with single
+ *    literal spaces, so skipping this step silently loses the matches the other two just bought.
+ *    Trimming matters for the join: an indented continuation line would otherwise contribute a
+ *    leading space that breaks a phrase straddling the boundary.
+ */
+const HTML_INLINE_EMPHASIS = /<\/?(?:b|strong|em|i|u|mark|small|code|span|kbd|samp|var|sub|sup)(?:\s[^<>]*)?>/gi;
+const normalise = (line) => line
+  .replace(HTML_INLINE_EMPHASIS, '')
+  .replace(/[*_`]/g, '')
+  .replace(/\s+/g, ' ')
+  .trim();
+
 /** Every readable text file in the repository, enumerated from the filesystem — never a list. */
 const textFiles = () => {
   const found = [];
@@ -134,7 +232,9 @@ const textFiles = () => {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (!SKIP_DIRS.has(entry.name)) walk(full);
+        if (SKIP_DIRS.has(entry.name)) continue;
+        if (SKIP_PATHS.has(path.relative(REPO, full).split(path.sep).join('/'))) continue;
+        walk(full);
       } else if (entry.isFile()) {
         if (DENY_EXT.has(path.extname(entry.name).toLowerCase())) continue;
         if (DENY_FILES.has(entry.name)) continue;
@@ -174,16 +274,43 @@ const CLAIM_PATTERNS = [
   // ── positive: the claim names its own quality ──
   /\bkeyless\b/i,
   /\bnon-?custodial\b/i,
+  /\bnot custodial\b/i,
+  /\bkey-?free\b/i,
+  /\bcustody-?free\b/i,
   /\bno keys\b/i,
   /\bno private keys?\b/i,
-  /\bholds? no (?:private )?keys?\b/i,
+  /\bno keypairs?\b/i,
+  /\bno (?:signing|secret) keys?\b/i,
+  // The holder verb and the quantifier are both open, and the ADJECTIVE SET IS CLOSED. That last
+  // point is load-bearing and was measured: adding `api` to the adjective set — which looks like an
+  // obvious omission next to `signing` and `secret` — reds two TRUE lines immediately,
+  // `docs/DEPLOYMENT.md:734` and `docs/TESTNET-CHECKLIST.md:87`, both of which say "no API key"
+  // about an Etherscan verification credential. "API key" is a different noun that happens to
+  // contain this guard's subject. Do not put it back.
+  /\b(?:holds?|has|have|carries|carry|keeps?|stores?) (?:no|zero) (?:private |signing |secret )?(?:keys?|keypairs?|key material)\b/i,
+  // Adjacent noun, same shape. One live instance tree-wide, `packages/reference-agent/src/salt.mjs:11`
+  // ("The fix is to hold no secret at all"), which is true, is about the reference agent's salt
+  // derivation, and sits more than 30 lines from any API mention. `.github/` contains the word
+  // `secret` zero times, so the CI-credential sense that would make this risky is not in the tree.
+  /\b(?:holds?|has|have|keeps?|stores?) no secrets?\b/i,
   // ── negated positive: the claim denies a holder ──
+  //
+  // BOTH HALVES MOVE TOGETHER, and the noun is where they drift apart. `keypair` and `key material`
+  // need nothing here — `\bkey` already matches inside both — and `not custodial`, `key-free` and
+  // `custody-free` are adjectives with no negated form. `secret` is the one that needed carrying
+  // across: the three patterns below are noun-gated, so adding `holds no secrets` positive-side
+  // without this left "the API does not hold a secret", "the API server never holds any secrets"
+  // and "nothing in the API holds a secret" passing. `neither` and `no process` are noun-agnostic
+  // and caught their variants already, which is why this was narrow rather than fatal — but narrow
+  // is how the first eight rounds of this family were missed.
   /\bneither\b[^.!?]{0,90}?\bhold/i,
   /\bno process\b[^.!?]{0,90}?\bhold/i,
-  /\bnothing\b[^.!?]{0,90}?\bholds an?\b[^.!?]{0,30}?\bkey/i,
-  /\bdoes not hold\b[^.!?]{0,60}?\bkey/i,
-  /\bnever holds\b[^.!?]{0,60}?\bkey/i,
-  /\bwithout a (?:private )?key\b/i,
+  /\bnothing\b[^.!?]{0,90}?\bholds an?\b[^.!?]{0,30}?\b(?:key|secret)/i,
+  /\bdoes not hold\b[^.!?]{0,60}?\b(?:key|secret)/i,
+  /\bnever holds\b[^.!?]{0,60}?\b(?:key|secret)/i,
+  // `any` covers "runs without any private key"; `\b` after the alternation is what stops this
+  // matching "without anything" and "without anyone", of which the tree has eight.
+  /\bwithout (?:an?|any)\b ?(?:private |signing |secret )?keys?\b/i,
 ];
 
 /** The blanket "no RPC client" shape, found by the same sweep and false for the same reason. */
@@ -202,14 +329,21 @@ const SUBJECT = /\bAPIs?\b|\bapps\/api\b|\bserve\.mjs\b|\bthe API server\b/;
 /**
  * What clears a match. A mode token, not a mood: the reader can check any of these against
  * `resolveApiConfig` in one grep, and none of them can be satisfied by hedging.
+ *
+ * `SVM_?KEYPAIR`, NOT `SVM_KEYPAIR`, and the underscore is the whole of gap 1. This regex is tested
+ * against the NORMALISED window, and the normaliser folds `*`, `_` and `` ` `` away so that
+ * `holds **no key**` and `_keyless_` are seen the way a reader sees them. `SVM_KEYPAIR` therefore
+ * arrives as `SVMKEYPAIR` and the anchored form matched nothing, ever. Making the token optional in
+ * the pattern is the fix that keeps the normaliser aggressive on the claim half, which is the half
+ * where being too lax loses a false claim rather than gaining a false red.
  */
-const MODE_TOKEN = /FACILITATOR\s*=\s*[`'"]?(?:svm|stub|http)\b|\bSVM_KEYPAIR\b/i;
+const MODE_TOKEN = /FACILITATOR\s*=\s*[`'"]?(?:svm|stub|http)\b|\bSVM_?KEYPAIR\b/i;
 
 /**
  * Exemptions, by exact `path:line`, each with the reason written out.
  *
  * Named individually rather than by loosening a pattern or exempting a directory, because that is
- * how a real miss hides. Two admissible reasons and no third:
+ * how a real miss hides. Three admissible reasons and no fourth:
  *
  *   RECORD — a dated account of a run that HAPPENED. `docs/X402-LIVE-REPORT.md` describes a
  *            `FACILITATOR=http` run, and "keyless API / key-holding facilitator split" is what that
@@ -220,16 +354,43 @@ const MODE_TOKEN = /FACILITATOR\s*=\s*[`'"]?(?:svm|stub|http)\b|\bSVM_KEYPAIR\b/
  *            sentence with a different subject, the claim is true and the match is an artefact of
  *            the window. The alternative — shrinking the window until these stop — reintroduces the
  *            exact miss this file exists for, since `.env.example`'s subject was one line above its
- *            claim. Both entries below name the claim's real subject, which is what makes them
+ *            claim. Every entry below names the claim's real subject, which is what makes them
  *            checkable rather than a mute.
  *
+ *   CLAUSE — the same cost one scale down. The API is named in the SAME sentence as the claim, in
+ *            a preceding clause with a different subject. Only reachable since the `CLAIM_SPAN`
+ *            join, which can see a claim that wraps away from the clause naming the API. One
+ *            instance, and it must name the claim's real subject exactly as a WINDOW entry does.
+ *
  * An entry whose reason cannot be written in one clause is a claim that needs fixing, not exempting.
+ *
+ * ONE THING AN ENTRY DOES THAT ITS `path:line` DOES NOT SAY, disclosed rather than left to be
+ * found. `unqualifiedClaims` consumes the lines a matched claim runs into BEFORE it applies any
+ * filter, so an exempted claim that wraps also silences its own continuation — up to `CLAIM_SPAN`
+ * lines past the one pinned here. That is deliberate: a claim and its own tail are one claim, and
+ * suppressing on the match rather than on the reported hit is what stops two patterns reporting one
+ * wrapped sentence twice. The cost was measured, not assumed: removing the suppression entirely
+ * changes no hit on the tree — only a synthetic goes red — so no claim is hidden by it today. The
+ * one entry it currently reaches past is `apps/web/index.html:1556`, whose match runs into 1557.
  */
 const EXEMPT = new Map([
   ['docs/X402-LIVE-REPORT.md:41', 'RECORD: a FACILITATOR=http run; the API was keyless in it'],
   ['docs/X402-LIVE-REPORT.md:305', 'RECORD: same run — the keyless-API/key-holding-facilitator split as measured'],
   ['docs/audit/TEST-CROSS-REFERENCE.md:125', 'WINDOW: subject is the canary and the reference agent, both genuinely keyless; `apps/api` is two lines later in a different sentence about audit scope'],
   ['docs/LAUNCH-READINESS.md:278', 'WINDOW: subject is scripts/verify-chainlink-oracle.mjs, which is read-only and keyless; the API is two table ROWS above, at line 276'],
+  // CLAUSE, not WINDOW, and the difference is worth the extra line. The two entries above are the
+  // documented cost of the ±WINDOW heuristic: a NEIGHBOURING sentence names the API. This one is
+  // different geometry — the API is named in the SAME sentence, in the clause before the `;`, and
+  // the claim's subject is the second clause. `unqualifiedClaims` has no clause parser and should
+  // not grow one for a single site. The claim is true: the browser demo signs a dummy all-zero
+  // envelope against a dev facilitator and never asks the user for a key (`renderApiConsent` at
+  // :1486 says the same thing about the same subject and is unaffected).
+  //
+  // This is the only exemption pinned inside a 1500-line file that is edited often, so it WILL
+  // drift. When it does, the fix is to re-pin the line, not to drop the CLAIM_SPAN join: the join
+  // is what makes the claim visible at all, and a wrapped claim about the API is exactly the miss
+  // this file exists for.
+  ['apps/web/index.html:1556', 'CLAUSE: subject is the browser demo, which holds no key; the API is named in the preceding clause of the same sentence'],
 ]);
 
 /**
@@ -239,26 +400,50 @@ const EXEMPT = new Map([
  * `RECORDS` unchanged.
  *
  * @param {RegExp[]} patterns
- * @param {{files?: string[], read?: (rel:string)=>string|null}} [opts]
+ * @param {{files?: string[], read?: (rel:string)=>string|null, exempt?: Map<string,string>}} [opts]
  */
-function unqualifiedClaims(patterns, { files = textFiles(), read = readText } = {}) {
+function unqualifiedClaims(patterns, { files = textFiles(), read = readText, exempt = EXEMPT } = {}) {
   const hits = [];
   for (const file of files) {
     const text = read(file);
     if (text == null) continue;
     // Cheap reject: a file with no subject anywhere cannot produce a window with one.
     if (!SUBJECT.test(text)) continue;
-    // EMPHASIS IS STRIPPED BEFORE MATCHING, and this is the third thing that hid a false claim
-    // from a sweep. `holds **no key**` does not match /holds no key/, and bolding exactly these
-    // words is this repository's dominant style — `**no key**`, `**Keyless by design**`,
-    // `**non-custodial**`, and this very branch's `**no client for the indexed chain by design**`.
-    // A guard for a claim family has to read the family as a reader sees it, not as the plainest
-    // author happened to type it. Measured over the tree: stripping these three characters turns
-    // up exactly one true finding and zero new false positives.
-    const lines = text.split(/\r?\n/).map((l) => l.replace(/[*_`]/g, ''));
     const raw = text.split(/\r?\n/);
+    const lines = raw.map(normalise);
+    // The last line index a matched claim ran into. A claim that wraps is ONE claim, and the lines
+    // it covers must not be rescanned: "The API server / holds / no private key." matches
+    // `holds no … key` from line 2 and `no private key` again from line 3, which reports one
+    // sentence twice and sends a reader to the fragment. Consuming is done on the MATCH, not on the
+    // reported hit, so a claim cleared by a mode token or an exemption silences its own tail too.
+    let consumed = -1;
     for (let i = 0; i < lines.length; i += 1) {
-      if (!patterns.some((p) => p.test(lines[i]))) continue;
+      if (i <= consumed) continue;
+      // GAP 2. The claim is matched over a forward join, not over `lines[i]`, because this repo
+      // hard-wraps at 100 columns and half this family's phrasings are longer than what is left of
+      // a line by the time the subject has been named. `match.index < lines[i].length` is what
+      // reports a wrapped claim ONCE, at the line it begins on, instead of once per line it
+      // touches — the probe below asserts exactly that count.
+      const span = Math.min(lines.length, i + CLAIM_SPAN + 1);
+      const hay = lines.slice(i, span).join(' ');
+      let match = null;
+      for (const p of patterns) {
+        const m = hay.match(p);
+        if (m && m.index < lines[i].length) {
+          match = m;
+          break; // one hit per line, never one per pattern: two patterns can match one sentence
+        }
+      }
+      if (!match) continue;
+      // The last line the match reaches, computed before any filter so that a cleared claim still
+      // consumes its own continuation lines.
+      const end = match.index + match[0].length;
+      let last = i;
+      for (let k = i, off = 0; k < span; k += 1) {
+        if (off < end) last = k;
+        off += lines[k].length + 1;
+      }
+      consumed = last;
       const window = lines
         .slice(Math.max(0, i - WINDOW), Math.min(lines.length, i + WINDOW + 1))
         .join(' ')
@@ -266,8 +451,14 @@ function unqualifiedClaims(patterns, { files = textFiles(), read = readText } = 
       if (!SUBJECT.test(window)) continue;
       if (MODE_TOKEN.test(window)) continue;
       const key = `${file}:${i + 1}`;
-      if (EXEMPT.has(key)) continue;
-      hits.push({ file, line: i + 1, quote: raw[i].trim() });
+      if (exempt.has(key)) continue;
+      // A cross-line claim quoted as its first line alone reads as a sentence fragment and sends
+      // the reader to the wrong place. Quote every line the match actually covers.
+      hits.push({
+        file,
+        line: i + 1,
+        quote: raw.slice(i, last + 1).map((l) => l.trim()).join(' ⏎ '),
+      });
     }
   }
   return hits;
@@ -289,6 +480,8 @@ test('no unqualified key/custody claim about the API', () => {
       + 'Name the mode within 3 lines of the claim — `FACILITATOR=stub` and `FACILITATOR=http`\n'
       + 'hold no key, `FACILITATOR=svm` does. Do not delete the sentence and do not widen this\n'
       + 'guard: the qualified form is the useful one.\n'
+      + 'A quote containing ⏎ is one claim that wraps: the line NUMBER is where it begins, and the\n'
+      + 'text after the ⏎ is the continuation line the match ran into.\n'
       + 'If the line is a dated record of a run that happened, add it to EXEMPT with its reason.',
   );
 });
@@ -372,6 +565,165 @@ test('probe: naming the mode clears the claim, and a bare "svm" does not', () =>
   assert.equal(named.length, 0, `naming FACILITATOR=svm should clear it:\n${report(named)}`);
 });
 
+// ---------------------------------------------------------------------------------------------
+// SYNTHETICS — the capability half of the probe above.
+//
+// `RETIRED` proves the patterns still catch text this repository actually wrote. Everything added
+// in the gap-closing pass has NO live instance: `not custodial`, `key-free`, `custody-free`,
+// `no keypair`, `zero keys`, `without any private key`, `no signing key` and `holds no secrets`
+// occur zero times tree-wide, and the `CLAIM_SPAN` join has zero true cross-line claims to find.
+// A green tree is therefore equally consistent with "these work" and "these match nothing" — the
+// exact confusion `RETIRED` exists to refuse, one axis over. So each family gets a synthetic that
+// must RED, and the two that turn on a clearing token get the paired control that must stay red
+// when the token is removed. Deleting a row here is deleting the only evidence for a pattern.
+//
+// `expect: 0` rows are just as load-bearing: `hasNoAPIKey` is the false positive this pass
+// measured and removed, and without a test the next person to widen the noun set re-breaks it.
+// ---------------------------------------------------------------------------------------------
+const SUBJECT_LINE = '# Runtime configuration for the indexer + API stack\n';
+
+/** @type {{what: string, text: string, expect: number, line?: number, quotes?: string}[]} */
+const SYNTHETIC = [
+  // ── gap 1: SVM_KEYPAIR survives the emphasis strip and clears a claim ──
+  {
+    what: 'gap 1: SVM_KEYPAIR in the window clears the claim',
+    text: `${SUBJECT_LINE}# Neither process holds a private key unless SVM_KEYPAIR is set.\n`,
+    expect: 0,
+  },
+  {
+    what: 'gap 1 control: the same claim without the token still reds',
+    text: `${SUBJECT_LINE}# Neither process holds a private key unless the operator decides otherwise.\n`,
+    expect: 1,
+    line: 2,
+  },
+  {
+    what: 'gap 1: the token clears through bold emphasis too',
+    text: `${SUBJECT_LINE}# Neither process holds a private key unless **SVM_KEYPAIR** is set.\n`,
+    expect: 0,
+  },
+  // ── gap 2: the claim wraps ──
+  {
+    what: 'gap 2: a claim hard-wrapped away from the line naming its subject',
+    text: 'Neither the indexer nor the API process\nholds a private key.\n',
+    expect: 1,
+    line: 1,
+    quotes: 'holds a private key.',
+  },
+  {
+    what: 'gap 2 control: the same wrapped claim with the mode named clears',
+    text: 'Neither the indexer nor the API process\nholds a private key under `FACILITATOR=stub`.\n',
+    expect: 0,
+  },
+  {
+    what: 'gap 2: a claim spanning all of CLAIM_SPAN is reported once, at the line it begins on',
+    text: 'The API server\nholds\nno private key.\n',
+    expect: 1,
+    line: 2,
+    quotes: 'no private key.',
+  },
+  {
+    // The whitespace half of `normalise`. A continuation line is indented in every list, table and
+    // JSDoc block in this repository, and joining without trimming leaves a double space exactly
+    // where a phrase straddles the boundary — which every pattern here, written with single literal
+    // spaces, then misses. Without the trim this row reports line 2 instead of line 1: the claim is
+    // found only by the shorter pattern that starts after the gap, so the reader is sent to the
+    // fragment and the sentence's real subject is a line further away than the guard thinks.
+    what: 'gap 2: an indented continuation still joins into one phrase',
+    text: 'The API server holds\n    no private key.\n',
+    expect: 1,
+    line: 1,
+    quotes: 'no private key.',
+  },
+  // ── HTML emphasis survives the markdown strip ──
+  {
+    what: 'HTML emphasis: holds <strong>no key</strong>',
+    text: '<p>The API server holds <strong>no key</strong> in this mode.</p>\n',
+    expect: 1,
+    line: 1,
+  },
+  {
+    what: 'HTML control: BLOCK tags are not stripped, so a cell boundary stays a word boundary',
+    text: '<tr><td>keyless</td><td>the API</td></tr>\n',
+    expect: 1,
+    line: 1,
+  },
+  // ── families added with no live instance ──
+  { what: 'not custodial', text: 'The API is not custodial.\n', expect: 1, line: 1 },
+  { what: 'key-free', text: 'The API server is key-free.\n', expect: 1, line: 1 },
+  { what: 'custody-free', text: 'The API is custody-free.\n', expect: 1, line: 1 },
+  // The next two are phrased with NO holder verb on purpose. `holds no keypair` and `has no
+  // signing key` are already caught by the holder-verb family, so a synthetic using those verbs
+  // passes with the bare-noun pattern deleted and proves nothing about it. These do not.
+  { what: 'no keypair', text: 'apps/api/src/serve.mjs runs with no keypair on disk.\n', expect: 1, line: 1 },
+  { what: 'no signing key', text: 'There is no signing key anywhere in apps/api.\n', expect: 1, line: 1 },
+  { what: 'zero keys (holder verb)', text: 'The API holds zero keys.\n', expect: 1, line: 1 },
+  { what: 'no secret key (holder verb)', text: 'The API server has no secret key.\n', expect: 1, line: 1 },
+  { what: 'holds no secrets', text: 'The API server stores no secrets.\n', expect: 1, line: 1 },
+  // The negated half of the `secret` noun. Three rows because three separate patterns are gated on
+  // the noun, and each was passing this text before `key` became `(?:key|secret)`.
+  { what: 'secret, negated: does not hold', text: 'The API does not hold a secret.\n', expect: 1, line: 1 },
+  { what: 'secret, negated: never holds', text: 'The API server never holds any secrets.\n', expect: 1, line: 1 },
+  { what: 'secret, negated: nothing holds', text: 'Nothing in the API holds a secret.\n', expect: 1, line: 1 },
+  {
+    what: 'without any private key',
+    text: 'The API server runs without any private key.\n',
+    expect: 1,
+    line: 1,
+  },
+  // ── negative controls: the measured false positives, locked out ──
+  {
+    what: 'control: "no API key" is an Etherscan credential, not this family',
+    text: 'The pinned rebuild has no API key, so apps/api verification was skipped.\n',
+    expect: 0,
+  },
+  {
+    what: 'control: "without anything" / "without anyone" are not "without a key"',
+    text: 'The API ships without anything to configure and without anyone to ask.\n',
+    expect: 0,
+  },
+];
+
+test('synthetic: every claim family reds, and every measured false positive stays green', () => {
+  for (const s of SYNTHETIC) {
+    const hits = unqualifiedClaims(CLAIM_PATTERNS, {
+      files: ['synthetic'],
+      read: () => s.text,
+    });
+    assert.equal(
+      hits.length,
+      s.expect,
+      `synthetic "${s.what}" matched ${hits.length} times, expected ${s.expect}:\n`
+        + `${report(hits)}\n${JSON.stringify(s.text)}`,
+    );
+    if (s.line !== undefined) assert.equal(hits[0].line, s.line, `synthetic "${s.what}": wrong line`);
+    if (s.quotes !== undefined) {
+      assert.ok(
+        hits[0].quote.includes(s.quotes),
+        `synthetic "${s.what}": the quote stops before the claim does — a cross-line hit reported\n`
+          + `as its first line alone sends the reader to a fragment. Got: ${hits[0].quote}`,
+      );
+    }
+  }
+});
+
+// Every exemption is a claim that this file would otherwise report, and an exemption that has
+// stopped matching is a silent mute: it looks identical to a live one and protects nothing, while
+// the line it was pinned to has drifted somewhere the guard is no longer looking. Cheapest possible
+// check — run with the exemptions off and require every key to come back.
+test('exemptions: every entry is still load-bearing, none has rotted', () => {
+  const all = unqualifiedClaims(CLAIM_PATTERNS, { exempt: new Map() })
+    .concat(unqualifiedClaims(RPC_PATTERNS, { exempt: new Map() }))
+    .map((h) => `${h.file}:${h.line}`);
+  for (const [key, reason] of EXEMPT) {
+    assert.ok(
+      all.includes(key),
+      `EXEMPT has ${key} (${reason}) but nothing matches there any more.\n`
+        + 'Either the line moved — re-pin it — or the claim was rewritten and the entry should go.\n'
+        + 'A stale exemption is indistinguishable from a live one, which is how the next miss hides.',
+    );
+  }
+});
+
 // The walk is the coverage, so assert it reached the file type that produced the defect. A pass
 // over nothing reads exactly like a pass over everything — the failure `claims-lede-truth.test.mjs`
 // records twice, once for the store axis and once for the file-type axis.
@@ -384,4 +736,21 @@ test('coverage: the walk reaches extensionless and non-.md config templates', ()
         + 'that produced this defect. Check SKIP_DIRS, DENY_EXT and MAX_BYTES before anything else.',
     );
   }
+  // Both halves of the `lib` fix, because each protects against the opposite mistake: the positives
+  // stop a future tidy-up putting the bare name back in SKIP_DIRS, and the negative stops a noisy
+  // vendored checkout being silenced by deleting SKIP_PATHS instead of narrowing it.
+  for (const required of ['scripts/lib/verdicts.mjs', 'contracts/src/lib/BoundedCall.sol']) {
+    assert.ok(
+      files.includes(required),
+      `the walk did not reach ${required}. \`lib\` is skipped by PATH (contracts/lib, the forge\n`
+        + 'dependency checkout) and never by bare directory name — this repository keeps its own\n'
+        + 'source in two directories called lib.',
+    );
+  }
+  assert.equal(
+    files.filter((f) => f.startsWith('contracts/lib/')).length,
+    0,
+    'the walk descended into contracts/lib, the vendored forge dependency checkout. Its prose is\n'
+      + 'not ours to guard and its volume would drown a real red.',
+  );
 });


### PR DESCRIPTION
Follow-up to #239. An independent review approved that guard and filed two completeness gaps as non-blocking. Both were demonstrated against synthetics; neither had a live instance. This closes them, plus the two further gaps that review listed (HTML emphasis, the `lib` skip) and three found while closing those (whitespace at a join boundary, one wrapped sentence reported twice, and the negated half left behind by a positive-half widening), and — the part that matters most — proves each one by mutation, because every family added has **zero occurrences in the tree**, so a green tree could not tell "these work" from "these match nothing".

One file: `scripts/test/claims-key-custody-truth.test.mjs`. No prose was rewritten to make a guard green.

## Gap 1 — `SVM_KEYPAIR` was advertised as a clearing token and could never match

`MODE_TOKEN` carried `\bSVM_KEYPAIR\b`, but the emphasis normaliser strips `_` from every line before matching, so the token reached the regex as `SVMKEYPAIR`. It failed **safe** — extra reds, never fewer — but the header and the assertion message both told a reader that writing `SVM_KEYPAIR` next to a claim would clear it, and it would not.

**Chose: make it work**, as `SVM_?KEYPAIR`. The alternative — dropping `_` from the normaliser — fixes the token by making the *claim* half fail **unsafe**: `_no key_` is live markdown emphasis here, and the one character that decides whether a claim is seen at all should not be relaxed to fix a token that only ever clears one.

## Gap 2 — the claim was matched single-line while only the subject was windowed

This repo hard-wraps at 100 columns, so `Neither the indexer nor the API process\nholds a private key.` passed while the same sentence on one line redded. The docstring stated the windowing property in general terms and so overstated what was implemented.

Claims are now matched over a forward join of `CLAIM_SPAN` (2) lines, reported only when the match **begins** inside line `i`, and the lines a match covers are consumed so one wrapped sentence is one hit rather than one per pattern that touches it. The `[^.!?]` bounds already in the negated-positive patterns stop a join at a sentence boundary.

**Measured cost, stated rather than buried:** zero true cross-line claims exist in the tree today — the value is entirely prospective — and the join produced exactly **one** new match, `apps/web/index.html:1556`, which is TRUE (subject: the browser demo). It is exempted under a new reason kind, **CLAUSE**: unlike the two existing WINDOW entries, the API is named in the *same sentence*, in the clause before the `;`. The entry names the claim's real subject, and says that when the line drifts the fix is to re-pin it, not to drop the join.

One consequence is disclosed in the `EXEMPT` header rather than left to be found: consumption happens **before** the filters, so an exempted claim that wraps also silences its own continuation, up to `CLAIM_SPAN` lines past the pinned one. Removing the suppression entirely changes no hit on the tree (only a synthetic goes red), so nothing is hidden by it today.

## Also closed

- **HTML inline emphasis survived the markdown strip.** `holds <strong>no key</strong>` did not match. Inline tags only (`b/strong/em/i/u/mark/small/code/span/kbd/samp/var/sub/sup`) — dropping block tags would fuse `<td>keyless</td>` into the next cell and *lose* matches, which a synthetic now locks in. Whitespace is collapsed and trimmed after both strips, without which a phrase straddling an indented continuation silently misses.
- **`SKIP_DIRS` matched `lib` by bare NAME.** The entry was only ever meant for `contracts/lib`, the forge dependency checkout; it also silenced `scripts/lib/` (6 files) and `contracts/src/lib/` (3). Now skipped by **path**. `coverage:` asserts both halves — the walk reaches `scripts/lib/verdicts.mjs` and `contracts/src/lib/BoundedCall.sol`, and reaches nothing under `contracts/lib/`.

## Patterns added, and the one declined

Added (all with zero live occurrences, all with a synthetic): `not custodial`, `key-free`, `custody-free`, `no keypair`, `zero keys`, `no signing/secret key`, an open holder-verb family (`holds|has|have|carries|keeps|stores` + `no|zero` + `keys|keypairs|key material`), `holds no secrets`, and `without a` widened to `without (a|an|any)`.

**Both halves move together**, as the file's header requires. Adding `holds no secrets` positive-side left three noun-gated negated patterns behind, so `The API does not hold a secret.`, `The API server never holds any secrets.` and `Nothing in the API holds a secret.` all passed. Their noun is now `(?:key|secret)`. `keypair` and `key material` needed nothing (`key` already matches inside both) and the three new adjectives have no negated form.

The **adjective set is closed on purpose**: adding `api`, which looks like an obvious omission next to `signing` and `secret`, immediately reds two TRUE lines (`docs/DEPLOYMENT.md:734`, `docs/TESTNET-CHECKLIST.md:87`) that say "no API key" about an Etherscan credential. That is a different noun that happens to contain this guard's subject. A negative-control synthetic keeps it out.

**`never signs` / `does not sign` — DECLINED, with the numbers in the file.** Thirteen instances tree-wide, every one TRUE and none about the API: the indexer, the canary, the reference agent, the oracle sampler all say it about themselves. Ten are further than 12 lines from any API mention, but **two are not** — `docs/REFERENCE-AGENT.md:384` at distance 5 and `docs/RUNTIME.md:432` at distance 6 — so a two-line edit to either paragraph would red a true sentence. The shape is real (`FACILITATOR=svm` co-signs as fee payer), but catching it needs a subject test requiring the API to be the *sentence's* subject, which does not exist here. The file says what would have to be built first.

**`docs/RUNTIME.md:34` — recorded as a known limit, not closed.** `(no key here: stub/http)` is true and passes because nothing matches `no key here`, not because anything cleared it. Both halves are now written down: a bare `\bno keys?\b` would be wide enough to reach it, **and it would then RED**, because `stub/http` is not a `MODE_TOKEN`. Closing the pattern alone converts a true line into a false red.

## Proof — 24 mutations, each reverting one piece

| Mutation | Expected | Got |
| --- | --- | --- |
| CONTROL, no mutation | GREEN | GREEN |
| **retired control:** `.env.example` header restored to the retired wording verbatim | RED | RED |
| gap 1: `MODE_TOKEN` back to the dead `\bSVM_KEYPAIR\b` | RED | RED |
| gap 2: `CLAIM_SPAN = 0` (single-line matching, as before) | RED | RED |
| gap 2: drop the match-start dedup | RED | RED |
| gap 2: drop the consumed-lines suppression | RED | RED |
| html: drop the inline-emphasis strip | RED | RED |
| norm: drop the whitespace collapse + trim | RED | RED |
| lib: put the bare name back in `SKIP_DIRS` | RED | RED |
| lib: drop `SKIP_PATHS` (vendored forge-std walked) | RED | RED |
| remove `/not custodial/` | RED | RED |
| remove `/key-?free/` | RED | RED |
| remove `/custody-?free/` | RED | RED |
| remove `/no keypairs?/` | RED | RED |
| remove `/no (signing\|secret) keys?/` | RED | RED |
| remove the holder-verb `no\|zero keys` family | RED | RED |
| remove `/no secrets?/` | RED | RED |
| negated half: revert `does not hold … secret` to key only | RED | RED |
| negated half: revert `never holds … secret` to key only | RED | RED |
| negated half: revert `nothing holds … secret` to key only | RED | RED |
| revert `without any` to `without a` | RED | RED |
| **FP:** put `api ` back in the adjective set | RED | RED |
| **FP:** add the declined `/never signs/` family | GREEN | GREEN |
| unpin the `apps/web/index.html:1556` exemption | RED | RED |

Two of these needed the mutation itself corrected before they meant anything, and both corrections are in the tests:

- The retired-wording control passed at first because `.env.example` lines 3-5 carry `FACILITATOR=stub`, which cleared the reintroduced claim from inside the window. Replacing the whole retired block is the honest control.
- `remove /no keypairs?/` and `remove /no (signing|secret) keys?/` passed because their synthetics used holder verbs and were caught by the holder-verb family instead. Rephrased without a holder verb, they fail as they should.

New tests: **22 synthetics** (families that must red, plus two negative controls that must stay green), and an **exemption-liveness test** that runs with exemptions off and fails if any entry has stopped matching — a stale exemption looks identical to a live one, which is how the next miss hides.

## Gate

`npm run gate` from the repo root, on this exact tree: **PASSED (327.1s)**, one advisory warning (slither, advisory in CI too). Backend suite 1242 pass / 0 fail. Contracts untouched, so no gas regeneration and no EIP-170 measurement is due.

## Not done

Not merged, preflight not dispatched.
