### PR TITLE
fix(site): rwally.com/disclaimers told readers no vault exists; two do

### DIFF
--- a/apps/site-next/README.md
+++ b/apps/site-next/README.md
@@ -1,8 +1,19 @@
 # `apps/site-next` — the public site, rebuilt
 
 Eight pages, built from React to static HTML, serving from one origin with no third party in the
-path. It replaces `apps/site` when it is finished; until then `apps/site` is what rwally.com serves
-and this directory is not deployed.
+path. **This is what rwally.com serves.**
+
+That last sentence used to read the other way round: "it replaces `apps/site` when it is finished;
+until then `apps/site` is what rwally.com serves and this directory is not deployed." That stopped
+being true at some point before 2026-09-12 and nothing here was updated. Checked that day against
+the live site: `https://rwally.com` returns this build's markup, and its live-from-chain panel
+reports `factory.vaultCount()` as 2. The old nine-page URLs (`/status.html`, `/vision.html`,
+`/faq.html`) all return 200 but serve THIS build's index, not `apps/site`'s pages, so nothing under
+`apps/site` reaches a reader today.
+
+`scripts/test/claims-token-absence.test.mjs` already labelled `apps/site-next/dist` "the pages
+rwally.com serves", so the guard and this README had been contradicting each other. The guard was
+right.
 
 Four owner decisions of 2026-09-04 shape everything here: **self-hosted React**, **dark
 cinematic**, **no per-claim review markers**, and **the status block is a footer link rather than a

--- a/apps/site-next/src/live/chain.ts
+++ b/apps/site-next/src/live/chain.ts
@@ -6,8 +6,14 @@
  * fetched by the reader's own browser from the chain's public JSON-RPC endpoint
  * while the page is open, which means a reader who doubts them can open the
  * network panel and watch the request go out. That is the difference between
- * "the factory has created no vault" as a sentence and as an observation, and it
- * is the whole reason the section exists.
+ * "the factory has created two vaults" as a sentence and as an observation, and
+ * it is the whole reason the section exists.
+ *
+ * That example used to read "no vault", and it is worth keeping the change in
+ * view rather than quietly swapping the number: the written claim went stale
+ * when vault #1 was created and nothing here noticed, while the READ beside it
+ * had been correct the whole time without anyone touching it. The section is
+ * its own argument.
  *
  * THIS FILE IS A PORT, NOT AN INVENTION. `apps/app/src/app.js` has been doing
  * exactly this against the same endpoint since 2026-09-05 and the request shape

--- a/apps/site-next/src/sections/risks-register/entries.tsx
+++ b/apps/site-next/src/sections/risks-register/entries.tsx
@@ -79,9 +79,13 @@
  *       24-hour execution window)"
  *     contracts/config/robinhood-mainnet.json  smoke.gov.executionWindow = 86400
  *     The zero timelock is a parameter of the REFERENCE CONFIGURATION, not of
- *     any particular deployed vault — no vault has been created yet (see
- *     status.html), which is why the sentence names the configuration rather
- *     than a vault.
+ *     any particular deployed vault, which is why the sentence names the
+ *     configuration rather than a vault. That distinction got MORE important
+ *     on 2026-09-12, not less: two vaults now exist on chain 4663 and they do
+ *     not agree with each other. Both set timelockDuration 0, but vault #1
+ *     carries executionWindow 86400 (matching the reference) and vault #2
+ *     carries 3600. A sentence naming "the deployed vault's window" would now
+ *     be false about one of them whichever number it picked.
  *
  *   r7  "25% of voting-eligible stake" quorum floor, and the reference minimum
  *     contracts/config/robinhood-mainnet.json  smoke.gov.quorumBps = 2500
@@ -101,15 +105,21 @@
  *       p.revealedWeight == p.snapshotTotal && p.forWeight >= p.snapshotTotal
  *     contracts/src/Governance.sol:531      passing starts the timelock
  *
- *   r14  REPOINTED 2026-09-05, copy deck v2. Owner: "I haven't created the
- *     safe vault yet. I want the pivot to the all-stocks index." The cell
- *     used to name a planned 50,000 USDG capacity cap; that figure described
- *     a vault that will not be created, so the cell states the honest,
- *     figure-free version instead — a capacity cap is a per-vault parameter
- *     and no vault exists. Its opening word is load-bearing: it must not
- *     start with "Nothing", or the risks-hero "Seven of these have no
- *     mitigation" count (derived from cells that DO start with "Nothing")
- *     goes to eight.
+ *   r14  REPOINTED 2026-09-05, copy deck v2, and again 2026-09-12.
+ *     The 2026-09-05 pass removed a planned 50,000 USDG figure because it
+ *     described a vault that would not be created, leaving "a capacity cap is
+ *     a per-vault parameter and no vault exists".
+ *     That second clause is now false. Two vaults exist on chain 4663 and BOTH
+ *     carry a cap, so the figure is real rather than planned:
+ *       0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4  capacityCapUsdc() 50000000000
+ *       0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38  capacityCapUsdc() 50000000000
+ *     Both read back on 2026-09-12; 5e10 at 6 decimals is 50,000 USDG. The cell
+ *     names the cap and then says what it does NOT bound, because a per-vault
+ *     cap is not a protocol-wide one and reading it as such is the mistake the
+ *     figure invites.
+ *     Its opening word is still load-bearing: it must not start with "Nothing",
+ *     or the risks-hero "Seven of these have no mitigation" count (derived from
+ *     cells that DO start with "Nothing") goes to eight. It opens with "A".
  *
 
  *   r6  the Mode-F trigger
@@ -313,7 +323,7 @@ export const ENTRIES: readonly RiskEntry[] = [
     rows: [
       { dt: "What it is", dd: "New contracts, a new governance mechanism and a new operator model, none of it battle-tested by time or volume." },
       { dt: "Worst case", dd: "Something nobody on this page thought of." },
-      { dt: "What is done", dd: "A capacity cap is a per-vault parameter and no vault exists, so there is no blast-radius bound in place today. Do not deposit what you cannot afford to lose entirely." },
+      { dt: "What is done", dd: "A capacity cap is a per-vault parameter. The two vaults on chain 4663 each set it to 50,000 USDG, so each vault's blast radius is bounded, but nothing bounds the protocol as a whole. Do not deposit what you cannot afford to lose entirely." },
     ],
   },
   {

--- a/apps/site-next/src/sections/risks-scope-additions/groups.ts
+++ b/apps/site-next/src/sections/risks-scope-additions/groups.ts
@@ -108,8 +108,15 @@ export const CARD_4_TITLE = 'Anyone in a restricted jurisdiction';
    CARD_1_BODY is also why this section is the one that must not be
    summarised. Every clause in it is a scope limit on the clause before it. */
 
+/* CARD_1_BODY's CONCLUSION is unchanged and its PREMISE was replaced on
+   2026-09-12. It used to reach "no cap for a treasury to check against" from
+   "no vault exists yet". Two vaults exist on chain 4663 now, both with
+   capacityCapUsdc() reading 50000000000, which is 50,000 USDG at 6 decimals.
+   So there IS a cap to check against, and it happens to make the same point
+   more sharply than its absence did: 50,000 USDG is not a treasury-scale
+   venue, and now a reader can verify that rather than take it on trust. */
 export const CARD_1_BODY =
-  'A capacity cap is a per-vault parameter, chosen by whoever creates a vault and frozen when it is funded. No vault exists yet, so there is no cap sized for a treasury to check against, and no vault this site can point to as able to absorb one.';
+  'A capacity cap is a per-vault parameter, chosen by whoever creates a vault and frozen when it is funded. The two vaults on chain 4663 are capped at 50,000 USDG each, so there is a figure to check against, and it is nowhere near large enough to absorb a treasury allocation.';
 
 export const CARD_2_BODY =
   'There is no autopilot. Skipping votes does not park your position neutrally: it moves quorum and wastes your commit; it hands the outcome to whoever did turn up.';

--- a/apps/site-next/test/site.test.mjs
+++ b/apps/site-next/test/site.test.mjs
@@ -1458,15 +1458,35 @@ t('the corrections from the 2026-08-29 review have not been undone', () => {
     assert.ok(!/no share of the exit fee/i.test(html), `${p}: "no share of the exit fee" is false, the operator's mandatory 5% collects it through share value`);
     // A7: the creator gate is a withdrawal gate, not a top-up obligation.
     assert.ok(!/must be topped up/i.test(html), `${p}: the creator gate is a withdrawal gate, not a top-up obligation`);
-    // C7: there is no population of vaults to generalise from.
-    assert.ok(!/set lower by many vaults/i.test(html), `${p}: there are no other vaults, nothing has been deployed`);
+    // C7: there is no population of vaults to generalise from. Two vaults exist on chain 4663 as
+    // of 2026-09-12, and two vaults created by the same account are still not a population: the
+    // claim this forbids generalises across independent creators, and there are none.
+    assert.ok(!/set lower by many vaults/i.test(html), `${p}: two vaults exist, both created by the same account, so there is no population of vaults to generalise from`);
     // A1: Mode F opens at reveal start, not at passage.
     assert.ok(!/rebalance has passed but has not yet executed/i.test(html), `${p}: Mode F opens at reveal start, not when a proposal passes`);
     // A4: the pre-audit findings are not all closed.
     assert.ok(!/all of which are now resolved/i.test(html), `${p}: one High remains open at the launch configuration and a sub-vault class is dormant, not fixed`);
-    // C8: the cap is a planned parameter of a vault that does not exist.
-    if (html.includes('50,000')) {
-      assert.ok(/\bplanned\b/i.test(html), `${p}: states the 50,000 figure without labelling it planned and undeployed`);
+    // C8, INVERTED ON 2026-09-12, and the inversion is the point.
+    //
+    // It used to require the opposite: a page stating 50,000 had to label it "planned", because
+    // the figure described a capacity cap on a vault nobody had created. That premise died when
+    // the vaults were created. Both now read capacityCapUsdc() 50000000000, which is 50,000 USDG
+    // at 6 decimals, so calling the figure planned is now the false statement and this guard was
+    // requiring it.
+    //
+    //   0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4
+    //   0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38
+    //
+    // SCOPED TO A WINDOW, not to the page. The old form tested /planned/ anywhere in the whole
+    // document, so inverting it page-wide would red on any unrelated legitimate use of the word.
+    // Each occurrence of the figure is judged by the prose around it and nothing else.
+    for (const m of html.matchAll(/50,000/g)) {
+      const window = html.slice(Math.max(0, m.index - 240), m.index + 240);
+      assert.ok(
+        !/\bplanned\b/i.test(window),
+        `${p}: calls the 50,000 cap "planned". It is deployed: two vaults on chain 4663 read` +
+          ` capacityCapUsdc() 50000000000. Say what it is, not what it was going to be.`,
+      );
     }
   }
 });


### PR DESCRIPTION
The live risk disclosures on `rwally.com/disclaimers` said, twice, that no vault exists. **Two vaults hold real funds on chain 4663.** Verified by fetching the deployed page, not by reading source:

```
curl https://rwally.com/disclaimers
  "A capacity cap is a per-vault parameter and no vault exists, so there is
   no blast-radius bound in place today."
  "No vault exists yet, so there is no cap sized for a treasury to check
   against, and no vault this site can point to as able to absorb one."
```

The risks page is the worst surface to be wrong on.

## The premise was false; both conclusions survive

A capacity cap **is** in place, on both vaults, read back the same day:

| Vault | `capacityCapUsdc()` |
|---|---|
| `0x9b0229FF0613EaD59e41Eec556e03b5ED228e2b4` | `50000000000` |
| `0x03E121e18c68B48B84a60D8F93BcD7D5be31ee38` | `50000000000` |

5e10 at 6 decimals is 50,000 USDG. r14 now names the cap and then says what it does **not** bound, because a per-vault cap is not a protocol-wide one. The "wrong for treasuries" card keeps its conclusion for a better reason: a reader can check 50,000 against their own size instead of taking the scope limit on trust.

## A guard was requiring the false version

`apps/site-next/test/site.test.mjs` carried C8 from the 2026-08-29 review: any page stating 50,000 had to label it **"planned"**, because the figure then described a cap on a vault nobody had created.

That premise died when the vaults were created. The guard had quietly become a requirement to misstate a deployed parameter.

Inverted rather than deleted: stating the figure must now **not** call it planned. Scoped to a 240-character window around each occurrence, because the old form tested the whole document and inverting that page-wide would red on any unrelated use of the word.

**Negative-controlled both ways** — reintroducing "planned" beside the figure reds test 37; removing it greens again.

## Two more, found while checking which surface is live

- `apps/site-next/README.md` opened by saying `apps/site` is what rwally.com serves and this directory is not deployed. **Both halves are false.** `claims-token-absence.test.mjs` had been labelling `apps/site-next/dist` "the pages rwally.com serves" all along, so the guard and the README were contradicting each other. The guard was right.
- `src/live/chain.ts` illustrated its own argument with *"the factory has created no vault"*. The written example went stale while the live read beside it stayed correct untouched, which **is** the argument.

The r6 comment was repointed, not corrected: it explains why the sentence names the reference configuration rather than a deployed vault, and that got more load-bearing, not less. The two vaults disagree with each other (both timelock 0, but `executionWindow` 86400 and 3600), so naming "the deployed vault's window" would now be false about one of them either way.

## Verification

- `npm run gate` passes
- The hero's "Seven of these have no mitigation" count is intact: exactly seven cells still open with "Nothing", and the replaced cell opens with "A", which its own comment flags as load-bearing
- Built `dist/` checked directly: no `no vault exists` survives in the served HTML

## Scope, and why it stops here

`apps/site-next` only. The rest is **not free to change yet**.

`llms.txt`, `README.md`, `docs/` and `apps/site/` carry `"no vault has been created"`, which `scripts/test/claims-robinhood-deployment.test.mjs` **requires verbatim** while `contracts/config/deployments/robinhood-mainnet.json` holds `smokeVault: null`. That guard is a two-state machine: record the vault, and every surface it names must stop saying the phrase in the same commit.

That flip is one atomic change and it is the next PR, the larger one. It also unblocks #211, whose own record note says it goes green when vault #1 is created and recorded.

One gap worth naming: the walk leg only catches the exact phrase `no vault has been created`. The variants fixed here (`no vault exists`) are caught by nothing, which is why they survived.