### PR TITLE
fix(app): the app said there were no vaults; there are two

### DIFF
--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -1,8 +1,11 @@
 # `apps/app` — the explore surface at app.rwally.com
 
-The vault explorer, v1. It renders one thing and it renders it honestly: a table of vaults with no
-rows, above a protocol card whose three most load-bearing facts are re-read from chain 4663 in the
-reader's own browser every time the page loads.
+The vault explorer, v1. It renders one thing and it renders it honestly: a protocol card whose three
+most load-bearing facts are re-read from chain 4663 in the reader's own browser every time the page
+loads, above a table of vaults with no rows.
+
+The order used to be stated the other way round here. In `index.html` the protocol card is the first
+`<section>` and the vaults card the second, so the table is BELOW it.
 
 It is deployed to the Cloudflare Pages project `rwally-app`, production branch `protocol/main`.
 
@@ -15,7 +18,7 @@ It is deployed to the Cloudflare Pages project `rwally-app`, production branch `
 | `VaultFactory.allowSubVaults()` | An `eth_call` from the browser, on load |
 | `ChainlinkOracle.usdc()`, then `symbol()` on the token it names | Two `eth_call`s from the browser, on load |
 | The block the reads landed at | `eth_blockNumber`, same load |
-| Every vault row | Nothing. There are none |
+| Every vault row | Nothing. This page renders no rows: there is no `<tbody>` in `index.html` and `app.js` writes only into the live-reads panel. Two vaults existed on chain 4663 as of 2026-09-12 and neither is listed |
 
 **The token that `usdc()` names is USDG, and the page prints what `symbol()` returned rather than
 what the getter is called.** The getter keeps the name `usdc` because that is the name in the
@@ -25,12 +28,19 @@ trusting a variable name over a chain read.
 
 ## Three decisions that are easy to undo by accident
 
-**1. The empty state is static markup, not a rendered value.** The sentence "No vaults have been
-created yet. `vaultCount()` reads 0 on chain 4663." lives in `index.html` and is never written by
-`app.js`. A claim produced by a fetch disappears exactly when the fetch fails, which is the moment a
-reader most needs to be told what is true. The LIVE READS panel **corroborates** that sentence with
-a number read seconds ago; it does not produce it. `test/claims.test.mjs` asserts the sentence is in
-the built HTML, so moving it into the script reds the guard.
+**1. The empty state is static markup, not a rendered value.** The sentence "This table lists no
+vaults. `vaultCount()` above is read live from chain 4663 and is the count that matters." lives in
+`index.html` and is never written by `app.js`. A claim produced by a fetch disappears exactly when
+the fetch fails, which is the moment a reader most needs to be told what is true. The LIVE READS
+panel **corroborates** that sentence with a number read seconds ago; it does not produce it.
+`test/claims.test.mjs` asserts the sentence is in the built HTML, so moving it into the script reds
+the guard.
+
+That sentence is deliberately a claim about the TABLE, not a count of vaults. The version before it
+pinned "`vaultCount()` reads 0", which was true when written and false from the moment vault #1 was
+created, with nothing going red in between: the guard is a static string match that reads no chain,
+so it can only prove the sentence is present, never that it is true. Pin what this deployment
+controls.
 
 **2. There is no `package.json`, and that is not an omission.** The repository root declares the
 workspace glob `apps/*`. A workspace package that is absent from `package-lock.json` makes `npm ci`
@@ -81,10 +91,15 @@ Six checks: the empty-state sentence survives into the build, the factory addres
 no banned claim shape appears in any built file, `_headers` carries every required directive, the
 markup has no inline script or style, and the page fetches from no origin but the chain RPC.
 
-**It is not wired into `npm run test:backend`.** That script enumerates `apps/web/test/*`,
-`apps/site/test/*` and `scripts/test/*` by name and does not glob `apps/app/test/*`. Wiring it in
-means editing the root `package.json`, which was outside this change's paths. Run it directly until
-someone does.
+**It runs in CI and in the gate, as its own step.** The root `package.json` declares `test:app`,
+`.github/workflows/ci.yml` runs it at line 137, and `scripts/gate.mjs` invokes it immediately before
+`test:backend`. It is deliberately NOT a glob inside `test:backend`: this file rebuilds `dist/`,
+and the repository-wide walks in `test:backend` enumerate files first and read them after, so
+batching them together lets this build delete a path another guard has listed and not yet opened.
+
+This paragraph previously said it was not wired in and to run it by hand. That stopped being true
+when `test:app` was added, and a stale instruction to run a check manually is worse than none: it
+invites someone to conclude the check is optional.
 
 The repository-wide claims guard, `scripts/test/claims-lede-truth.test.mjs`, **does** walk this
 page once it is built: `dist` is deliberately absent from that file's `SKIP_DIRS` and `.html` is in
@@ -106,5 +121,11 @@ directory; there is no such directory here and there should not be one.
 Everything in `Design/app-spec-2026-09-05.md` past v1's first screen: the vault detail page, the
 hive activity screens, stake, vote, and every wallet action. The Connect control in the masthead is
 inert and says so, carries `aria-disabled` rather than `disabled` so it keeps its place in the tab
-order, and names its reason through `aria-describedby`. It becomes a real control when there is a
-vault to deposit into and not before.
+order, and names its reason through `aria-describedby`.
+
+Its reason changed with this pass. It used to say deposits open "when a vault exists", which made
+the control's own copy a hostage to chain state: vaults now exist and the button is still inert, so
+that sentence had quietly become a broken promise. The blocker was never the factory. `app.js`
+contains no wallet code at all, so the title and the note now say what is true of this page, and
+they say the same thing as each other: a sighted reader gets the `title`, a screen-reader user gets
+the `aria-describedby` note, and those two disagreeing is its own defect.

--- a/apps/app/src/index.html
+++ b/apps/app/src/index.html
@@ -66,13 +66,20 @@
           <path fill="currentColor" d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
         </svg>
       </a>
-      <!-- THE CONNECT CONTROL IS UNCHANGED. Still aria-disabled with the same
-           explanatory note, because deposits open only once a vault exists
-           and nothing about that fact has changed with this pass. -->
-      <button type="button" class="connect" aria-disabled="true" aria-describedby="connect-note" title="Deposits open when a vault exists.">
+      <!-- THE CONNECT CONTROL IS STILL INERT, AND ITS REASON HAS CHANGED.
+           It used to say deposits open "when a vault exists". Vaults now exist,
+           so that wording promised something this page does not do. The reason
+           it is inert has nothing to do with the chain: app.js contains no
+           wallet code at all -- no eth_requestAccounts, no signing, no
+           window.ethereum -- so the honest sentence is about this page, not
+           about the factory. The title and the note below must keep saying the
+           same thing: a sighted reader gets the title, a screen-reader user
+           gets the note, and a page that tells them different things is worse
+           than one that tells them nothing. -->
+      <button type="button" class="connect" aria-disabled="true" aria-describedby="connect-note" title="This page is read-only. It connects no wallet.">
         Connect wallet
       </button>
-      <span id="connect-note" class="sr-only">Deposits open when a vault exists. There is nothing to connect to yet.</span>
+      <span id="connect-note" class="sr-only">This page is read-only. It connects no wallet and takes no deposits.</span>
     </div>
   </div>
 </header>
@@ -107,9 +114,15 @@
         <dt>Deployed at</dt>
         <dd><time datetime="2026-09-05T08:47:02Z">2026-09-05 08:47:02 UTC</time>, block <span class="num">54,989,195</span></dd>
       </div>
+      <!-- A DATED COUNT, not a bare one. "None" was true when this card was
+           written and became false the moment vault #1 was created, silently,
+           because nothing in the build re-reads it. A count stamped with the
+           date it was read stays true forever: it is a statement about
+           2026-09-12, not a standing claim about now. The live read below is
+           what answers "now". -->
       <div class="meta-cell">
         <dt>Vaults</dt>
-        <dd>None. The factory has created no vault.</dd>
+        <dd>Two as of <time datetime="2026-09-12">2026-09-12</time>. The live read below reports the current count.</dd>
       </div>
     </dl>
 
@@ -120,9 +133,15 @@
         <p class="reads-stamp" id="reads-stamp" aria-live="polite">Reading from the public RPC.</p>
       </div>
 
+      <!-- THE COUNT IS OF CALLS, NOT OF ROWS BELOW, and the two differ: the
+           third row spends TWO calls, usdc() and then symbol() on whatever
+           address that returns. app.js says "four eth_call requests and one
+           eth_blockNumber" in its own header, and that file is the authority
+           on what it sends. This sentence said "three" and undercounted it. -->
       <p class="reads-intro">
-        Three calls, sent from this browser straight to the chain 4663 public RPC with
-        <span class="mono">eth_call</span>. Nothing is proxied and nothing is cached.
+        Four <span class="mono">eth_call</span> requests and one <span class="mono">eth_blockNumber</span>,
+        sent from this browser straight to the chain 4663 public RPC. Nothing is proxied and nothing
+        is cached.
       </p>
 
       <ul class="reads-list">
@@ -189,19 +208,27 @@
 
   <!-- ===================================================================
        VAULTS
-       Zero rows today. The empty state is static markup on purpose: the
-       sentence has to be true whether or not the RPC answers, and the
-       LIVE READS panel above corroborates it rather than producing it.
+       Zero ROWS, which is not the same as zero vaults, and this section used
+       to conflate them. Two vaults exist on chain 4663; this page renders no
+       row for either, because nothing here renders rows at all: there is no
+       <tbody> in this file and app.js writes only into the LIVE READS panel.
+
+       The empty state stays static markup on purpose: the sentence has to be
+       true whether or not the RPC answers, and the LIVE READS panel above
+       corroborates it rather than producing it. What changed is WHICH
+       sentence is the true one to pin. It is now a claim about this table,
+       which no chain state can falsify, rather than a count, which the next
+       createVault call falsifies silently.
        =================================================================== -->
   <section class="card vaults" aria-labelledby="vaults-h">
     <div class="card-head">
       <h2 id="vaults-h">Vaults</h2>
-      <span class="count-chip"><span class="num">0</span> listed</span>
+      <span class="count-chip"><span class="num">0</span> listed here</span>
     </div>
 
     <div class="table-scroll">
       <table class="vault-table">
-        <caption class="sr-only">Vaults on chain 4663. The table has no rows because no vault has been created.</caption>
+        <caption class="sr-only">Vaults on chain 4663. The table has no rows: this page does not list individual vaults yet.</caption>
         <thead>
           <tr>
             <th scope="col" class="col-name">Name</th>
@@ -217,9 +244,9 @@
     <!-- THE EMPTY STATE SITS OUTSIDE THE SCROLL CONTAINER, NOT IN A SPANNING
          CELL. Inside one it inherits the table's 40rem min-width, so at 375 px
          the sentence this page exists to say is clipped by the horizontal
-         scroll and the reader sees "No vaults have been create". A table may
-         carry a header row and no body rows; the explanation of why there are
-         none belongs beside the table, at the width of the card. -->
+         scroll and the reader sees only its first few words. A table may carry
+         a header row and no body rows; the explanation of why there are none
+         belongs beside the table, at the width of the card. -->
     <div class="empty">
       <svg class="empty-mark" viewBox="0 0 64 40" role="presentation" focusable="false" aria-hidden="true">
         <rect x="0.75" y="0.75" width="62.5" height="38.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></rect>
@@ -227,7 +254,7 @@
         <line x1="20.75" y1="0.75" x2="20.75" y2="39.25" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></line>
         <line x1="42.25" y1="0.75" x2="42.25" y2="39.25" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></line>
       </svg>
-      <p class="empty-lede">No vaults have been created yet. vaultCount() reads 0 on chain 4663.</p>
+      <p class="empty-lede">This table lists no vaults. vaultCount() above is read live from chain 4663 and is the count that matters.</p>
       <p class="empty-sub">
         Creating a vault is permissionless. The caller becomes its creator and its attested
         operator, immutably.
@@ -237,14 +264,31 @@
           <dt>Factory</dt>
           <dd><a class="addr" href="https://robinhoodchain.blockscout.com/address/0xc44B853F037b4fF33B831C9a2B341686dEC88Fd1" rel="noopener">0xc44B853F037b4fF33B831C9a2B341686dEC88Fd1</a></dd>
         </div>
+        <!-- Named, dated, and linked so a reader can check them without this
+             page rendering a single row. Both addresses were read back from
+             VaultFactory.allVaults() on chain 4663 on 2026-09-12. -->
+        <div>
+          <dt>Created so far</dt>
+          <dd>
+            Two, as of <time datetime="2026-09-12">2026-09-12</time>:
+            <a class="addr" href="https://robinhoodchain.blockscout.com/address/0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4" rel="noopener">0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4</a>
+            and
+            <a class="addr" href="https://robinhoodchain.blockscout.com/address/0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38" rel="noopener">0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38</a>.
+          </dd>
+        </div>
         <div>
           <dt>Sub-vaults</dt>
           <dd>Off. <span class="mono">allowSubVaults()</span> reads false, and the factory is immutable, so this deployment is root vaults only.</dd>
         </div>
       </dl>
+      <!-- THIS PARAGRAPH USED TO PROMISE A ROW. It said the first row appears
+           here the moment the factory reports a vault. Two vaults have since
+           been reported and no row has appeared, because there is no <tbody>
+           in this file and app.js writes only into the LIVE READS panel. It
+           was a promise about code nobody had written. -->
       <p class="empty-watch">
-        Watch this page. The first row appears here the moment the factory reports a vault,
-        because the count above is read from the chain on every load.
+        Rows are not built yet. Until they are, the live <span class="mono">vaultCount()</span>
+        read above and the addresses beside it are how this page tells you what exists.
       </p>
     </div>
   </section>

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -70,7 +70,20 @@ const FACTORY = '0xc44B853F037b4fF33B831C9a2B341686dEC88Fd1';
 
 // The empty state, exactly as it must read. Whitespace is collapsed on both
 // sides so a hard wrap in the markup does not break the match.
-const EMPTY_STATE = 'No vaults have been created yet. vaultCount() reads 0 on chain 4663.';
+//
+// IT USED TO PIN A COUNT, AND THE COUNT WENT STALE WITHOUT ANYTHING GOING RED.
+// The pinned sentence was "No vaults have been created yet. vaultCount() reads
+// 0 on chain 4663." That became false when vault #1 was created, and falser
+// again at vault #2, while this guard stayed green the whole time: it is a
+// static string match against the built HTML and reads no chain, so it can
+// only tell you the sentence is PRESENT, never that it is TRUE.
+//
+// The replacement is a claim about this table rather than about the chain. No
+// createVault call can falsify "this table lists no vaults"; only writing the
+// row-rendering code can, and whoever writes it will be editing this line
+// anyway. That is the property to preserve when changing this string: pin
+// something the deployment controls, not something the world does.
+const EMPTY_STATE = 'This table lists no vaults. vaultCount() above is read live from chain 4663 and is the count that matters.';
 
 const flat = (s) => s.replace(/\s+/g, ' ');
 
@@ -104,8 +117,8 @@ test('the built page names the factory address', () => {
   const html = read('index.html');
   assert.ok(
     html.includes(FACTORY),
-    'The empty state claims vaultCount() reads 0. A reader who wants to check that needs the\n' +
-      'address to call it on, on the same page, without leaving to find it.\n' +
+    'The empty state points at a live vaultCount() read. A reader who wants to check that number\n' +
+      'for themselves needs the address to call it on, on the same page, without leaving to find it.\n' +
       `Expected to find: ${FACTORY}`,
   );
 });


### PR DESCRIPTION
`app.rwally.com` pinned this as static markup:

> No vaults have been created yet. `vaultCount()` reads 0 on chain 4663.

True when written. False from the moment vault #1 was created. **Two vaults now exist** on chain 4663, both holding funds, and the page told every reader there were none.

```
vaultCount()      2
allVaults(0)      0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4
allVaults(1)      0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38
```

## Why nothing went red

`apps/app/test/claims.test.mjs` asserts the sentence is **present** in the built HTML. It reads no chain. A static string match can prove a sentence exists; it can never prove it is true. So the count drifted from reality with CI green the whole way.

The fix is not a new count. It is a claim about the **table**, which no `createVault` call can falsify:

> This table lists no vaults. `vaultCount()` above is read live from chain 4663 and is the count that matters.

Counts that must stay accurate are now either read live or stamped with a date, which makes them statements about a past instant rather than standing claims about now.

## The other eight

Found by reading each surrounding unit, not by grepping the one sentence.

| Where | Was | Problem |
|---|---|---|
| protocol card, Vaults cell | "None. The factory has created no vault." | false |
| table caption | "no rows because no vault has been created" | false reason |
| empty state | "the first row appears here the moment the factory reports a vault" | **no row will ever appear**: zero `<tbody>` in the file, and `app.js` writes only into the live-reads panel |
| live-reads intro | "Three calls" | `app.js` sends **four** `eth_call`s plus one `eth_blockNumber`, and says so in its own header. The third row spends two calls: `usdc()`, then `symbol()` on the address it returns |
| Connect control | "Deposits open when a vault exists." | vaults exist and it is still inert. `app.js` contains no wallet code at all. Title and `sr-only` note now say the same true thing as each other |
| README lede | table "above a protocol card" | it is below |
| README table | "Every vault row: Nothing. There are none" | there are two vaults; there are no rows |
| README tests | "not wired into `npm run test:backend`, run it directly" | it runs as its own step in `ci.yml:137` and in `gate.mjs` |

That last one matters beyond accuracy: a stale instruction to run a check by hand invites the next reader to treat it as optional.

## Verification

- `npm run gate` passes (344.6s, one pre-existing slither advisory)
- **Negative control**: mutating the pinned sentence reds test 1, so the guard checks what it claims to
- Both repo-wide guards that initially failed (`claims-lede-truth`, `claims-token-absence`) were a missing `apps/site-next` build, not this change. Green after `npm run build --workspace apps/site-next`, which CI and the gate both run first
- Every chain fact above read back with `cast` against `https://rpc.mainnet.chain.robinhood.com`

## Scope

`apps/app` only, three files. `apps/site`, `apps/site-next` and `apps/web` carry their own "no vault exists" copy. That is a larger change across published marketing copy and is deliberately not in this PR.