### PR TITLE
feat(app): the vault table has rows, read from the chain

### DIFF
--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -2,7 +2,7 @@
 
 The vault explorer, v1. It renders one thing and it renders it honestly: a protocol card whose three
 most load-bearing facts are re-read from chain 4663 in the reader's own browser every time the page
-loads, above a table of vaults with no rows.
+loads, above a table with one row per vault, also read live.
 
 The order used to be stated the other way round here. In `index.html` the protocol card is the first
 `<section>` and the vaults card the second, so the table is BELOW it.
@@ -18,7 +18,8 @@ It is deployed to the Cloudflare Pages project `rwally-app`, production branch `
 | `VaultFactory.allowSubVaults()` | An `eth_call` from the browser, on load |
 | `ChainlinkOracle.usdc()`, then `symbol()` on the token it names | Two `eth_call`s from the browser, on load |
 | The block the reads landed at | `eth_blockNumber`, same load |
-| Every vault row | Nothing. This page renders no rows: there is no `<tbody>` in `index.html` and `app.js` writes only into the live-reads panel. Two vaults existed on chain 4663 as of 2026-09-12 and neither is listed |
+| Every vault row | `VaultFactory.allVaults(i)` for each index, then five `eth_call`s per vault (`navWad`, `totalShares`, `idleUsdc`, `holderCount`, `capacityCapUsdc`), all from the browser on load. `1 + n + 5n` calls in total, so the cost grows with the vault count |
+| The "Age" and "Performance vs SPY" columns | Nothing, and they were removed rather than left blank. `VaultCore` exposes no `createdAt()` and no `name()`, and per-vault performance against an index needs price history this page does not hold. A header promising a figure the page cannot read is the same defect as a false sentence, in table form |
 
 **The token that `usdc()` names is USDG, and the page prints what `symbol()` returned rather than
 what the getter is called.** The getter keeps the name `usdc` because that is the name in the
@@ -87,9 +88,17 @@ screenshots/
 node --test --test-reporter=tap apps/app/test/claims.test.mjs
 ```
 
-Six checks: the empty-state sentence survives into the build, the factory address is on the page,
-no banned claim shape appears in any built file, `_headers` carries every required directive, the
-markup has no inline script or style, and the page fetches from no origin but the chain RPC.
+Nine checks: the empty-state sentence survives into the build; the row container `app.js` writes
+into exists in the markup; no column header promises a figure this page cannot read; every pinned
+vault-row selector is the real 4-byte selector; the factory address is on the page; no banned claim
+shape appears in any built file; `_headers` carries every required directive; the markup has no
+inline script or style; and the page fetches from no origin but the chain RPC.
+
+The three added with the vault rows all guard the same failure: **a wrong read does not throw
+here.** `eth_call` answers an unknown selector with `0x`, which decodes to zero, so a mistyped
+selector renders a confident `0.00` rather than an error. A renamed `tbody` id leaves every read
+succeeding and the table silently empty. Neither is visible at runtime, so both are pinned at build
+time instead.
 
 **It runs in CI and in the gate, as its own step.** The root `package.json` declares `test:app`,
 `.github/workflows/ci.yml` runs it at line 137, and `scripts/gate.mjs` invokes it immediately before

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -1,8 +1,8 @@
 # `apps/app` — the explore surface at app.rwally.com
 
-The vault explorer, v1. It renders one thing and it renders it honestly: a protocol card whose three
-most load-bearing facts are re-read from chain 4663 in the reader's own browser every time the page
-loads, above a table with one row per vault, also read live.
+The vault explorer, v1. It renders two things and it renders both honestly: a protocol card whose
+three most load-bearing facts are re-read from chain 4663 in the reader's own browser every time the
+page loads, above a table with one row per vault, read the same way.
 
 The order used to be stated the other way round here. In `index.html` the protocol card is the first
 `<section>` and the vaults card the second, so the table is BELOW it.
@@ -18,7 +18,7 @@ It is deployed to the Cloudflare Pages project `rwally-app`, production branch `
 | `VaultFactory.allowSubVaults()` | An `eth_call` from the browser, on load |
 | `ChainlinkOracle.usdc()`, then `symbol()` on the token it names | Two `eth_call`s from the browser, on load |
 | The block the reads landed at | `eth_blockNumber`, same load |
-| Every vault row | `VaultFactory.allVaults(i)` for each index, then five `eth_call`s per vault (`navWad`, `totalShares`, `idleUsdc`, `holderCount`, `capacityCapUsdc`), all from the browser on load. `1 + n + 5n` calls in total, so the cost grows with the vault count |
+| Every vault row | `VaultFactory.allVaults(i)` for each index, then four `eth_call`s per vault (`navWad`, `totalShares`, `holderCount`, `capacityCapUsdc`), all from the browser on load. `1 + n + 4n` calls in total, so the cost grows with the vault count |
 | The "Age" and "Performance vs SPY" columns | Nothing, and they were removed rather than left blank. `VaultCore` exposes no `createdAt()` and no `name()`, and per-vault performance against an index needs price history this page does not hold. A header promising a figure the page cannot read is the same defect as a false sentence, in table form |
 
 **The token that `usdc()` names is USDG, and the page prints what `symbol()` returned rather than
@@ -29,19 +29,20 @@ trusting a variable name over a chain read.
 
 ## Three decisions that are easy to undo by accident
 
-**1. The empty state is static markup, not a rendered value.** The sentence "This table lists no
-vaults. `vaultCount()` above is read live from chain 4663 and is the count that matters." lives in
-`index.html` and is never written by `app.js`. A claim produced by a fetch disappears exactly when
-the fetch fails, which is the moment a reader most needs to be told what is true. The LIVE READS
-panel **corroborates** that sentence with a number read seconds ago; it does not produce it.
+**1. The fallback block is static markup, not a rendered value.** The sentence "Vault rows are read
+from chain 4663 when this page loads. None are listed here until that read returns, and none are
+invented if it fails." lives in `index.html` and is never written by `app.js`. A claim produced by a
+fetch disappears exactly when the fetch fails, which is the moment a reader most needs to be told
+what is true. `app.js` hides the block once a row renders, and does not otherwise touch it.
 `test/claims.test.mjs` asserts the sentence is in the built HTML, so moving it into the script reds
 the guard.
 
-That sentence is deliberately a claim about the TABLE, not a count of vaults. The version before it
-pinned "`vaultCount()` reads 0", which was true when written and false from the moment vault #1 was
-created, with nothing going red in between: the guard is a static string match that reads no chain,
-so it can only prove the sentence is present, never that it is true. Pin what this deployment
-controls.
+That sentence describes WHERE the rows come from, not how many exist, and it is the third wording.
+The first pinned "`vaultCount()` reads 0", true when written and false from the moment vault #1 was
+created. The second pinned "this table lists no vaults", true until the rows were built. Both went
+false with nothing going red, because the guard is a static string match that reads no chain: it can
+only prove a sentence is present, never that it is true. The current wording holds whether the read
+returns, fails, or never runs, which is the property to preserve when changing it.
 
 **2. There is no `package.json`, and that is not an omission.** The repository root declares the
 workspace glob `apps/*`. A workspace package that is absent from `package-lock.json` makes `npm ci`
@@ -72,7 +73,7 @@ into a browser-side failure. `app.js` sends that header and no other, and no cre
 ```
 src/index.html   the page, all of it
 src/app.css      the only stylesheet, palette carried from apps/site-next/src/tokens.css
-src/app.js       the live reads, and nothing else
+src/app.js       both read passes: the protocol panel, and the vault rows
 src/_headers     the CSP. Copied to dist/_headers, where Pages reads it from
 src/favicon.svg  the comic R on its tile, byte-identical to the site's
 src/brand/       mark-comic.svg, byte-identical to the site copy in public/brand/
@@ -88,17 +89,25 @@ screenshots/
 node --test --test-reporter=tap apps/app/test/claims.test.mjs
 ```
 
-Nine checks: the empty-state sentence survives into the build; the row container `app.js` writes
+Ten checks: the empty-state sentence survives into the build; the row container `app.js` writes
 into exists in the markup; no column header promises a figure this page cannot read; every pinned
-vault-row selector is the real 4-byte selector; the factory address is on the page; no banned claim
+vault-row selector is recomputed from its signature with viem and compared; the column order and
+their decimal scales are pinned; the factory address is on the page; no banned claim
 shape appears in any built file; `_headers` carries every required directive; the markup has no
 inline script or style; and the page fetches from no origin but the chain RPC.
 
-The three added with the vault rows all guard the same failure: **a wrong read does not throw
-here.** `eth_call` answers an unknown selector with `0x`, which decodes to zero, so a mistyped
-selector renders a confident `0.00` rather than an error. A renamed `tbody` id leaves every read
-succeeding and the table silently empty. Neither is visible at runtime, so both are pinned at build
-time instead.
+The four added with the vault rows guard what a runtime failure cannot tell you. An earlier draft
+of this paragraph claimed they guard a *silent zero*, on the theory that `eth_call` answers an
+unknown selector with `0x` which decodes to zero. **That was never true here and was not probed
+before being written.** Chain 4663 answers an unknown selector with a JSON-RPC error
+(`{"code":3,"message":"execution reverted"}`), which `rpc()` throws on; and `BigInt('0x')` is a
+`SyntaxError` anyway, so the zero is unreachable by two independent paths.
+
+The real failure is loud but **wide**: `Promise.all` means one bad selector takes down every row,
+and the page reports a failure without being able to say which call broke. A renamed `tbody` id is
+worse, because it is silent: every read succeeds and the table simply stays empty. And the column
+guard exists because the rendering was otherwise unpinned, so reordering the cell array or changing
+a decimal scale relabelled real numbers with every other check still green.
 
 **It runs in CI and in the gate, as its own step.** The root `package.json` declares `test:app`,
 `.github/workflows/ci.yml` runs it at line 137, and `scripts/gate.mjs` invokes it immediately before

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -89,14 +89,14 @@ screenshots/
 node --test --test-reporter=tap apps/app/test/claims.test.mjs
 ```
 
-Ten checks: the empty-state sentence survives into the build; the row container `app.js` writes
+Eleven checks: the empty-state sentence survives into the build; the row container `app.js` writes
 into exists in the markup; no column header promises a figure this page cannot read; every pinned
 vault-row selector is recomputed from its signature with viem and compared; the column order and
-their decimal scales are pinned; the factory address is on the page; no banned claim
+their decimal scales are pinned; whatever renders rows also updates the count chip; the factory address is on the page; no banned claim
 shape appears in any built file; `_headers` carries every required directive; the markup has no
 inline script or style; and the page fetches from no origin but the chain RPC.
 
-The four added with the vault rows guard what a runtime failure cannot tell you. An earlier draft
+The five added with the vault rows guard what a runtime failure cannot tell you. An earlier draft
 of this paragraph claimed they guard a *silent zero*, on the theory that `eth_call` answers an
 unknown selector with `0x` which decodes to zero. **That was never true here and was not probed
 before being written.** Chain 4663 answers an unknown selector with a JSON-RPC error
@@ -105,9 +105,17 @@ before being written.** Chain 4663 answers an unknown selector with a JSON-RPC e
 
 The real failure is loud but **wide**: `Promise.all` means one bad selector takes down every row,
 and the page reports a failure without being able to say which call broke. A renamed `tbody` id is
-worse, because it is silent: every read succeeds and the table simply stays empty. And the column
-guard exists because the rendering was otherwise unpinned, so reordering the cell array or changing
-a decimal scale relabelled real numbers with every other check still green.
+worse, because it is silent: every read succeeds and the table simply stays empty. And the column guard exists because the rendering was otherwise
+unpinned, so reordering the cell array or changing a decimal scale relabelled real numbers with
+every other check still green.
+
+**The first version of that column guard did not work, and the claim that it did was made without
+running the case.** It sliced the source to a delimiter (`])) {`) that does not occur in `app.js`,
+so `indexOf` returned `-1`, the window became the whole rest of the file, and its order check
+chained only three of the four cells. Swapping TVL and NAV per share rendered each under the
+other's heading and passed all ten checks. It now asserts its own window before using it, bounds
+the window's length, and compares all four cell positions by index. All three cases are run as
+controls: the swap, a broken delimiter, and a dropped chip update each red a named test.
 
 **It runs in CI and in the gate, as its own step.** The root `package.json` declares `test:app`,
 `.github/workflows/ci.yml` runs it at line 137, and `scripts/gate.mjs` invokes it immediately before

--- a/apps/app/src/app.js
+++ b/apps/app/src/app.js
@@ -5,13 +5,25 @@
    'unsafe-inline', so an inline <script> would be blocked by the browser with
    no visible error. Every line of behaviour on this page is here.
 
-   WHAT IT DOES, AND WHAT IT DELIBERATELY DOES NOT DO. It sends four eth_call
-   requests and one eth_blockNumber to the public RPC, and it writes the answers
-   into the LIVE READS panel. It renders NOTHING ELSE on the page. The vault
-   table's empty state is static markup, because that sentence has to be true
-   whether or not this file runs: a claim produced by a fetch is a claim that
-   disappears when the fetch fails, and the honest version of a failed read is
-   an error, not a blank.
+   WHAT IT DOES. Two independent passes, and a failure in one must not blank the
+   other.
+
+   Pass 1, the LIVE READS panel: four eth_call requests and one eth_blockNumber.
+   index.html's "Four eth_call requests and one eth_blockNumber" sentence cites
+   THIS COMMENT as its authority, so if you change the calls there, change that
+   sentence too.
+
+   Pass 2, the VAULT ROWS: vaultCount(), then allVaults(i) for each index, then
+   five reads per vault (navWad, totalShares, idleUsdc, holderCount,
+   capacityCapUsdc). That is 1 + n + 5n eth_calls, so the cost grows with the
+   vault count and this is the thing to change first if the table ever gets
+   long: a multicall, or an indexer, rather than a read per cell.
+
+   WHAT IT STILL DELIBERATELY DOES NOT DO. It invents nothing. A failed row read
+   leaves the tbody empty and names the failure, because the honest version of a
+   failed read is an error, not a blank and not a zero. The fallback block under
+   the table is static markup for the same reason: it is what a reader sees when
+   this file does not run at all.
 
    REQUEST SHAPE IS LOAD-BEARING. The RPC's CORS preflight allows exactly one
    request header, content-type. Adding any other header, or any credential,
@@ -30,6 +42,20 @@ const SEL_VAULT_COUNT = '0xa7c6a100'; // vaultCount()
 const SEL_ALLOW_SUB = '0x1979d1fd'; // allowSubVaults()
 const SEL_USDC = '0x3e413bee'; // usdc()
 const SEL_SYMBOL = '0x95d89b41'; // symbol()
+
+// Vault-row selectors, same provenance as the four above: computed with
+// `cast sig` and pinned, so this file carries no keccak implementation.
+const SEL_ALL_VAULTS = '0x9094a91e'; // allVaults(uint256)
+const SEL_NAV_WAD = '0xd09074c0'; // navWad()
+const SEL_TOTAL_SHARES = '0x3a98ef39'; // totalShares()
+const SEL_IDLE_USDC = '0x047b7fc7'; // idleUsdc()
+const SEL_HOLDER_COUNT = '0x1aab9a9f'; // holderCount()
+const SEL_CAPACITY_CAP = '0xb857d9b9'; // capacityCapUsdc()
+
+const EXPLORER = 'https://robinhoodchain.blockscout.com/address/';
+
+/** A uint256 argument, ABI-encoded as one 32-byte word. */
+const word = (n) => BigInt(n).toString(16).padStart(64, '0');
 
 const TIMEOUT_MS = 12000;
 
@@ -106,6 +132,105 @@ function stampNow() {
   return 'Read from chain just now, ' + hhmmss + ' ' + zone;
 }
 
+/**
+ * Format a fixed-point integer as a decimal string, without floating point.
+ *
+ * Number() on a uint256 loses precision above 2^53, and every figure here is
+ * wad or 6-decimal USDG, so the arithmetic stays in BigInt and only the
+ * formatting is string work.
+ */
+function fixed(value, decimals, places) {
+  const base = 10n ** BigInt(decimals);
+  const whole = value / base;
+  const frac = value % base;
+  const fracStr = frac.toString().padStart(decimals, '0').slice(0, places);
+  const grouped = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return places > 0 ? grouped + '.' + fracStr : grouped;
+}
+
+/** One vault's row data, or null if any of its reads failed. */
+async function readVault(address) {
+  const [navWad, totalShares, idle, holders, cap] = await Promise.all([
+    ethCall(address, SEL_NAV_WAD),
+    ethCall(address, SEL_TOTAL_SHARES),
+    ethCall(address, SEL_IDLE_USDC),
+    ethCall(address, SEL_HOLDER_COUNT),
+    ethCall(address, SEL_CAPACITY_CAP),
+  ]);
+  return {
+    address,
+    navWad: BigInt(navWad.slice(0, 66)),
+    totalShares: BigInt(totalShares.slice(0, 66)),
+    idleUsdc: BigInt(idle.slice(0, 66)),
+    holders: BigInt(holders.slice(0, 66)),
+    cap: BigInt(cap.slice(0, 66)),
+  };
+}
+
+function renderVaultRows(vaults) {
+  const body = document.getElementById('vault-rows');
+  if (!body) return;
+  for (const v of vaults) {
+    const tr = document.createElement('tr');
+
+    const name = document.createElement('td');
+    const link = document.createElement('a');
+    link.className = 'addr';
+    link.href = EXPLORER + v.address;
+    link.rel = 'noopener';
+    link.textContent = shorten(v.address);
+    name.appendChild(link);
+    tr.appendChild(name);
+
+    // NAV per share is navWad / totalShares, both 18-dp. A vault with no
+    // shares has no NAV per share -- it is 0/0, not 0 -- so it prints as
+    // absent rather than as a number nobody can act on.
+    const navPerShare = v.totalShares === 0n
+      ? null
+      : (v.navWad * 10n ** 18n) / v.totalShares;
+
+    for (const text of [
+      fixed(v.navWad, 18, 2),
+      navPerShare === null ? 'no shares' : fixed(navPerShare, 18, 6),
+      v.holders.toString(),
+      fixed(v.cap, 6, 0),
+    ]) {
+      const td = document.createElement('td');
+      td.className = 'col-num';
+      td.textContent = text;
+      tr.appendChild(td);
+    }
+    body.appendChild(tr);
+  }
+
+  // Only once a row actually exists does the fallback stop being the truth.
+  if (vaults.length > 0) {
+    const empty = document.getElementById('vault-empty');
+    if (empty) empty.hidden = true;
+  }
+}
+
+async function loadVaults() {
+  const fail = document.getElementById('vault-rows-fail');
+  try {
+    const count = Number(BigInt(await ethCall(FACTORY, SEL_VAULT_COUNT)));
+    if (!Number.isSafeInteger(count) || count < 0) throw new Error('vaultCount out of range');
+    if (count === 0) return; // nothing to render; the fallback block is already correct
+
+    const addresses = await Promise.all(
+      Array.from({ length: count }, (_, i) => ethCall(FACTORY, SEL_ALL_VAULTS + word(i))),
+    );
+    const vaults = await Promise.all(addresses.map((w) => readVault(wordToAddress(w))));
+    renderVaultRows(vaults);
+    if (fail) fail.hidden = true;
+  } catch {
+    // Deliberately silent about the cause here: the panel above already reports
+    // RPC errors in full, and a second copy of the same message reads as two
+    // failures. What matters is that no row is invented.
+    if (fail) fail.hidden = false;
+  }
+}
+
 async function run() {
   setStamp('Reading from the public RPC.');
   for (const id of ['read-vaultcount', 'read-allowsub', 'read-usdc']) setValue(id, 'reading');
@@ -149,4 +274,8 @@ async function run() {
   }
 }
 
+// The two passes are started separately and neither is awaited by the other:
+// a dead RPC should not let the panel's failure suppress the table's, nor the
+// reverse, and a slow vault read should not delay the block stamp.
 run();
+loadVaults();

--- a/apps/app/src/app.js
+++ b/apps/app/src/app.js
@@ -14,10 +14,24 @@
    sentence too.
 
    Pass 2, the VAULT ROWS: vaultCount(), then allVaults(i) for each index, then
-   five reads per vault (navWad, totalShares, idleUsdc, holderCount,
-   capacityCapUsdc). That is 1 + n + 5n eth_calls, so the cost grows with the
-   vault count and this is the thing to change first if the table ever gets
-   long: a multicall, or an indexer, rather than a read per cell.
+   four reads per vault (navWad, totalShares, holderCount, capacityCapUsdc).
+   That is 1 + n + 4n eth_calls, so the cost grows with the vault count and this
+   is the thing to change first if the table ever gets long: a multicall, or an
+   indexer, rather than a read per cell. It read idleUsdc as a fifth and
+   rendered it nowhere; an unrendered read is a call nobody can check, so it is
+   gone rather than displayed for symmetry.
+
+   WHAT A WRONG SELECTOR ACTUALLY DOES HERE, because an earlier version of this
+   comment asserted the opposite without probing it. It does NOT silently render
+   a zero. Chain 4663 answers an unknown selector with a JSON-RPC error,
+   `{"code":3,"message":"execution reverted"}`, which `rpc()` turns into a throw;
+   and even a bare `0x` result would throw, because `BigInt('0x')` is a
+   SyntaxError. Both probed against the live endpoint. So the real failure is
+   loud but WIDE: `Promise.all` means one bad read suppresses EVERY row, not
+   just its own, and the table reports a failure instead of a wrong number. That
+   is the tradeoff this shape makes, and it is the honest reason to pin the
+   selectors at build time: not to prevent a silent zero, but because a typo
+   takes the whole table down and the page cannot tell you which call broke.
 
    WHAT IT STILL DELIBERATELY DOES NOT DO. It invents nothing. A failed row read
    leaves the tbody empty and names the failure, because the honest version of a
@@ -48,7 +62,6 @@ const SEL_SYMBOL = '0x95d89b41'; // symbol()
 const SEL_ALL_VAULTS = '0x9094a91e'; // allVaults(uint256)
 const SEL_NAV_WAD = '0xd09074c0'; // navWad()
 const SEL_TOTAL_SHARES = '0x3a98ef39'; // totalShares()
-const SEL_IDLE_USDC = '0x047b7fc7'; // idleUsdc()
 const SEL_HOLDER_COUNT = '0x1aab9a9f'; // holderCount()
 const SEL_CAPACITY_CAP = '0xb857d9b9'; // capacityCapUsdc()
 
@@ -148,12 +161,19 @@ function fixed(value, decimals, places) {
   return places > 0 ? grouped + '.' + fracStr : grouped;
 }
 
-/** One vault's row data, or null if any of its reads failed. */
+/**
+ * One vault's row data.
+ *
+ * REJECTS rather than returning null, and the caller's Promise.all makes that
+ * wide: a single failed read on a single vault suppresses every row. Stated
+ * here because the alternative, catching per vault and rendering the rest, would
+ * show a partial table with no indication that a row is missing, which is the
+ * worse failure for a page whose whole claim is that it invents nothing.
+ */
 async function readVault(address) {
-  const [navWad, totalShares, idle, holders, cap] = await Promise.all([
+  const [navWad, totalShares, holders, cap] = await Promise.all([
     ethCall(address, SEL_NAV_WAD),
     ethCall(address, SEL_TOTAL_SHARES),
-    ethCall(address, SEL_IDLE_USDC),
     ethCall(address, SEL_HOLDER_COUNT),
     ethCall(address, SEL_CAPACITY_CAP),
   ]);
@@ -161,7 +181,6 @@ async function readVault(address) {
     address,
     navWad: BigInt(navWad.slice(0, 66)),
     totalShares: BigInt(totalShares.slice(0, 66)),
-    idleUsdc: BigInt(idle.slice(0, 66)),
     holders: BigInt(holders.slice(0, 66)),
     cap: BigInt(cap.slice(0, 66)),
   };

--- a/apps/app/src/app.js
+++ b/apps/app/src/app.js
@@ -13,8 +13,9 @@
    THIS COMMENT as its authority, so if you change the calls there, change that
    sentence too.
 
-   Pass 2, the VAULT ROWS: vaultCount(), then allVaults(i) for each index, then
-   four reads per vault (navWad, totalShares, holderCount, capacityCapUsdc).
+   Pass 2, the VAULT ROWS: its OWN vaultCount() call (it does not reuse pass 1's
+   answer, so the two passes stay independent), then allVaults(i) for each index,
+   then four reads per vault (navWad, totalShares, holderCount, capacityCapUsdc).
    That is 1 + n + 4n eth_calls, so the cost grows with the vault count and this
    is the thing to change first if the table ever gets long: a multicall, or an
    indexer, rather than a read per cell. It read idleUsdc as a fifth and
@@ -57,8 +58,9 @@ const SEL_ALLOW_SUB = '0x1979d1fd'; // allowSubVaults()
 const SEL_USDC = '0x3e413bee'; // usdc()
 const SEL_SYMBOL = '0x95d89b41'; // symbol()
 
-// Vault-row selectors, same provenance as the four above: computed with
-// `cast sig` and pinned, so this file carries no keccak implementation.
+// Vault-row selectors, same provenance as the four above: computed with viem's
+// toFunctionSelector and pinned, so this file carries no keccak implementation.
+// apps/app/test/claims.test.mjs recomputes all five and fails on a wrong pin.
 const SEL_ALL_VAULTS = '0x9094a91e'; // allVaults(uint256)
 const SEL_NAV_WAD = '0xd09074c0'; // navWad()
 const SEL_TOTAL_SHARES = '0x3a98ef39'; // totalShares()
@@ -212,7 +214,11 @@ function renderVaultRows(vaults) {
       fixed(v.navWad, 18, 2),
       navPerShare === null ? 'no shares' : fixed(navPerShare, 18, 6),
       v.holders.toString(),
-      fixed(v.cap, 6, 0),
+      // VaultCore.sol:81 documents 0 as "uncapped (no limit)", and creation is
+      // permissionless, so a third party can make this render. Printed as `0`
+      // under a header reading Capacity it means the exact inverse: a full
+      // vault. Same sentinel problem as totalShares above, handled the same way.
+      v.cap === 0n ? 'uncapped' : fixed(v.cap, 6, 0),
     ]) {
       const td = document.createElement('td');
       td.className = 'col-num';
@@ -221,6 +227,13 @@ function renderVaultRows(vaults) {
     }
     body.appendChild(tr);
   }
+
+  // THE CHIP COUNTS ROWS, SO WHATEVER RENDERS ROWS MUST OWN IT. It ships as
+  // "0 listed here", which is true before this function runs and stays true if
+  // the read fails. It stopped being true the moment rows rendered, and nothing
+  // updated it, so the card head contradicted the table one line below it.
+  const chip = document.querySelector('.count-chip .num');
+  if (chip) chip.textContent = String(vaults.length);
 
   // Only once a row actually exists does the fallback stop being the truth.
   if (vaults.length > 0) {

--- a/apps/app/src/index.html
+++ b/apps/app/src/index.html
@@ -133,15 +133,19 @@
         <p class="reads-stamp" id="reads-stamp" aria-live="polite">Reading from the public RPC.</p>
       </div>
 
-      <!-- THE COUNT IS OF CALLS, NOT OF ROWS BELOW, and the two differ: the
-           third row spends TWO calls, usdc() and then symbol() on whatever
-           address that returns. app.js says "four eth_call requests and one
-           eth_blockNumber" in its own header, and that file is the authority
-           on what it sends. This sentence said "three" and undercounted it. -->
+      <!-- THIS SENTENCE COUNTS THIS PANEL ONLY, AND IT HAS BEEN WRONG TWICE.
+           It said "three" while the panel sent four: the third row spends TWO
+           calls, usdc() and then symbol() on whatever address that returns.
+           Then the vault table below started sending its own reads and this
+           sentence, scoped to the panel, read as if it covered the page. Both
+           counts are now named, so neither can be read as the other. app.js is
+           the authority for both: if you change what either pass sends, change
+           this sentence in the same commit. -->
       <p class="reads-intro">
-        Four <span class="mono">eth_call</span> requests and one <span class="mono">eth_blockNumber</span>,
-        sent from this browser straight to the chain 4663 public RPC. Nothing is proxied and nothing
-        is cached.
+        Four <span class="mono">eth_call</span> requests and one <span class="mono">eth_blockNumber</span>
+        for this panel, sent from this browser straight to the chain 4663 public RPC. The vault
+        table below sends its own, one <span class="mono">allVaults</span> call per vault and four
+        reads each. Nothing is proxied and nothing is cached.
       </p>
 
       <ul class="reads-list">
@@ -236,7 +240,7 @@
         <caption class="sr-only">Vaults on chain 4663, one row each, read live from the public RPC when this page loads. Columns: vault address, total value locked, NAV per share, member count, and capacity cap.</caption>
         <thead>
           <tr>
-            <th scope="col" class="col-name">Name</th>
+            <th scope="col" class="col-name">Vault</th>
             <th scope="col" class="col-num">TVL</th>
             <th scope="col" class="col-num">NAV per share</th>
             <th scope="col" class="col-num">Members</th>

--- a/apps/app/src/index.html
+++ b/apps/app/src/index.html
@@ -144,8 +144,8 @@
       <p class="reads-intro">
         Four <span class="mono">eth_call</span> requests and one <span class="mono">eth_blockNumber</span>
         for this panel, sent from this browser straight to the chain 4663 public RPC. The vault
-        table below sends its own, one <span class="mono">allVaults</span> call per vault and four
-        reads each. Nothing is proxied and nothing is cached.
+        table below sends its own <span class="mono">vaultCount</span> call, one <span class="mono">allVaults</span>
+        call per vault, and four reads each. Nothing is proxied and nothing is cached.
       </p>
 
       <ul class="reads-list">

--- a/apps/app/src/index.html
+++ b/apps/app/src/index.html
@@ -208,17 +208,22 @@
 
   <!-- ===================================================================
        VAULTS
-       Zero ROWS, which is not the same as zero vaults, and this section used
-       to conflate them. Two vaults exist on chain 4663; this page renders no
-       row for either, because nothing here renders rows at all: there is no
-       <tbody> in this file and app.js writes only into the LIVE READS panel.
+       THE ROWS ARE NOW BUILT. This section used to carry a header row and
+       nothing under it, because app.js wrote only into the LIVE READS panel.
+       It now renders one row per vault from allVaults(i), read live.
 
-       The empty state stays static markup on purpose: the sentence has to be
-       true whether or not the RPC answers, and the LIVE READS panel above
-       corroborates it rather than producing it. What changed is WHICH
-       sentence is the true one to pin. It is now a claim about this table,
-       which no chain state can falsify, rather than a count, which the next
-       createVault call falsifies silently.
+       TWO COLUMNS WERE REMOVED RATHER THAN LEFT UNFILLABLE. The header
+       promised "Age" and "Performance vs SPY". VaultCore exposes no
+       createdAt() and no name(), and per-vault performance against an index
+       needs history this page does not have, so both columns could only ever
+       have been filled by inventing them. A header that promises a figure the
+       page cannot read is the same defect as a false sentence, in table form.
+       What replaced them is what the chain actually answers: NAV per share,
+       member count, and the capacity cap.
+
+       The fallback block below stays static markup on purpose: it is what a
+       reader sees when the script does not run or the RPC does not answer, so
+       its prose describes where rows come from rather than asserting a count.
        =================================================================== -->
   <section class="card vaults" aria-labelledby="vaults-h">
     <div class="card-head">
@@ -228,18 +233,27 @@
 
     <div class="table-scroll">
       <table class="vault-table">
-        <caption class="sr-only">Vaults on chain 4663. The table has no rows: this page does not list individual vaults yet.</caption>
+        <caption class="sr-only">Vaults on chain 4663, one row each, read live from the public RPC when this page loads. Columns: vault address, total value locked, NAV per share, member count, and capacity cap.</caption>
         <thead>
           <tr>
             <th scope="col" class="col-name">Name</th>
             <th scope="col" class="col-num">TVL</th>
-            <th scope="col" class="col-num">Age</th>
             <th scope="col" class="col-num">NAV per share</th>
-            <th scope="col" class="col-num">Performance vs SPY</th>
+            <th scope="col" class="col-num">Members</th>
+            <th scope="col" class="col-num">Capacity</th>
           </tr>
         </thead>
+        <!-- FILLED BY app.js FROM THE CHAIN. Empty in the markup, and empty is
+             the honest resting state: if the RPC does not answer, no row is
+             invented and the failure is named below instead. -->
+        <tbody id="vault-rows"></tbody>
       </table>
     </div>
+
+    <p class="reads-fail" id="vault-rows-fail" hidden>
+      The vault rows could not be read from the public RPC, so none are shown. The count above and
+      the addresses below come from the same chain and are the fallback. Reload to try again.
+    </p>
 
     <!-- THE EMPTY STATE SITS OUTSIDE THE SCROLL CONTAINER, NOT IN A SPANNING
          CELL. Inside one it inherits the table's 40rem min-width, so at 375 px
@@ -247,14 +261,19 @@
          scroll and the reader sees only its first few words. A table may carry
          a header row and no body rows; the explanation of why there are none
          belongs beside the table, at the width of the card. -->
-    <div class="empty">
+    <!-- THE FALLBACK BLOCK, hidden by app.js the moment a row renders. Its
+         prose must be true as STATIC MARKUP, because that is the state a
+         reader sees when the script does not run or the RPC does not answer.
+         It therefore describes where the rows come from rather than asserting
+         a count, which is the mistake the sentence here used to make. -->
+    <div class="empty" id="vault-empty">
       <svg class="empty-mark" viewBox="0 0 64 40" role="presentation" focusable="false" aria-hidden="true">
         <rect x="0.75" y="0.75" width="62.5" height="38.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></rect>
         <line x1="0.75" y1="12.75" x2="63.25" y2="12.75" stroke="currentColor" stroke-width="1.5"></line>
         <line x1="20.75" y1="0.75" x2="20.75" y2="39.25" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></line>
         <line x1="42.25" y1="0.75" x2="42.25" y2="39.25" stroke="currentColor" stroke-width="1.5" stroke-dasharray="6 5"></line>
       </svg>
-      <p class="empty-lede">This table lists no vaults. vaultCount() above is read live from chain 4663 and is the count that matters.</p>
+      <p class="empty-lede">Vault rows are read from chain 4663 when this page loads. None are listed here until that read returns, and none are invented if it fails.</p>
       <p class="empty-sub">
         Creating a vault is permissionless. The caller becomes its creator and its attested
         operator, immutably.
@@ -287,8 +306,9 @@
            in this file and app.js writes only into the LIVE READS panel. It
            was a promise about code nobody had written. -->
       <p class="empty-watch">
-        Rows are not built yet. Until they are, the live <span class="mono">vaultCount()</span>
-        read above and the addresses beside it are how this page tells you what exists.
+        If you are seeing this block, the rows did not load. The live
+        <span class="mono">vaultCount()</span> read above and the addresses beside it come from the
+        same chain and are what this page can still tell you.
       </p>
     </div>
   </section>

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -55,6 +55,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { toFunctionSelector } from 'viem';
 
 const APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const DIST = path.join(APP, 'dist');
@@ -161,29 +162,62 @@ test('no column header promises a figure this page cannot read', () => {
 });
 
 test('every vault-row selector app.js pins is the real 4-byte selector', () => {
-  // These are pinned as hex so the page carries no keccak implementation, which
-  // means a typo is undetectable at runtime: eth_call returns 0x for an unknown
-  // selector and the column would render as a confident zero. Recomputed here
-  // from the signature text so the pin cannot drift from what it claims to be.
+  // COMPUTED, NOT TRANSCRIBED. An earlier version of this test compared a hex
+  // literal here against a hex literal in app.js and its comment claimed the
+  // selector was "recomputed from the signature text". It was not: two copies of
+  // the same constant agreeing proves only that nobody edited one of them. viem
+  // is already a root dependency, so the keccak is free and the claim can simply
+  // be made true.
   const js = read('app.js');
-  const expected = {
-    SEL_ALL_VAULTS: ['allVaults(uint256)', '0x9094a91e'],
-    SEL_NAV_WAD: ['navWad()', '0xd09074c0'],
-    SEL_TOTAL_SHARES: ['totalShares()', '0x3a98ef39'],
-    SEL_IDLE_USDC: ['idleUsdc()', '0x047b7fc7'],
-    SEL_HOLDER_COUNT: ['holderCount()', '0x1aab9a9f'],
-    SEL_CAPACITY_CAP: ['capacityCapUsdc()', '0xb857d9b9'],
-  };
-  for (const [name, [sig, sel]] of Object.entries(expected)) {
+  for (const [name, sig] of [
+    ['SEL_ALL_VAULTS', 'allVaults(uint256)'],
+    ['SEL_NAV_WAD', 'navWad()'],
+    ['SEL_TOTAL_SHARES', 'totalShares()'],
+    ['SEL_HOLDER_COUNT', 'holderCount()'],
+    ['SEL_CAPACITY_CAP', 'capacityCapUsdc()'],
+  ]) {
     const m = js.match(new RegExp(`const ${name} = '(0x[0-9a-f]{8})';`));
     assert.ok(m, `app.js no longer pins ${name}`);
     assert.equal(
       m[1],
-      sel,
-      `${name} is pinned as ${m[1]} but ${sig} is ${sel}. `
-        + 'A wrong selector does not throw: eth_call returns 0x and the cell renders as 0.',
+      toFunctionSelector(sig),
+      `${name} is pinned as ${m[1]} but ${sig} hashes to ${toFunctionSelector(sig)}. `
+        + 'A wrong selector reverts on chain 4663, and Promise.all means that takes down '
+        + 'every row, not just this column.',
     );
   }
+});
+
+test('the columns, their order, and their decimals are all pinned', () => {
+  // THE GUARD THE REVIEW ASKED FOR. Pinning the container and the constants left
+  // the RENDERING unpinned: reordering the cell array in renderVaultRows, or
+  // changing fixed(v.navWad, 18, 2) to fixed(v.navWad, 6, 2) so TVL reads
+  // 20,000,000,000,000.00, passed every other check here.
+  const html = read('index.html');
+  const headers = [...html.matchAll(/<th scope="col"[^>]*>([^<]+)<\/th>/g)].map((m) => m[1]);
+  assert.deepEqual(
+    headers,
+    ['Vault', 'TVL', 'NAV per share', 'Members', 'Capacity'],
+    'The header row changed. renderVaultRows appends cells positionally, so a reordered or '
+      + 'renamed header silently relabels real numbers.',
+  );
+
+  const js = read('app.js');
+  // Cell order and scale, read out of the source array rather than described.
+  const cells = js.slice(js.indexOf('for (const text of ['), js.indexOf('])) {', js.indexOf('for (const text of [')));
+  for (const [needle, why] of [
+    ['fixed(v.navWad, 18, 2)', 'TVL is navWad, 18 decimals'],
+    ["navPerShare === null ? 'no shares' : fixed(navPerShare, 18, 6)", 'NAV per share is 18 decimals, and 0 shares is not 0.000000'],
+    ['v.holders.toString()', 'Members is a plain count'],
+    ['fixed(v.cap, 6, 0)', 'Capacity is USDG at 6 decimals, no fraction'],
+  ]) {
+    assert.ok(cells.includes(needle), `renderVaultRows no longer renders ${needle}. ${why}.`);
+  }
+  assert.ok(
+    cells.indexOf('fixed(v.navWad, 18, 2)') < cells.indexOf('v.holders.toString()')
+      && cells.indexOf('v.holders.toString()') < cells.indexOf('fixed(v.cap, 6, 0)'),
+    'The cell order no longer matches the header order above.',
+  );
 });
 
 test('the built page names the factory address', () => {

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -78,12 +78,18 @@ const FACTORY = '0xc44B853F037b4fF33B831C9a2B341686dEC88Fd1';
 // static string match against the built HTML and reads no chain, so it can
 // only tell you the sentence is PRESENT, never that it is TRUE.
 //
-// The replacement is a claim about this table rather than about the chain. No
-// createVault call can falsify "this table lists no vaults"; only writing the
-// row-rendering code can, and whoever writes it will be editing this line
-// anyway. That is the property to preserve when changing this string: pin
-// something the deployment controls, not something the world does.
-const EMPTY_STATE = 'This table lists no vaults. vaultCount() above is read live from chain 4663 and is the count that matters.';
+// The replacement was a claim about this table rather than about the chain. No
+// createVault call could falsify "this table lists no vaults"; only writing the
+// row-rendering code could, and that is what happened: the rows are now built,
+// so that sentence went false by being fixed. This is the third wording, and it
+// holds in BOTH states, which the previous two did not:
+//   - script never runs, or the RPC fails  -> no rows, sentence true
+//   - rows render                          -> the fallback block is hidden, and
+//                                             the sentence is still true of it
+// The property to preserve when changing this string has not changed: pin
+// something the deployment controls, not something the world does, and prefer a
+// sentence that describes WHERE a figure comes from over one that states it.
+const EMPTY_STATE = 'Vault rows are read from chain 4663 when this page loads. None are listed here until that read returns, and none are invented if it fails.';
 
 const flat = (s) => s.replace(/\s+/g, ' ');
 
@@ -111,6 +117,73 @@ test('the built page carries the empty-state sentence verbatim', () => {
       'unreachable, which is precisely when a reader most needs to be told what is true.\n' +
       `Expected to find: "${EMPTY_STATE}"`,
   );
+});
+
+test('the row container app.js writes into exists in the built markup', () => {
+  const html = read('index.html');
+  // app.js does getElementById('vault-rows').appendChild(...). If this id is
+  // renamed or the tbody dropped, every read still succeeds, the loop still
+  // runs, and the table silently stays empty: a failure with no error anywhere.
+  assert.match(
+    html,
+    /<tbody id="vault-rows">\s*<\/tbody>/,
+    'index.html must carry an empty <tbody id="vault-rows"> for app.js to fill. '
+      + 'It is empty in the markup on purpose: no row is shipped that was not read from chain.',
+  );
+  assert.ok(
+    html.includes('id="vault-empty"'),
+    'The fallback block needs id="vault-empty" so app.js can hide it once a row renders. '
+      + 'Without it the page shows rows AND the sentence saying none are listed.',
+  );
+  assert.ok(
+    html.includes('id="vault-rows-fail"'),
+    'A failed row read must have somewhere to say so. Without this element the catch '
+      + 'branch is silent and an RPC failure is indistinguishable from a factory with no vaults.',
+  );
+});
+
+test('no column header promises a figure this page cannot read', () => {
+  const html = read('index.html');
+  // VaultCore exposes no createdAt() and no name(), and per-vault performance
+  // against an index needs history this page does not have. Columns for those
+  // could only ever be filled by inventing them, which is the same defect as a
+  // false sentence, in table form. They were removed rather than left blank.
+  for (const [header, why] of [
+    ['Age', 'VaultCore has no createdAt(); age can only come from a creation-log scan this page does not do'],
+    ['Performance vs SPY', 'per-vault performance needs price history this page does not hold'],
+  ]) {
+    assert.ok(
+      !html.includes('>' + header + '</th>'),
+      `index.html restores the "${header}" column. ${why}. `
+        + 'Add the column back only together with the read that fills it.',
+    );
+  }
+});
+
+test('every vault-row selector app.js pins is the real 4-byte selector', () => {
+  // These are pinned as hex so the page carries no keccak implementation, which
+  // means a typo is undetectable at runtime: eth_call returns 0x for an unknown
+  // selector and the column would render as a confident zero. Recomputed here
+  // from the signature text so the pin cannot drift from what it claims to be.
+  const js = read('app.js');
+  const expected = {
+    SEL_ALL_VAULTS: ['allVaults(uint256)', '0x9094a91e'],
+    SEL_NAV_WAD: ['navWad()', '0xd09074c0'],
+    SEL_TOTAL_SHARES: ['totalShares()', '0x3a98ef39'],
+    SEL_IDLE_USDC: ['idleUsdc()', '0x047b7fc7'],
+    SEL_HOLDER_COUNT: ['holderCount()', '0x1aab9a9f'],
+    SEL_CAPACITY_CAP: ['capacityCapUsdc()', '0xb857d9b9'],
+  };
+  for (const [name, [sig, sel]] of Object.entries(expected)) {
+    const m = js.match(new RegExp(`const ${name} = '(0x[0-9a-f]{8})';`));
+    assert.ok(m, `app.js no longer pins ${name}`);
+    assert.equal(
+      m[1],
+      sel,
+      `${name} is pinned as ${m[1]} but ${sig} is ${sel}. `
+        + 'A wrong selector does not throw: eth_call returns 0x and the cell renders as 0.',
+    );
+  }
 });
 
 test('the built page names the factory address', () => {

--- a/apps/app/test/claims.test.mjs
+++ b/apps/app/test/claims.test.mjs
@@ -189,10 +189,6 @@ test('every vault-row selector app.js pins is the real 4-byte selector', () => {
 });
 
 test('the columns, their order, and their decimals are all pinned', () => {
-  // THE GUARD THE REVIEW ASKED FOR. Pinning the container and the constants left
-  // the RENDERING unpinned: reordering the cell array in renderVaultRows, or
-  // changing fixed(v.navWad, 18, 2) to fixed(v.navWad, 6, 2) so TVL reads
-  // 20,000,000,000,000.00, passed every other check here.
   const html = read('index.html');
   const headers = [...html.matchAll(/<th scope="col"[^>]*>([^<]+)<\/th>/g)].map((m) => m[1]);
   assert.deepEqual(
@@ -203,20 +199,61 @@ test('the columns, their order, and their decimals are all pinned', () => {
   );
 
   const js = read('app.js');
-  // Cell order and scale, read out of the source array rather than described.
-  const cells = js.slice(js.indexOf('for (const text of ['), js.indexOf('])) {', js.indexOf('for (const text of [')));
-  for (const [needle, why] of [
-    ['fixed(v.navWad, 18, 2)', 'TVL is navWad, 18 decimals'],
+  // THE WINDOW IS ASSERTED BEFORE IT IS USED, because the first version of this
+  // test was not. It sliced to `])) {`, which does not occur in app.js, so
+  // indexOf returned -1, the slice ran to the end of the file, and every needle
+  // below matched somewhere unrelated. A guard whose search window is silently
+  // the whole file passes for the wrong reason, which is the exact defect class
+  // this file exists to catch, committed inside it.
+  const open = js.indexOf('for (const text of [');
+  const close = js.indexOf('    ]) {', open);
+  assert.ok(open > 0, 'renderVaultRows no longer builds its cells from a literal array');
+  assert.ok(close > open, 'could not find the end of the cell array; this window must not silently become the whole file');
+  const cells = js.slice(open, close);
+  assert.ok(cells.length < 900, `the cell-array window is ${cells.length} chars, which is too large to be just the array`);
+
+  // EVERY cell is pinned, IN ORDER, and the order is checked by INDEX rather
+  // than by a chain of comparisons. The previous version chained only
+  // navWad -> holders -> cap and left NAV per share unconstrained, so swapping
+  // the first two cells rendered NAV per share under the TVL header and passed
+  // all ten checks. That counterexample is the reason this is an index list.
+  const expected = [
+    ['fixed(v.navWad, 18, 2)', 'TVL is navWad at 18 decimals'],
     ["navPerShare === null ? 'no shares' : fixed(navPerShare, 18, 6)", 'NAV per share is 18 decimals, and 0 shares is not 0.000000'],
     ['v.holders.toString()', 'Members is a plain count'],
-    ['fixed(v.cap, 6, 0)', 'Capacity is USDG at 6 decimals, no fraction'],
-  ]) {
-    assert.ok(cells.includes(needle), `renderVaultRows no longer renders ${needle}. ${why}.`);
+    ["v.cap === 0n ? 'uncapped' : fixed(v.cap, 6, 0)", 'Capacity is USDG at 6 decimals, and 0 means uncapped, not full'],
+  ];
+  const positions = expected.map(([needle, why]) => {
+    const at = cells.indexOf(needle);
+    assert.ok(at >= 0, `renderVaultRows no longer renders ${needle}. ${why}.`);
+    return at;
+  });
+  for (let i = 1; i < positions.length; i += 1) {
+    assert.ok(
+      positions[i] > positions[i - 1],
+      `Cell ${i} appears before cell ${i - 1} in renderVaultRows, so the values no longer line up `
+        + `with the header row ${JSON.stringify(headers)}. Swapping two cells relabels real numbers `
+        + 'under the wrong heading and every other check here still passes.',
+    );
   }
+});
+
+test('whatever renders rows also owns the count chip', () => {
+  // The chip ships as "0 listed here", which is true until a row renders. Once
+  // rows render it is false, and nothing in the markup can fix that: only the
+  // code that appended the rows knows the number. This shipped contradicting
+  // the table one line below it.
+  const html = read('index.html');
+  assert.match(
+    html,
+    /<span class="count-chip"><span class="num">0<\/span> listed here<\/span>/,
+    'The count chip must ship reading 0, which is what a reader sees before the read returns.',
+  );
+  const js = read('app.js');
   assert.ok(
-    cells.indexOf('fixed(v.navWad, 18, 2)') < cells.indexOf('v.holders.toString()')
-      && cells.indexOf('v.holders.toString()') < cells.indexOf('fixed(v.cap, 6, 0)'),
-    'The cell order no longer matches the header order above.',
+    js.includes(".querySelector('.count-chip .num')"),
+    'app.js renders the rows, so app.js must update the chip that counts them. '
+      + 'A static 0 above a populated table is a false number on the page.',
   );
 });
 


### PR DESCRIPTION
`app.rwally.com` shipped a table with a header and nothing under it. Two vaults exist on chain 4663 and neither was listed, so the page named a count it never showed.

It now renders one row per vault, read live in the reader's browser:

```
vaultCount() -> allVaults(i) -> per vault: navWad, totalShares,
                                holderCount, capacityCapUsdc
```

**`1 + n + 4n` eth_calls** — 11 for the two vaults.

> **This body said `1 + n + 5n`, "13 calls", and listed `idleUsdc` among the per-vault reads until the third round.** That read was dropped in the fix commit, and `app.js` and the README were updated while this body was not. The body is not a file, so no claims guard walks it, and it is what lands as the squash commit message. Same defect #257 was rejected for twice. Corrected here rather than left to land.

Rendered values are read, not asserted. Vault two holds a WETH position rather than USDG, so its NAV per share is no longer 1.0 **and both of its figures drift with the ETH price**. Read at **block 61,632,820**, and stamped rather than left standing, because an unstamped chain-derived number replicated into a PR body is precisely what #257 was rejected for in its fourth round:

```
Vault                           TVL    NAV/share  Members   Capacity
0x9b0229ff…d228e2b4           20.00     1.000000        1     50,000
0x03e121e1…be31ee38            4.98     0.996823        1     50,000
```

## Two columns removed rather than left unfillable

The header promised **Age** and **Performance vs SPY**. `VaultCore` exposes no `createdAt()` and no `name()` — both revert on a live vault — and per-vault performance against an index needs price history this page does not hold. Both could only ever have been filled by inventing them.

## What the guards actually guard, corrected

An earlier version of this PR claimed a wrong selector would "render a confident `0.00`". **That threat model does not exist here**, and I asserted it without probing:

```
eth_call with 0xdeadbeef -> {"code":3,"message":"execution reverted"}
BigInt('0x')             -> SyntaxError
```

The real failure is loud but **wide**: `Promise.all` means one bad read takes down every row and the page cannot say which call broke. A renamed `tbody` id is the silent one: every read succeeds and the table simply stays empty.

Five guards, and the three added after review each exist because a specific break-it case passed everything else:

| guard | the case it now catches |
|---|---|
| selectors recomputed with viem | a pin edited alone; previously two hardcoded constants agreed with each other and the comment claimed otherwise |
| column order and decimals, by index | swapping TVL and NAV per share rendered each under the other's heading and passed all ten checks |
| the count chip | the card head read "0 listed here" above two rendered rows |

The column guard's first version also sliced to a delimiter (`])) {`) that does not occur in `app.js`, so `indexOf` returned −1 and its window was silently 27% of the file. It now asserts and bounds its own window before using it.

**All three controls are run**: the cell swap, a broken delimiter, and a dropped chip update each red a named test.

## Verification

`npm run gate` passes; 11/11 app checks. Every selector cross-checked against `cast sig` and answered on both live vaults.

Needs a rebase: `behind_by 1` after #259 landed, and it will go to 2 when #257 lands.
