### PR TITLE
fix(claims): re-pin the key-custody exemption, protocol/main is red

### DIFF
--- a/scripts/test/claims-key-custody-truth.test.mjs
+++ b/scripts/test/claims-key-custody-truth.test.mjs
@@ -82,7 +82,7 @@
  *
  *   Measured cost of gap 2 on the tree as it stands: zero true cross-line claims exist to catch
  *   today (its whole value is prospective) and it produced exactly one new match, at
- *   `apps/web/index.html:1556`, which is TRUE and is exempted below with its geometry written out.
+ *   `apps/web/index.html:1583`, which is TRUE and is exempted below with its geometry written out.
  *   That ratio is stated rather than buried: a reviewer will compute it.
  *
  * ## What was measured and DELIBERATELY NOT added
@@ -384,7 +384,7 @@ const EXEMPT = new Map([
   // the claim's subject is the second clause. `unqualifiedClaims` has no clause parser and should
   // not grow one for a single site. The claim is true: the browser demo signs a dummy all-zero
   // envelope against a dev facilitator and never asks the user for a key (`renderApiConsent` at
-  // :1486 says the same thing about the same subject and is unaffected).
+  // :1513 says the same thing about the same subject and is unaffected).
   //
   // This is the only exemption pinned inside a 1500-line file that is edited often, so it WILL
   // drift. When it does, the fix is to re-pin the line, not to drop the CLAIM_SPAN join: the join

--- a/scripts/test/claims-key-custody-truth.test.mjs
+++ b/scripts/test/claims-key-custody-truth.test.mjs
@@ -371,7 +371,7 @@ const MODE_TOKEN = /FACILITATOR\s*=\s*[`'"]?(?:svm|stub|http)\b|\bSVM_?KEYPAIR\b
  * suppressing on the match rather than on the reported hit is what stops two patterns reporting one
  * wrapped sentence twice. The cost was measured, not assumed: removing the suppression entirely
  * changes no hit on the tree — only a synthetic goes red — so no claim is hidden by it today. The
- * one entry it currently reaches past is `apps/web/index.html:1556`, whose match runs into 1557.
+ * one entry it currently reaches past is `apps/web/index.html:1583`, whose match runs into 1584.
  */
 const EXEMPT = new Map([
   ['docs/X402-LIVE-REPORT.md:41', 'RECORD: a FACILITATOR=http run; the API was keyless in it'],
@@ -390,7 +390,7 @@ const EXEMPT = new Map([
   // drift. When it does, the fix is to re-pin the line, not to drop the CLAIM_SPAN join: the join
   // is what makes the claim visible at all, and a wrapped claim about the API is exactly the miss
   // this file exists for.
-  ['apps/web/index.html:1556', 'CLAUSE: subject is the browser demo, which holds no key; the API is named in the preceding clause of the same sentence'],
+  ['apps/web/index.html:1583', 'CLAUSE: subject is the browser demo, which holds no key; the API is named in the preceding clause of the same sentence'],
 ]);
 
 /**


### PR DESCRIPTION
`protocol/main` is red at 31708bfe. The `backend` job fails (16 steps, so real
work, not the billing wall) on the guard that #250 just landed.

`scripts/test/claims-key-custody-truth.test.mjs` exempts
`apps/web/index.html:1556`. The claim is now at 1583. `9f25872b feat(web): say
on the page that a queued exit stripped the vote` landed between #250's CI run
and its merge and inserted 27 lines above it. Both of the guard's tests then
fired at once, which is the design working: guard 1 reported the un-exempted
claim at :1583, and the rot detector reported that the :1556 key no longer
matches anything.

The claim itself is unchanged and still true: the browser demo signs an
all-zero envelope against a dev facilitator and never asks for a key. Only its
line number moved, so this re-pins the number in the two places that carry it,
the EXEMPT key and the comment above it that names the same site.

#250's own comment anticipated exactly this and recorded the intended remedy:
"This is the only exemption pinned inside a 1500-line file that is edited often,
so it WILL drift. When it does, the fix is to re-pin the line, not to drop the
CLAIM_SPAN join." This is that re-pin, and nothing else.

It does not fix the shape. Line-keyed exemptions break under any edit above
them, and this is the second instance today: the same keying reds
`docs/LAUNCH-READINESS.md:278` on a separate in-flight branch whose edit shifts
it to :292. A content-anchored key would close the class, but that is a change
against #250's written direction and belongs in its own PR with its own verdict,
not in a hotfix whose job is to make main green.

Note the mechanism, because it is new. #250 was green against a base where the
line was 1556, `9f25872b` moved it, and #250 merged without re-integrating.
`strict_required_status_checks_policy` was turned off on protocol-main earlier
today, so nothing forced the rebase that would have caught this. This is the
first landed instance of that cost.

`npm run gate` passes (327 s, slither advisory only); the guard's own 7 tests
are green.

---
Verdict needed from someone who is not me. `protocol/main` is red right now, so this is the front of the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)